### PR TITLE
Clean up reduce by key benchmark

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -39,6 +39,7 @@ function(ConfigureBench BENCH_NAME BENCH_SRC)
                                         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/gbenchmarks")
     target_include_directories(${BENCH_NAME} PRIVATE
                                              "${CMAKE_CURRENT_SOURCE_DIR}")
+    target_compile_options(${BENCH_NAME} PRIVATE --expt-extended-lambda --expt-relaxed-constexpr)
     target_link_libraries(${BENCH_NAME} PRIVATE 
                                         benchmark benchmark_main 
                                         pthread 
@@ -58,3 +59,5 @@ set(STATIC_MAP_BENCH_SRC "${CMAKE_CURRENT_SOURCE_DIR}/hash_table/static_map_benc
 ConfigureBench(STATIC_MAP_BENCH "${STATIC_MAP_BENCH_SRC}")
 
 ###################################################################################################
+set(RBK_BENCH_SRC "${CMAKE_CURRENT_SOURCE_DIR}/reduce_by_key/reduce_by_key.cu")
+ConfigureBench(RBK_BENCH "${RBK_BENCH_SRC}")

--- a/benchmarks/reduce_by_key/reduce_by_key.cu
+++ b/benchmarks/reduce_by_key/reduce_by_key.cu
@@ -15,16 +15,14 @@
  */
 
 #include <benchmark/benchmark.h>
+
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/pair.h>
 #include <thrust/reduce.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
-
-#include <cuco/insert_only_hash_array.cuh>
-
-#include "../hash_table/cudf/concurrent_unordered_map.cuh"
+#include <thrust/device_vector.h>
 
 /**
  * @brief Generates input sizes and number of unique keys
@@ -77,196 +75,14 @@ static void BM_thrust(::benchmark::State& state)
     cudaDeviceSynchronize();
   }
 }
-/*
 BENCHMARK_TEMPLATE(BM_thrust, int32_t, int32_t)
     ->Unit(benchmark::kMillisecond)
     ->Apply(generate_size_and_num_unique);
-    */
 
-/*
 BENCHMARK_TEMPLATE(BM_thrust, int64_t, int64_t)
     ->Unit(benchmark::kMillisecond)
-    ->RangeMultiplier(10)
-    ->Range(100'000, 100'000'000);
-    */
-/*
+    ->Apply(generate_size_and_num_unique);
 
-template <typename KeyRandomIterator, typename ValueRandomIterator>
-void cuco_reduce_by_key(KeyRandomIterator keys_begin,
-                     KeyRandomIterator keys_end,
-                     ValueRandomIterator values_begin) {
-using Key = typename thrust::iterator_traits<KeyRandomIterator>::value_type;
-using Value =
-   typename thrust::iterator_traits<ValueRandomIterator>::value_type;
+// TODO: Hash based reduce by key benchmark
 
-auto const input_size = thrust::distance(keys_begin, keys_end);
-auto const occupancy = 0.9;
-std::size_t const map_capacity = input_size / occupancy;
 
-using map_type =
-   cuco::insert_only_hash_array<Key, Value, cuda::thread_scope_device>;
-
-map_type map{map_capacity, -1};
-}
-
-template <typename Key, typename Value>
-static void BM_cuco(::benchmark::State& state) {
-std::string msg{"cuco rbk: "};
-msg += std::to_string(state.range(0));
-for (auto _ : state) {
- state.PauseTiming();
- thrust::device_vector<Key> keys(state.range(0));
- thrust::device_vector<Value> values(state.range(0));
- state.ResumeTiming();
- cuco_reduce_by_key(keys.begin(), keys.end(), values.begin());
- cudaDeviceSynchronize();
-}
-}
-BENCHMARK_TEMPLATE(BM_cuco, int32_t, int32_t)
- ->Unit(benchmark::kMillisecond)
- ->RangeMultiplier(10)
- ->Range(1'000'000, 1'000'000'000);
- */
-
-template <typename KeyRandomIterator, typename ValueRandomIterator>
-void cudf_reduce_by_key(KeyRandomIterator keys_begin,
-                        KeyRandomIterator keys_end,
-                        ValueRandomIterator values_begin)
-{
-  using Key   = typename thrust::iterator_traits<KeyRandomIterator>::value_type;
-  using Value = typename thrust::iterator_traits<ValueRandomIterator>::value_type;
-
-  auto const input_size          = thrust::distance(keys_begin, keys_end);
-  auto const occupancy           = 0.5;
-  std::size_t const map_capacity = input_size / occupancy;
-
-  using map_type = concurrent_unordered_map<Key, Value>;
-  auto map       = map_type::create(map_capacity);
-
-  // Concurrent insert/find are supported
-  if (sizeof(Key) + sizeof(Value) <= 8) {
-    thrust::transform(thrust::device,
-                      keys_begin,
-                      keys_end,
-                      values_begin,
-                      thrust::make_discard_iterator(),
-                      [view = *map] __device__(Key const& k, Value const& v) mutable {
-                        auto found = view.find(k);
-
-                        if (view.end() == found) {
-                          auto result = view.insert(thrust::make_pair(k, 0));
-                          found       = result.first;
-                        }
-
-                        atomicAdd(&(found->second), v);
-                        return 0;
-                      });
-  } else {
-    thrust::transform(thrust::device,
-                      keys_begin,
-                      keys_end,
-                      values_begin,
-                      thrust::make_discard_iterator(),
-                      [view = *map] __device__(Key const& k, Value const& v) mutable {
-                        auto result                          = view.insert(thrust::make_pair(k, 0));
-                        auto found                           = result.first;
-                        thrust::pair<Key, Value>& found_pair = *found;
-                        atomicAdd(&(found_pair.second), v);
-                        return 0;
-                      });
-  }
-}
-
-template <typename Key, typename Value>
-static void BM_cudf(::benchmark::State& state)
-{
-  std::string msg{"cudf rbk: "};
-  msg += std::to_string(state.range(0));
-  auto const num_unique_keys = state.range(1);
-
-  for (auto _ : state) {
-    state.PauseTiming();
-    thrust::device_vector<Key> keys(state.range(0));
-    auto begin = thrust::make_counting_iterator(0);
-    thrust::transform(
-      begin, begin + state.range(0), keys.begin(), [num_unique_keys] __device__(auto i) {
-        return i % num_unique_keys;
-      });
-    auto values = thrust::counting_iterator<int32_t>(0);
-    state.ResumeTiming();
-    cudf_reduce_by_key(keys.begin(), keys.end(), values);
-    cudaDeviceSynchronize();
-  }
-}
-BENCHMARK_TEMPLATE(BM_cudf, unsigned long long int, unsigned long long int)
-  ->Unit(benchmark::kMillisecond)
-  ->Apply(generate_size_and_num_unique);
-
-/*
-template <typename KeyRandomIterator, typename ValueRandomIterator>
-void cuco_cas_reduce_by_key(KeyRandomIterator keys_begin,
-                            KeyRandomIterator keys_end,
-                            ValueRandomIterator values_begin)
-{
-  using Key   = typename thrust::iterator_traits<KeyRandomIterator>::value_type;
-  using Value = typename thrust::iterator_traits<ValueRandomIterator>::value_type;
-
-  auto const input_size          = thrust::distance(keys_begin, keys_end);
-  auto const occupancy           = 0.5;
-  std::size_t const map_capacity = input_size / occupancy;
-
-  using map_type = cuco::insert_only_hash_array<Key, Value, cuda::thread_scope_device>;
-
-  map_type map{map_capacity, -1, -1};
-
-  auto zipped_begin = thrust::make_zip_iterator(thrust::make_tuple(keys_begin, values_begin));
-  auto zipped_end   = zipped_begin + thrust::distance(keys_begin, keys_end);
-
-  std::cout << "hello\n";
-
-  thrust::for_each(thrust::device,
-                   zipped_begin,
-                   zipped_end,
-                   [view = map.get_device_view()] __device__(auto const& key_value) mutable {
-                     auto k = thrust::get<0>(key_value);
-                     auto v = thrust::get<1>(key_value);
-
-      auto found = view.find(k);
-
-      if (view.end() == found) {
-        auto result = view.insert(cuco::make_pair(k, 0));
-        found       = result.first;
-      }
-
-                     // TODO: JH: This is currently causing a hang for some reason.
-
-                     found->second.fetch_add(v, cuda::std::memory_order_relaxed);
-    });
-}
-
-template <typename Key, typename Value>
-static void BM_cuco_cas(::benchmark::State& state)
-{
-  std::string msg{"cudf rbk: "};
-  msg += std::to_string(state.range(0));
-  auto const num_unique_keys = state.range(1);
-
-  for (auto _ : state) {
-    state.PauseTiming();
-    thrust::device_vector<Key> keys(state.range(0));
-    auto begin = thrust::make_counting_iterator(1);
-    thrust::transform(
-      begin, begin + state.range(0), keys.begin(), [num_unique_keys] __device__(auto i) {
-        return i % num_unique_keys;
-      });
-    auto values = thrust::counting_iterator<int32_t>(0);
-    state.ResumeTiming();
-    cuco_cas_reduce_by_key(keys.begin(), keys.end(), values);
-    cudaDeviceSynchronize();
-  }
-}
-
-BENCHMARK_TEMPLATE(BM_cuco_cas, int64_t, int64_t)
-  ->Unit(benchmark::kMillisecond)
-  ->Apply(generate_size_and_num_unique);
-  */


### PR DESCRIPTION
Remove the old hash based rbk benchmark since it is not currently possible to implement with `cuco::static_map`. 