### PR TITLE
Add allocator interface to allow customizable allocation

### DIFF
--- a/include/cuco/allocator.hpp
+++ b/include/cuco/allocator.hpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuco/detail/error.hpp>
+
+namespace cuco {
+
+template <typename T>
+class cuda_allocator {
+ public:
+  using value_type = T;
+
+  cuda_allocator() = default;
+
+  template <class U>
+  cuda_allocator(cuda_allocator<U> const&) noexcept
+  { }
+
+  value_type* allocate(std::size_t n)
+  {
+    value_type* p;
+    CUCO_CUDA_TRY(cudaMalloc(&p, sizeof(value_type) * n));
+    return p;
+  }
+
+  void deallocate(value_type* p, std::size_t) { CUCO_CUDA_TRY(cudaFree(p)); }
+};
+
+template <typename T, typename U>
+bool operator==(cuda_allocator<T> const&, cuda_allocator<U> const&) noexcept
+{
+  return true;
+}
+
+template <typename T, typename U>
+bool operator!=(cuda_allocator<T> const& lhs, cuda_allocator<U> const& rhs) noexcept
+{
+  return not(lhs == rhs);
+}
+
+}  // namespace cuco

--- a/include/cuco/detail/dynamic_map.inl
+++ b/include/cuco/detail/dynamic_map.inl
@@ -16,54 +16,50 @@
 
 namespace cuco {
 
-
-
-template<typename Key, typename Value, cuda::thread_scope Scope>
-dynamic_map<Key, Value, Scope>::dynamic_map(
-  std::size_t initial_capacity, Key empty_key_sentinel, Value empty_value_sentinel) :
-  empty_key_sentinel_(empty_key_sentinel),
-  empty_value_sentinel_(empty_value_sentinel),
-  size_(0),
-  capacity_(initial_capacity),
-  min_insert_size_(1E4),
-  max_load_factor_(0.60) {
-
-  submaps_.push_back(
-    std::unique_ptr<static_map<Key, Value, Scope>>{
-    new static_map<Key, Value, Scope>{initial_capacity, empty_key_sentinel, empty_value_sentinel}});
+template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
+dynamic_map<Key, Value, Scope, Allocator>::dynamic_map(std::size_t initial_capacity,
+                                                       Key empty_key_sentinel,
+                                                       Value empty_value_sentinel,
+                                                       Allocator const& alloc)
+  : empty_key_sentinel_(empty_key_sentinel),
+    empty_value_sentinel_(empty_value_sentinel),
+    size_(0),
+    capacity_(initial_capacity),
+    min_insert_size_(1E4),
+    max_load_factor_(0.60),
+    alloc_{alloc}
+{
+  submaps_.push_back(std::make_unique<static_map<Key, Value, Scope, Allocator>>(
+    initial_capacity, empty_key_sentinel, empty_value_sentinel, alloc));
   submap_views_.push_back(submaps_[0]->get_device_view());
   submap_mutable_views_.push_back(submaps_[0]->get_device_mutable_view());
-  
+
   CUCO_CUDA_TRY(cudaMallocManaged(&num_successes_, sizeof(atomic_ctr_type)));
-}
+}  // namespace cuco
 
-
-
-template<typename Key, typename Value, cuda::thread_scope Scope>
-dynamic_map<Key, Value, Scope>::~dynamic_map() {
+template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
+dynamic_map<Key, Value, Scope, Allocator>::~dynamic_map()
+{
   CUCO_CUDA_TRY(cudaFree(num_successes_));
 }
 
-
-
-template<typename Key, typename Value, cuda::thread_scope Scope>
-void dynamic_map<Key, Value, Scope>::reserve(std::size_t n) {
-
+template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
+void dynamic_map<Key, Value, Scope, Allocator>::reserve(std::size_t n)
+{
   int64_t num_elements_remaining = n;
-  auto submap_idx = 0;
-  while(num_elements_remaining > 0) {
+  auto submap_idx                = 0;
+  while (num_elements_remaining > 0) {
     std::size_t submap_capacity;
 
     // if the submap already exists
-    if(submap_idx < submaps_.size()) {
+    if (submap_idx < submaps_.size()) {
       submap_capacity = submaps_[submap_idx]->get_capacity();
     }
     // if the submap does not exist yet, create it
     else {
       submap_capacity = capacity_;
-      submaps_.push_back(
-        std::unique_ptr<static_map<Key, Value, Scope>>{
-        new static_map<Key, Value, Scope>{submap_capacity, empty_key_sentinel_, empty_value_sentinel_}});
+      submaps_.push_back(std::make_unique<static_map<Key, Value, Scope, Allocator>>(
+        submap_capacity, empty_key_sentinel_, empty_value_sentinel_, alloc_));
       submap_views_.push_back(submaps_[submap_idx]->get_device_view());
       submap_mutable_views_.push_back(submaps_[submap_idx]->get_device_mutable_view());
 
@@ -75,43 +71,44 @@ void dynamic_map<Key, Value, Scope>::reserve(std::size_t n) {
   }
 }
 
-
-
-template<typename Key, typename Value, cuda::thread_scope Scope>
+template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
 template <typename InputIt, typename Hash, typename KeyEqual>
-void dynamic_map<Key, Value, Scope>::insert(
-  InputIt first, InputIt last, Hash hash, KeyEqual key_equal) {
-  
+void dynamic_map<Key, Value, Scope, Allocator>::insert(InputIt first,
+                                                       InputIt last,
+                                                       Hash hash,
+                                                       KeyEqual key_equal)
+{
   std::size_t num_to_insert = std::distance(first, last);
   reserve(size_ + num_to_insert);
 
   uint32_t submap_idx = 0;
-  while(num_to_insert > 0) {
-    std::size_t capacity_remaining = max_load_factor_ * submaps_[submap_idx]->get_capacity() - 
-                                                        submaps_[submap_idx]->get_size();
-    // If we are tying to insert some of the remaining keys into this submap, we can insert 
+  while (num_to_insert > 0) {
+    std::size_t capacity_remaining =
+      max_load_factor_ * submaps_[submap_idx]->get_capacity() - submaps_[submap_idx]->get_size();
+    // If we are tying to insert some of the remaining keys into this submap, we can insert
     // only if we meet the minimum insert size.
-    if(capacity_remaining >= min_insert_size_) {
+    if (capacity_remaining >= min_insert_size_) {
       *num_successes_ = 0;
       int device_id;
       CUCO_CUDA_TRY(cudaGetDevice(&device_id));
       CUCO_CUDA_TRY(cudaMemPrefetchAsync(num_successes_, sizeof(atomic_ctr_type), device_id));
-      
-      auto n = std::min(capacity_remaining, num_to_insert);
+
+      auto n                = std::min(capacity_remaining, num_to_insert);
       auto const block_size = 128;
-      auto const stride = 1;
-      auto const tile_size = 4;
-      auto const grid_size = (tile_size * n + stride * block_size - 1) /
-                             (stride * block_size);
+      auto const stride     = 1;
+      auto const tile_size  = 4;
+      auto const grid_size  = (tile_size * n + stride * block_size - 1) / (stride * block_size);
 
       detail::insert<block_size, tile_size, cuco::pair_type<key_type, mapped_type>>
-      <<<grid_size, block_size>>>
-      (first, first + n,
-       submap_views_.data().get(),
-       submap_mutable_views_.data().get(),
-       num_successes_, 
-       submap_idx, submaps_.size(),
-       hash, key_equal);
+        <<<grid_size, block_size>>>(first,
+                                    first + n,
+                                    submap_views_.data().get(),
+                                    submap_mutable_views_.data().get(),
+                                    num_successes_,
+                                    submap_idx,
+                                    submaps_.size(),
+                                    hash,
+                                    key_equal);
       CUCO_CUDA_TRY(cudaDeviceSynchronize());
 
       std::size_t h_num_successes = num_successes_->load(cuda::std::memory_order_relaxed);
@@ -124,52 +121,36 @@ void dynamic_map<Key, Value, Scope>::insert(
   }
 }
 
-
-
-template <typename Key, typename Value, cuda::thread_scope Scope>
-template <typename InputIt, typename OutputIt, 
-          typename Hash, typename KeyEqual>
-void dynamic_map<Key, Value, Scope>::find(
-  InputIt first, InputIt last, OutputIt output_begin,
-  Hash hash, KeyEqual key_equal) noexcept {
-  
-  auto num_keys = std::distance(first, last);
+template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
+template <typename InputIt, typename OutputIt, typename Hash, typename KeyEqual>
+void dynamic_map<Key, Value, Scope, Allocator>::find(
+  InputIt first, InputIt last, OutputIt output_begin, Hash hash, KeyEqual key_equal) noexcept
+{
+  auto num_keys         = std::distance(first, last);
   auto const block_size = 128;
-  auto const stride = 1;
-  auto const tile_size = 4;
-  auto const grid_size = (tile_size * num_keys + stride * block_size - 1) /
-                          (stride * block_size);
+  auto const stride     = 1;
+  auto const tile_size  = 4;
+  auto const grid_size  = (tile_size * num_keys + stride * block_size - 1) / (stride * block_size);
 
-  detail::find<block_size, tile_size, Value>
-  <<<grid_size, block_size>>>
-  (first, last, output_begin,
-   submap_views_.data().get(), submaps_.size(), hash, key_equal);
-  CUCO_CUDA_TRY(cudaDeviceSynchronize());    
+  detail::find<block_size, tile_size, Value><<<grid_size, block_size>>>(
+    first, last, output_begin, submap_views_.data().get(), submaps_.size(), hash, key_equal);
+  CUCO_CUDA_TRY(cudaDeviceSynchronize());
 }
 
-
-
-template <typename Key, typename Value, cuda::thread_scope Scope>
-template <typename InputIt, typename OutputIt, 
-          typename Hash, typename KeyEqual>
-void dynamic_map<Key, Value, Scope>::contains(
-  InputIt first, InputIt last, OutputIt output_begin,
-  Hash hash, KeyEqual key_equal) noexcept {
-  
-  auto num_keys = std::distance(first, last);
+template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
+template <typename InputIt, typename OutputIt, typename Hash, typename KeyEqual>
+void dynamic_map<Key, Value, Scope, Allocator>::contains(
+  InputIt first, InputIt last, OutputIt output_begin, Hash hash, KeyEqual key_equal) noexcept
+{
+  auto num_keys         = std::distance(first, last);
   auto const block_size = 128;
-  auto const stride = 1;
-  auto const tile_size = 4;
-  auto const grid_size = (tile_size * num_keys + stride * block_size - 1) /
-                          (stride * block_size);
-  
-  detail::contains<block_size, tile_size>
-  <<<grid_size, block_size>>>
-  (first, last, output_begin,
-   submap_views_.data().get(), submaps_.size(), hash, key_equal);
-  CUCO_CUDA_TRY(cudaDeviceSynchronize());    
+  auto const stride     = 1;
+  auto const tile_size  = 4;
+  auto const grid_size  = (tile_size * num_keys + stride * block_size - 1) / (stride * block_size);
+
+  detail::contains<block_size, tile_size><<<grid_size, block_size>>>(
+    first, last, output_begin, submap_views_.data().get(), submaps_.size(), hash, key_equal);
+  CUCO_CUDA_TRY(cudaDeviceSynchronize());
 }
 
-
-
-}
+}  // namespace cuco

--- a/include/cuco/dynamic_map.cuh
+++ b/include/cuco/dynamic_map.cuh
@@ -82,6 +82,7 @@ namespace cuco {
  * @tparam Value Type of the mapped values
  * @tparam Scope The scope in which insert/find/contains will be performed by
  * individual threads.
+ * @tparam Allocator Type of allocator used to allocate submap device storage
  */
 template <typename Key,
           typename Value,
@@ -120,6 +121,7 @@ class dynamic_map {
    * @param growth_factor The factor by which the capacity increases when resizing
    * @param empty_key_sentinel The reserved key value for empty slots
    * @param empty_value_sentinel The reserved mapped value for empty slots
+   * @param alloc Allocator used to allocate submap device storage
    */
   dynamic_map(std::size_t initial_capacity,
               Key empty_key_sentinel,
@@ -251,7 +253,7 @@ class dynamic_map {
     submap_mutable_views_;          ///< vector of mutable device views for each submap
   std::size_t min_insert_size_{};   ///< min remaining capacity of submap for insert
   atomic_ctr_type* num_successes_;  ///< number of successfully inserted keys on insert
-  Allocator alloc_{};
+  Allocator alloc_{};  ///< Allocator passed to submaps to allocate their device storage
 };
 }  // namespace cuco
 

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -32,7 +32,7 @@
 
 namespace cuco {
 
-template <typename Key, typename Value, cuda::thread_scope Scope>
+template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
 class dynamic_map;
 
 /**
@@ -107,9 +107,7 @@ template <typename Key,
           typename Allocator       = cuco::cuda_allocator<char>>
 class static_map {
   static_assert(std::is_arithmetic<Key>::value, "Unsupported, non-arithmetic key type.");
-  friend class dynamic_map<Key, Value, Scope>;
-
-  friend class dynamic_map<Key, Value, Scope>;
+  friend class dynamic_map<Key, Value, Scope, Allocator>;
 
  public:
   using value_type          = cuco::pair_type<Key, Value>;


### PR DESCRIPTION
closes https://github.com/NVIDIA/cuCollections/issues/54

Adds an `Allocator` argument to `static_map` and `dynamic_map` to allow users to customize how the underlying storage is allocated. 

Future TODO is to add an interface for stream-ordered allocation, but that depends first on the hash map interfaces using streams. 