### PR TITLE
Make cuda_memcmp inline

### DIFF
--- a/include/cuco/detail/cuda_memcmp.cuh
+++ b/include/cuco/detail/cuda_memcmp.cuh
@@ -1,5 +1,5 @@
 __host__ __device__
-inline int __cuda_memcmp(void const * __lhs, void const * __rhs, size_t __count) {
+inline int cuda_memcmp(void const * __lhs, void const * __rhs, size_t __count) {
     auto __lhs_c = reinterpret_cast<unsigned char const *>(__lhs);
     auto __rhs_c = reinterpret_cast<unsigned char const *>(__rhs);
     while (__count--) {

--- a/include/cuco/detail/cuda_memcmp.cuh
+++ b/include/cuco/detail/cuda_memcmp.cuh
@@ -1,5 +1,5 @@
 __host__ __device__
-int __cuda_memcmp(void const * __lhs, void const * __rhs, size_t __count) {
+inline int __cuda_memcmp(void const * __lhs, void const * __rhs, size_t __count) {
     auto __lhs_c = reinterpret_cast<unsigned char const *>(__lhs);
     auto __rhs_c = reinterpret_cast<unsigned char const *>(__rhs);
     while (__count--) {

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -22,7 +22,6 @@
 #include <cub/cub.cuh>
 #include <cuda/std/atomic>
 
-#include <cuco/detail/cuda_memcmp.cuh>
 #include <cuco/detail/error.hpp>
 #include <cuco/detail/pair.cuh>
 #include <cuco/detail/static_map_kernels.cuh>


### PR DESCRIPTION
- [x] Rename `__cuda_memcmp` to `cuda_memcmp` to avoid using a reserved name
- [x] Remove unused `cuda_memcmp.hpp` include as it is unused for now
- [x] Make `cuda_memcmp` inline