### PR TITLE
Add examples and fix iterator conversion 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ target_compile_features(cuco INTERFACE cxx_std_14 cuda_std_14)
 # Build options
 option(BUILD_TESTS "Configure CMake to build tests" ON)
 option(BUILD_BENCHMARKS "Configure CMake to build (google) benchmarks" ON)
+option(BUILD_EXAMPLES "Configure CMake to build examples" ON)
 
 ###################################################################################################
 # - cmake modules ---------------------------------------------------------------------------------
@@ -97,3 +98,10 @@ endif(BUILD_TESTS)
 if(BUILD_BENCHMARKS)
     add_subdirectory(benchmarks)
 endif(BUILD_BENCHMARKS)
+
+###################################################################################################
+# - Optionally build examples ---------------------------------------------------------------------
+
+if(BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif(BUILD_EXAMPLES)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,29 @@
+﻿cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
+
+###################################################################################################
+# Auto-detect available GPU compute architectures
+set(GPU_ARCHS "" CACHE STRING "List of GPU architectures (semicolon-separated) to be compiled for. Empty string means to auto-detect the GPUs on the current system")
+
+if("${GPU_ARCHS}" STREQUAL "")
+  include(../cmake/EvalGpuArchs.cmake)
+  evaluate_gpu_archs(GPU_ARCHS)
+endif()
+
+###################################################################################################
+# - compiler function -----------------------------------------------------------------------------
+
+function(ConfigureExample EXAMPLE_NAME EXAMPLE_SRC)
+    add_executable(${EXAMPLE_NAME} "${EXAMPLE_SRC}")
+    set_target_properties(${EXAMPLE_NAME} PROPERTIES 
+                                          CUDA_ARCHITECTURES ${GPU_ARCHS}
+                                          RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples")
+    target_include_directories(${EXAMPLE_NAME} PRIVATE
+                                             "${CMAKE_CURRENT_SOURCE_DIR}")
+    target_link_libraries(${EXAMPLE_NAME} PRIVATE cuco)
+endfunction(ConfigureExample)
+
+###################################################################################################
+### Example sources ##################################################################################
+###################################################################################################
+
+ConfigureExample(STATIC_MAP_EXAMPLE "${CMAKE_CURRENT_SOURCE_DIR}/static_map/static_map_example.cu")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -19,6 +19,7 @@ function(ConfigureExample EXAMPLE_NAME EXAMPLE_SRC)
                                           RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples")
     target_include_directories(${EXAMPLE_NAME} PRIVATE
                                              "${CMAKE_CURRENT_SOURCE_DIR}")
+    target_compile_options(${EXAMPLE_NAME} PRIVATE --expt-extended-lambda --expt-relaxed-constexpr)
     target_link_libraries(${EXAMPLE_NAME} PRIVATE cuco)
 endfunction(ConfigureExample)
 

--- a/examples/static_map/static_map_example.cu
+++ b/examples/static_map/static_map_example.cu
@@ -25,7 +25,6 @@ int main(void)
   int empty_value_sentinel = std::numeric_limits<int>::max();
   cuco::static_map<int, int> my_map{100'000, empty_key_sentinel, empty_value_sentinel};
   thrust::device_vector<thrust::pair<int, int>> pairs(50'000);
-  my_map.get_device_view();
   my_map.insert(pairs.begin(), pairs.end());
   return 0;
 }

--- a/examples/static_map/static_map_example.cu
+++ b/examples/static_map/static_map_example.cu
@@ -14,17 +14,43 @@
  * limitations under the License.
  */
 
-#include <thrust/device_vector.h>
 #include <limits>
+
+#include <thrust/device_vector.h>
+#include <thrust/sequence.h>
+#include <thrust/transform.h>
 
 #include <cuco/static_map.cuh>
 
 int main(void)
 {
-  int empty_key_sentinel   = std::numeric_limits<int>::max();
-  int empty_value_sentinel = std::numeric_limits<int>::max();
-  cuco::static_map<int, int> my_map{100'000, empty_key_sentinel, empty_value_sentinel};
+  int empty_key_sentinel   = -1;
+  int empty_value_sentinel = -1;
+
+  // Constructs a map with 100,000 slots using -1 and -1 as the empty key/value
+  // sentinels. Note the capacity is chosen knowing we will insert 50,000 keys,
+  // for an load factor of 50%.
+  cuco::static_map<int, int> map{100'000, empty_key_sentinel, empty_value_sentinel};
+
   thrust::device_vector<thrust::pair<int, int>> pairs(50'000);
-  my_map.insert(pairs.begin(), pairs.end());
+
+  // Create a sequence of pairs {{0,0}, {1,1}, ... {i,i}}
+  thrust::transform(thrust::make_counting_iterator<int>(0),
+                    thrust::make_counting_iterator<int>(pairs.size()),
+                    pairs.begin(),
+                    [] __device__(auto i) { return thrust::make_pair(i, i); });
+
+  // Inserts all pairs into the map
+  map.insert(pairs.begin(), pairs.end());
+
+  // Sequence of keys {0, 1, 2, ...}
+  thrust::device_vector<int> keys_to_find(50'000);
+  thrust::sequence(keys_to_find.begin(), keys_to_find.end(), 0);
+  thrust::device_vector<int> found_values(50'000);
+
+  // Finds all keys {0, 1, 2, ...} and stores associated values into `found_values`
+  // If a key `keys_to_find[i]` doesn't exist, `found_values[i] == empty_value_sentinel`
+  map.find(keys_to_find.begin(), keys_to_find.end(), found_values.begin());
+
   return 0;
 }

--- a/examples/static_map/static_map_example.cu
+++ b/examples/static_map/static_map_example.cu
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <thrust/device_vector.h>
+#include <limits>
+
+#include <cuco/static_map.cuh>
+
+int main(void)
+{
+  int empty_key_sentinel   = std::numeric_limits<int>::max();
+  int empty_value_sentinel = std::numeric_limits<int>::max();
+  cuco::static_map<int, int> my_map{100'000, empty_key_sentinel, empty_value_sentinel};
+  thrust::device_vector<thrust::pair<int, int>> pairs(50'000);
+  my_map.get_device_view();
+  my_map.insert(pairs.begin(), pairs.end());
+  return 0;
+}

--- a/include/cuco/detail/pair.cuh
+++ b/include/cuco/detail/pair.cuh
@@ -14,6 +14,8 @@
  * limitations under the License.
  */ 
 
+#include <thrust/pair.h>
+
 namespace cuco {
 namespace detail {
 
@@ -59,8 +61,10 @@ struct alignas(detail::pair_alignment<First, Second>()) pair {
   First first{};
   Second second{};
   pair() = default;
-  __host__ __device__ constexpr pair(First const& f, Second const& s) noexcept
-      : first{f}, second{s} {}
+  __host__ __device__ constexpr pair(thrust::pair<First, Second> const& p) noexcept
+    : first{p.first}, second{p.second}
+  {
+  }
 };
 
 template <typename K, typename V>

--- a/include/cuco/detail/static_map_kernels.cuh
+++ b/include/cuco/detail/static_map_kernels.cuh
@@ -86,11 +86,9 @@ __global__ void insert(InputIt first,
   auto tid = blockDim.x * blockIdx.x + threadIdx.x;
   auto it = first + tid;
   
-  while(it < last) {
-    auto insert_pair = *it;
-    if(view.insert(insert_pair, hash, key_equal)) {
-      thread_num_successes++;
-    }
+  while (it < last) {
+    typename viewT::value_type const insert_pair{*it};
+    if (view.insert(insert_pair, hash, key_equal)) { thread_num_successes++; }
     it += gridDim.x * blockDim.x;
   }
 
@@ -148,9 +146,10 @@ __global__ void insert(InputIt first,
   auto tid = blockDim.x * blockIdx.x + threadIdx.x;
   auto it = first + tid / tile_size;
   
-  while(it < last) {
-    auto insert_pair = *it;
-    if(view.insert(tile, insert_pair, hash, key_equal) && tile.thread_rank() == 0) {
+  while (it < last) {
+    // force conversion to value_type
+    typename viewT::value_type const insert_pair{*it};
+    if (view.insert(tile, insert_pair, hash, key_equal) && tile.thread_rank() == 0) {
       thread_num_successes++;
     }
     it += (gridDim.x * blockDim.x) / tile_size;

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -228,6 +228,10 @@ class static_map {
  private:
   class device_view_base {
    protected:
+    // Import member type definitions from `static_map`
+    using value_type     = value_type;
+    using key_type       = Key;
+    using mapped_type    = Value;
     using iterator       = pair_atomic_type*;
     using const_iterator = pair_atomic_type const*;
 
@@ -485,6 +489,9 @@ class static_map {
    */
   class device_mutable_view : public device_view_base {
    public:
+    using value_type     = typename device_view_base::value_type;
+    using key_type       = typename device_view_base::key_type;
+    using mapped_type    = typename device_view_base::mapped_type;
     using iterator       = typename device_view_base::iterator;
     using const_iterator = typename device_view_base::const_iterator;
     /**
@@ -567,6 +574,9 @@ class static_map {
    */
   class device_view : public device_view_base {
    public:
+    using value_type     = typename device_view_base::value_type;
+    using key_type       = typename device_view_base::key_type;
+    using mapped_type    = typename device_view_base::mapped_type;
     using iterator       = typename device_view_base::iterator;
     using const_iterator = typename device_view_base::const_iterator;
     /**


### PR DESCRIPTION
Added `examples` to help triage issue of inserting iterators who are not exactly the same type as `value_type`.

Updated insert kernels to force conversion of the de-referenced iterator element to the `value_type`. 

This required exposing the `static_map::value_type` type definition in the views. 
