### PR TITLE
Update to fetch CUB via Thrust to prevent version mismatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,30 +39,6 @@ find_package(CUDAToolkit 10.2 REQUIRED)
 
 include(cmake/Modules/CPM.cmake)
 
-#CPMAddPackage(
-#    NAME CUB
-#    GITHUB_REPOSITORY thrust/cub
-#    GIT_TAG main # TODO: Update to a tagged version of CUB that incorporates their cmake overhaul
-#    OPTIONS
-#      "CUB_ENABLE_HEADER_TESTING Off"
-#      "CUB_ENABLE_TESTING Off"
-#      "CUB_ENABLE_EXAMPLES Off"
-#      "CUB_DISABLE_ARCH_BY_DEFAULT On"
-#)
-
-# TODO: Work around for the fact that the above doesn't work due to issues with CPM/CUB
-CPMAddPackage(
-    NAME CUB
-    GITHUB_REPOSITORY thrust/cub
-    GIT_TAG 1.10.0
-    DOWNLOAD_ONLY YES
-)
-find_package(CUB
-    REQUIRED
-    NO_DEFAULT_PATH
-    HINTS
-        ${CUB_SOURCE_DIR}
-)
 
 ###################################################################################################
 # - cuco target   ---------------------------------------------------------------------------------
@@ -70,7 +46,7 @@ add_library(cuco INTERFACE)
 target_include_directories(cuco INTERFACE 
                            "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                            $<INSTALL_INTERFACE:include>)
-target_link_libraries(cuco INTERFACE CUDA::cudart CUB::CUB)
+target_link_libraries(cuco INTERFACE CUDA::cudart)
 target_compile_features(cuco INTERFACE cxx_std_14 cuda_std_14)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,13 @@ find_package(CUDAToolkit 10.2 REQUIRED)
 
 include(cmake/Modules/CPM.cmake)
 
+CPMFindPackage(
+  NAME Thrust
+  GITHUB_REPOSITORY NVIDIA/thrust
+  GIT_TAG 1.10.0
+  GIT_SHALLOW TRUE
+)
+thrust_create_target(Thrust)
 
 CPMAddPackage(
     NAME libcudacxx
@@ -58,7 +65,7 @@ add_library(cuco INTERFACE)
 target_include_directories(cuco INTERFACE 
                            "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                            $<INSTALL_INTERFACE:include>)
-target_link_libraries(cuco INTERFACE libcudacxx CUDA::cudart)
+target_link_libraries(cuco INTERFACE libcudacxx CUDA::cudart Thrust CUB::CUB)
 target_compile_features(cuco INTERFACE cxx_std_14 cuda_std_14)
 
 


### PR DESCRIPTION
Fetching newer versions of CUB can cause problems because it will be picked up by Thrust which will complain about version mismatch. 

To avoid this, fetch CUB through Thrust and link both against `cuco` to avoid version mismatch issues.
