### PR TITLE
Use relaxed load of existing key in CG insert

### DIFF
--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -163,7 +163,7 @@ __device__ bool static_map<Key, Value, Scope, Allocator>::device_mutable_view::i
   auto current_slot = initial_slot(g, insert_pair.first, hash);
 
   while (true) {
-    key_type const existing_key = current_slot->first;
+    key_type const existing_key = current_slot->first.load(cuda::memory_order_relaxed);
 
     // The user provide `key_equal` can never be used to compare against `empty_key_sentinel` as the
     // sentinel is not a valid key value. Therefore, first check for the sentinel


### PR DESCRIPTION
The CG insert loads a window of slots. It was previously using the default `load()` which defaults to sequentially consistent, which is unnecessarily strong for this use case. Use relax load instead. 

Quick look at the benchmarks show that results are marginally better after this change, but not earth shattering. 