### PR TITLE
Add const overloads of static_map::find 

### DIFF
--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -609,6 +609,26 @@ class static_map {
                              Hash hash          = Hash{},
                              KeyEqual key_equal = KeyEqual{}) noexcept;
 
+    /** @brief Finds the value corresponding to the key `k`.
+     *
+     * Returns an iterator to the pair whose key is equivalent to `k`.
+     * If no such pair exists, returns `end()`.
+     *
+     * @tparam Hash Unary callable type
+     * @tparam KeyEqual Binary callable type
+     * @param k The key to search for
+     * @param hash The unary callable used to hash the key
+     * @param key_equal The binary callable used to compare two keys
+     * for equality
+     * @return An iterator to the position at which the key/value pair
+     * containing `k` was inserted
+     */
+    template <typename Hash     = MurmurHash3_32<key_type>,
+              typename KeyEqual = thrust::equal_to<key_type>>
+    __device__ const_iterator find(Key const& k,
+                                   Hash hash          = Hash{},
+                                   KeyEqual key_equal = KeyEqual{}) const noexcept;
+
     /**
      * @brief Finds the value corresponding to the key `k`.
      *
@@ -634,6 +654,32 @@ class static_map {
               typename KeyEqual = thrust::equal_to<key_type>>
     __device__ iterator
     find(CG g, Key const& k, Hash hash = Hash{}, KeyEqual key_equal = KeyEqual{}) noexcept;
+
+    /**
+     * @brief Finds the value corresponding to the key `k`.
+     *
+     * Returns an iterator to the pair whose key is equivalent to `k`.
+     * If no such pair exists, returns `end()`. Uses the CUDA Cooperative Groups API to
+     * to leverage multiple threads to perform a single find. This provides a
+     * significant boost in throughput compared to the non Cooperative Group
+     * `find` at moderate to high load factors.
+     *
+     * @tparam CG Cooperative Group type
+     * @tparam Hash Unary callable type
+     * @tparam KeyEqual Binary callable type
+     * @param g The Cooperative Group used to perform the find
+     * @param k The key to search for
+     * @param hash The unary callable used to hash the key
+     * @param key_equal The binary callable used to compare two keys
+     * for equality
+     * @return An iterator to the position at which the key/value pair
+     * containing `k` was inserted
+     */
+    template <typename CG,
+              typename Hash     = MurmurHash3_32<key_type>,
+              typename KeyEqual = thrust::equal_to<key_type>>
+    __device__ const_iterator
+    find(CG g, Key const& k, Hash hash = Hash{}, KeyEqual key_equal = KeyEqual{}) const noexcept;
 
     /**
      * @brief Indicates whether the key `k` was inserted into the map.

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -611,7 +611,7 @@ class static_map {
 
     /** @brief Finds the value corresponding to the key `k`.
      *
-     * Returns an iterator to the pair whose key is equivalent to `k`.
+     * Returns a const_iterator to the pair whose key is equivalent to `k`.
      * If no such pair exists, returns `end()`.
      *
      * @tparam Hash Unary callable type
@@ -658,7 +658,7 @@ class static_map {
     /**
      * @brief Finds the value corresponding to the key `k`.
      *
-     * Returns an iterator to the pair whose key is equivalent to `k`.
+     * Returns a const_iterator to the pair whose key is equivalent to `k`.
      * If no such pair exists, returns `end()`. Uses the CUDA Cooperative Groups API to
      * to leverage multiple threads to perform a single find. This provides a
      * significant boost in throughput compared to the non Cooperative Group


### PR DESCRIPTION
Unfortunately there isn't really a safe way to have the const version call the non-const version or vice versa. We'll just have to live with the redundancy or factor out some common code. 