### PR TITLE
Added static_map::device_view::make_copy()

### DIFF
--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -655,8 +655,8 @@ class static_map {
      */
     template <typename CG>
     __device__ static device_view make_copy(CG g,
-                                            device_view source_device_view,
-                                            pair_atomic_type* const memory_to_use) noexcept
+                                            pair_atomic_type* const memory_to_use,
+                                            device_view source_device_view) noexcept
     {
 #ifndef CUDART_VERSION
 #error CUDART_VERSION Undefined!

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -678,8 +678,8 @@ class static_map {
       pair_atomic_type const* const slots_ptr = source_device_view.get_slots();
       for (std::size_t i = g.thread_rank(); i < source_device_view.get_capacity(); i += g.size())
       {
-        memory_to_use[i].first.store(slots_ptr[i].first.load());
-        memory_to_use[i].second.store(slots_ptr[i].second.load());
+        new (&memory_to_use[i].first) atomic_key_type{slots_ptr[i].first.load(cuda::memory_order_relaxed)};
+        new (&memory_to_use[i].second) atomic_mapped_type{slots_ptr[i].second.load(cuda::memory_order_relaxed)};
       }
       g.sync();
 #endif

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -655,7 +655,7 @@ class static_map {
      */
     template <typename CG>
     __device__ static device_view make_copy(CG g,
-                                            device_view const& source_device_view,
+                                            device_view source_device_view,
                                             pair_atomic_type* const memory_to_use) noexcept
     {
 #ifndef CUDART_VERSION

--- a/tests/static_map/static_map_test.cu
+++ b/tests/static_map/static_map_test.cu
@@ -99,8 +99,6 @@ TEMPLATE_TEST_CASE_SIG("Unique sequence of keys",
   std::vector<Key> h_keys(num_keys);
   std::vector<Value> h_values(num_keys);
   std::vector<cuco::pair_type<Key, Value>> h_pairs(num_keys);
-  std::vector<Value> h_results(num_keys);
-  std::vector<bool> h_contained(num_keys);
 
   generate_keys<Dist, Key>(h_keys.begin(), h_keys.end());
 

--- a/tests/static_map/static_map_test.cu
+++ b/tests/static_map/static_map_test.cu
@@ -18,10 +18,13 @@
 #include <thrust/device_vector.h>
 #include <thrust/for_each.h>
 #include <algorithm>
+#include <limits>
 #include <catch2/catch.hpp>
 #include <cuco/static_map.cuh>
 
 namespace {
+namespace cg = cooperative_groups;
+
 // Thrust logical algorithms (any_of/all_of/none_of) don't work with device
 // lambdas: See https://github.com/thrust/thrust/issues/1062
 template <typename Iterator, typename Predicate>
@@ -205,5 +208,159 @@ TEMPLATE_TEST_CASE_SIG("Unique sequence of keys",
                  (found->first.load() == pair.first and found->second.load() == pair.second);
         }));
     }
+  }
+}
+
+template <typename MapType, int CAPACITY>
+__global__ void shared_memory_test_kernel(typename MapType::device_view const* const device_views,
+                                          typename MapType::device_view::key_type const* const insterted_keys,
+                                          typename MapType::device_view::mapped_type const* const inserted_values,
+                                          const size_t number_of_elements,
+                                          bool* const keys_exist,
+                                          bool* const keys_and_values_correct)
+{
+    // Each block processes one map
+    const size_t map_id = blockIdx.x;
+    const size_t offset = map_id * number_of_elements;
+
+    __shared__ typename MapType::pair_atomic_type sm_buffer[CAPACITY];
+
+    auto g = cg::this_thread_block();
+    typename MapType::device_view sm_device_view = device_views[map_id].make_copy(g,
+                                                                                  sm_buffer);
+
+    for (int i = g.thread_rank(); i < number_of_elements; i += g.size())
+    {
+      auto found_pair_it = sm_device_view.find(insterted_keys[offset + i]);
+
+      if (found_pair_it != sm_device_view.end())
+      {
+        keys_exist[offset + i] = true;
+        if (found_pair_it->first == insterted_keys[offset + i] and found_pair_it->second == inserted_values[offset + i])
+        {
+          keys_and_values_correct[offset + i] = true;
+        }
+        else
+        {
+          keys_and_values_correct[offset + i] = false;
+        }
+      }
+      else
+      {
+        keys_exist[offset + i]   = false;
+        keys_and_values_correct[offset + i] = true;
+      }
+    }
+}
+
+TEMPLATE_TEST_CASE_SIG("Shared memory static map",
+                       "",
+                       ((typename T, dist_type Dist), T, Dist),
+                       (int32_t, dist_type::UNIQUE),
+                       (int64_t, dist_type::UNIQUE),
+                       (int32_t, dist_type::UNIFORM),
+                       (int64_t, dist_type::UNIFORM),
+                       (int32_t, dist_type::GAUSSIAN),
+                       (int64_t, dist_type::GAUSSIAN))
+{
+  using KeyType                = T;
+  using ValueType              = T;
+  using MapType                = cuco::static_map<KeyType, ValueType>;
+  using DeviceViewType         = typename MapType::device_view;
+  using DeviceViewIteratorType = typename DeviceViewType::iterator;
+
+  constexpr std::size_t number_of_maps  = 1000;
+  constexpr std::size_t elements_in_map = 500;
+  constexpr std::size_t map_capacity    = 2 * elements_in_map;
+
+  // one array for all maps, first elements_in_map element belong to map 0, second to map 1 and so on
+  std::vector<KeyType> h_keys(number_of_maps * elements_in_map);
+  std::vector<ValueType> h_values(number_of_maps * elements_in_map);
+  std::vector<cuco::pair_type<KeyType, ValueType>> h_pairs(number_of_maps * elements_in_map);
+
+  // using std::unique_ptr because static_map does not have copy/move constructor/assignment operator yet
+  std::vector<std::unique_ptr<MapType>> maps;
+
+  for (std::size_t map_id = 0; map_id < number_of_maps; ++map_id)
+  {
+    const std::size_t offset = map_id * elements_in_map;
+
+    generate_keys<Dist, KeyType>(h_keys.begin() + offset, h_keys.begin() + offset + elements_in_map);
+
+    for (std::size_t i = 0; i < elements_in_map; ++i)
+    {
+      KeyType key                             = h_keys[offset + i];
+      ValueType val                           = key < std::numeric_limits<KeyType>::max() ? key + 1 : 0;
+      h_values[offset + i]       = val;
+      h_pairs[offset + i].first  = key;
+      h_pairs[offset + i].second = val;
+    }
+
+    maps.push_back(std::make_unique<MapType>(map_capacity, -1, -1));
+  }
+
+  thrust::device_vector<KeyType> d_keys(h_keys);
+  thrust::device_vector<ValueType> d_values(h_values);
+  thrust::device_vector<cuco::pair_type<KeyType, ValueType>> d_pairs(h_pairs);
+
+  SECTION("Keys are all found after insertion.")
+  {
+    std::vector<DeviceViewType> h_device_views;
+    for (std::size_t map_id = 0; map_id < number_of_maps; ++map_id)
+    {
+      const std::size_t offset = map_id * elements_in_map;
+
+      MapType* map = maps[map_id].get();
+      map->insert(d_pairs.begin() + offset, d_pairs.begin() + offset + elements_in_map);
+      h_device_views.push_back(map->get_device_view());
+    }
+    thrust::device_vector<DeviceViewType> d_device_views(h_device_views);
+
+    thrust::device_vector<bool> d_keys_exist(number_of_maps * elements_in_map);
+    thrust::device_vector<bool> d_keys_and_values_correct(number_of_maps * elements_in_map);
+
+    shared_memory_test_kernel<MapType, map_capacity><<<number_of_maps, 64>>>(d_device_views.data().get(),
+                                                                             d_keys.data().get(),
+                                                                             d_values.data().get(),
+                                                                             elements_in_map,
+                                                                             d_keys_exist.data().get(),
+                                                                             d_keys_and_values_correct.data().get());
+
+    REQUIRE(d_keys_exist.size() == d_keys_and_values_correct.size());
+    auto zip = thrust::make_zip_iterator(thrust::make_tuple(d_keys_exist.begin(), d_keys_and_values_correct.begin()));
+
+    REQUIRE(all_of(zip,
+                   zip + d_keys_exist.size(),
+                   [] __device__ (auto const& z)
+                   {
+                     return thrust::get<0>(z) and thrust::get<1>(z);
+                   }));
+  }
+
+  SECTION("No key is found before insertion.")
+  {
+    std::vector<DeviceViewType> h_device_views;
+    for (std::size_t map_id = 0; map_id < number_of_maps; ++map_id)
+    {
+      h_device_views.push_back(maps[map_id].get()->get_device_view());
+    }
+    thrust::device_vector<DeviceViewType> d_device_views(h_device_views);
+
+    thrust::device_vector<bool> d_keys_exist(number_of_maps * elements_in_map);
+    thrust::device_vector<bool> d_keys_and_values_correct(number_of_maps * elements_in_map);
+
+    shared_memory_test_kernel<MapType, map_capacity><<<number_of_maps, 64>>>(d_device_views.data().get(),
+                                                                             d_keys.data().get(),
+                                                                             d_values.data().get(),
+                                                                             elements_in_map,
+                                                                             d_keys_exist.data().get(),
+                                                                             d_keys_and_values_correct.data().get());
+
+    REQUIRE(none_of(d_keys_exist.begin(),
+                   d_keys_exist.end(),
+                   [] __device__ (const bool key_found)
+                   {
+                     return key_found;
+                   }));
   }
 }

--- a/tests/static_map/static_map_test.cu
+++ b/tests/static_map/static_map_test.cu
@@ -225,8 +225,8 @@ __global__ void shared_memory_test_kernel(typename MapType::device_view const* c
 
     auto g = cg::this_thread_block();
     typename MapType::device_view sm_device_view = MapType::device_view::make_copy(g,
-                                                                                   device_views[map_id],
-                                                                                   sm_buffer);
+                                                                                   sm_buffer,
+                                                                                   device_views[map_id]);
 
     for (int i = g.thread_rank(); i < number_of_elements; i += g.size())
     {

--- a/tests/static_map/static_map_test.cu
+++ b/tests/static_map/static_map_test.cu
@@ -224,8 +224,9 @@ __global__ void shared_memory_test_kernel(typename MapType::device_view const* c
     __shared__ typename MapType::pair_atomic_type sm_buffer[CAPACITY];
 
     auto g = cg::this_thread_block();
-    typename MapType::device_view sm_device_view = device_views[map_id].make_copy(g,
-                                                                                  sm_buffer);
+    typename MapType::device_view sm_device_view = MapType::device_view::make_copy(g,
+                                                                                   device_views[map_id],
+                                                                                   sm_buffer);
 
     for (int i = g.thread_rank(); i < number_of_elements; i += g.size())
     {


### PR DESCRIPTION
`static_map::device_view::make_copy()` creates a copy of `device_view` in memory that is passed to it.
This is useful when small `static_map` is expected to be used many consecutive times so it can be loaded into shared memory.

Tested with CUDA 10.2, 11.0 and 11.1