### PR TITLE
Changed libcu++ version from 1.3.0-rc0 to 1.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ thrust_create_target(Thrust)
 CPMAddPackage(
     NAME libcudacxx
     GITHUB_REPOSITORY NVIDIA/libcudacxx
-    GIT_TAG 1.3.0-rc0
+    GIT_TAG 1.3.0
     DOWNLOAD_ONLY YES
 )
 


### PR DESCRIPTION
libcu++ repository has removed tag `1.3.0-rc0` and created `1.3.0`. Updating `CMakeLists.txt` to reflect this change.