### PR TITLE
[REVIEW] cuco::static_map bug fixes for corner cases

### DIFF
--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -31,7 +31,7 @@ static_map<Key, Value, Scope, Allocator>::static_map(std::size_t capacity,
                                                      Key empty_key_sentinel,
                                                      Value empty_value_sentinel,
                                                      Allocator const& alloc)
-  : capacity_{std::max(capacity, std::size_t{1}},  // to avoid dereferencing a nullptr (Issue #72)
+  : capacity_{std::max(capacity, std::size_t{1})},  // to avoid dereferencing a nullptr (Issue #72)
     empty_key_sentinel_{empty_key_sentinel},
     empty_value_sentinel_{empty_value_sentinel},
     slot_allocator_{alloc}

--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -62,7 +62,7 @@ void static_map<Key, Value, Scope, Allocator>::insert(InputIt first,
                                                       KeyEqual key_equal)
 {
   auto num_keys         = std::distance(first, last);
-  if (num_keys == 0) { return };
+  if (num_keys == 0) { return; }
 
   auto const block_size = 128;
   auto const stride     = 1;
@@ -88,7 +88,7 @@ void static_map<Key, Value, Scope, Allocator>::find(
   InputIt first, InputIt last, OutputIt output_begin, Hash hash, KeyEqual key_equal) noexcept
 {
   auto num_keys         = std::distance(first, last);
-  if (num_keys == 0) { return };
+  if (num_keys == 0) { return; }
 
   auto const block_size = 128;
   auto const stride     = 1;
@@ -107,7 +107,7 @@ void static_map<Key, Value, Scope, Allocator>::contains(
   InputIt first, InputIt last, OutputIt output_begin, Hash hash, KeyEqual key_equal) noexcept
 {
   auto num_keys         = std::distance(first, last);
-  if (num_keys == 0) { return };
+  if (num_keys == 0) { return; }
 
   auto const block_size = 128;
   auto const stride     = 1;

--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -62,6 +62,8 @@ void static_map<Key, Value, Scope, Allocator>::insert(InputIt first,
                                                       KeyEqual key_equal)
 {
   auto num_keys         = std::distance(first, last);
+  if (num_keys == 0) { return };
+
   auto const block_size = 128;
   auto const stride     = 1;
   auto const tile_size  = 4;
@@ -86,6 +88,8 @@ void static_map<Key, Value, Scope, Allocator>::find(
   InputIt first, InputIt last, OutputIt output_begin, Hash hash, KeyEqual key_equal) noexcept
 {
   auto num_keys         = std::distance(first, last);
+  if (num_keys == 0) { return };
+
   auto const block_size = 128;
   auto const stride     = 1;
   auto const tile_size  = 4;
@@ -103,6 +107,8 @@ void static_map<Key, Value, Scope, Allocator>::contains(
   InputIt first, InputIt last, OutputIt output_begin, Hash hash, KeyEqual key_equal) noexcept
 {
   auto num_keys         = std::distance(first, last);
+  if (num_keys == 0) { return };
+
   auto const block_size = 128;
   auto const stride     = 1;
   auto const tile_size  = 4;

--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -245,6 +245,8 @@ static_map<Key, Value, Scope, Allocator>::device_view::find(Key const& k,
                                                             Hash hash,
                                                             KeyEqual key_equal) noexcept
 {
+  if (this->get_capacity() == 0) { return this->end(); }
+
   auto current_slot = initial_slot(k, hash);
 
   while (true) {
@@ -266,6 +268,8 @@ static_map<Key, Value, Scope, Allocator>::device_view::find(Key const& k,
                                                             Hash hash,
                                                             KeyEqual key_equal) const noexcept
 {
+  if (this->get_capacity() == 0) { return this->end(); }
+
   auto current_slot = initial_slot(k, hash);
 
   while (true) {
@@ -288,6 +292,8 @@ static_map<Key, Value, Scope, Allocator>::device_view::find(CG g,
                                                             Hash hash,
                                                             KeyEqual key_equal) noexcept
 {
+  if (this->get_capacity() == 0) { return this->end(); }
+
   auto current_slot = initial_slot(g, k, hash);
 
   while (true) {
@@ -325,6 +331,8 @@ static_map<Key, Value, Scope, Allocator>::device_view::find(CG g,
                                                             Hash hash,
                                                             KeyEqual key_equal) const noexcept
 {
+  if (this->get_capacity() == 0) { return this->end(); }
+
   auto current_slot = initial_slot(g, k, hash);
 
   while (true) {
@@ -361,6 +369,8 @@ template <typename Hash, typename KeyEqual>
 __device__ bool static_map<Key, Value, Scope, Allocator>::device_view::contains(
   Key const& k, Hash hash, KeyEqual key_equal) noexcept
 {
+  if (this->get_capacity() == 0) { return false; }
+
   auto current_slot = initial_slot(k, hash);
 
   while (true) {
@@ -379,6 +389,8 @@ template <typename CG, typename Hash, typename KeyEqual>
 __device__ bool static_map<Key, Value, Scope, Allocator>::device_view::contains(
   CG g, Key const& k, Hash hash, KeyEqual key_equal) noexcept
 {
+  if (this->get_capacity() == 0) { return false; }
+
   auto current_slot = initial_slot(g, k, hash);
 
   while (true) {

--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -41,7 +41,7 @@ static_map<Key, Value, Scope, Allocator>::static_map(std::size_t capacity,
   auto constexpr block_size = 256;
   auto constexpr stride     = 4;
   auto const grid_size      = (capacity_ + stride * block_size - 1) / (stride * block_size);
-  detail::initialize<atomic_key_type, atomic_mapped_type>
+  detail::initialize<block_size, atomic_key_type, atomic_mapped_type>
     <<<grid_size, block_size>>>(slots_, empty_key_sentinel, empty_value_sentinel, capacity_);
 
   CUCO_CUDA_TRY(cudaMallocManaged(&num_successes_, sizeof(atomic_ctr_type)));

--- a/include/cuco/detail/static_map_kernels.cuh
+++ b/include/cuco/detail/static_map_kernels.cuh
@@ -39,11 +39,11 @@ __global__ void initialize(
   pair_atomic_type* const slots, Key k,
   Value v, std::size_t size) {
   
-  auto tid = static_cast<uint64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
+  auto tid = block_size * blockIdx.x + threadIdx.x;
   while (tid < size) {
     new (&slots[tid].first) atomic_key_type{k};
     new (&slots[tid].second) atomic_mapped_type{v};
-    tid += gridDim.x * static_cast<uint64_t>(blockDim.x);
+    tid += gridDim.x * block_size;
   }
 }
 
@@ -67,7 +67,7 @@ __global__ void initialize(
  * @param hash The unary function to apply to hash each key
  * @param key_equal The binary function used to compare two keys for equality
  */
-template<uint32_t block_size,
+template<std::size_t block_size,
          typename InputIt,
          typename atomicT,
          typename viewT,
@@ -83,13 +83,13 @@ __global__ void insert(InputIt first,
   __shared__ typename BlockReduce::TempStorage temp_storage;
   std::size_t thread_num_successes = 0;
   
-  auto tid = static_cast<uint64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
+  auto tid = block_size * blockIdx.x + threadIdx.x;
   auto it = first + tid;
   
   while (it < last) {
     typename viewT::value_type const insert_pair{*it};
     if (view.insert(insert_pair, hash, key_equal)) { thread_num_successes++; }
-    it += gridDim.x * static_cast<uint64_t>(blockDim.x);
+    it += gridDim.x * block_size;
   }
 
   // compute number of successfully inserted elements for each block
@@ -125,7 +125,7 @@ __global__ void insert(InputIt first,
  * @param hash The unary function to apply to hash each key
  * @param key_equal The binary function used to compare two keys for equality
  */
-template<uint32_t block_size,
+template<std::size_t block_size,
          uint32_t tile_size,
          typename InputIt,
          typename atomicT,
@@ -143,7 +143,7 @@ __global__ void insert(InputIt first,
   std::size_t thread_num_successes = 0;
 
   auto tile = cg::tiled_partition<tile_size>(cg::this_thread_block());
-  auto tid = static_cast<uint64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
+  auto tid = block_size * blockIdx.x + threadIdx.x;
   auto it = first + tid / tile_size;
   
   while (it < last) {
@@ -152,7 +152,7 @@ __global__ void insert(InputIt first,
     if (view.insert(tile, insert_pair, hash, key_equal) && tile.thread_rank() == 0) {
       thread_num_successes++;
     }
-    it += (gridDim.x * static_cast<uint64_t>(blockDim.x)) / tile_size;
+    it += (gridDim.x * block_size) / tile_size;
   }
   
   // compute number of successfully inserted elements for each block
@@ -184,7 +184,7 @@ __global__ void insert(InputIt first,
  * @param hash The unary function to apply to hash each key
  * @param key_equal The binary function to compare two keys for equality
  */
-template<uint32_t block_size,
+template<std::size_t block_size,
          typename Value,
          typename InputIt, typename OutputIt, 
          typename viewT,
@@ -196,7 +196,7 @@ __global__ void find(InputIt first,
                      viewT view,
                      Hash hash,
                      KeyEqual key_equal) {
-  auto tid = static_cast<uint64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
+  auto tid = block_size * blockIdx.x + threadIdx.x;
   auto key_idx = tid;
   __shared__ Value writeBuffer[block_size];
   
@@ -217,7 +217,7 @@ __global__ void find(InputIt first,
         : found->second.load(cuda::std::memory_order_relaxed);
     __syncthreads();
     *(output_begin + key_idx) = writeBuffer[threadIdx.x];
-    key_idx += gridDim.x * static_cast<uint64_t>(blockDim.x);
+    key_idx += gridDim.x * block_size;
   }
 }
 
@@ -247,7 +247,7 @@ __global__ void find(InputIt first,
  * @param hash The unary function to apply to hash each key
  * @param key_equal The binary function to compare two keys for equality
  */
-template<uint32_t block_size, uint32_t tile_size,
+template<std::size_t block_size, uint32_t tile_size,
          typename Value,
          typename InputIt, typename OutputIt, 
          typename viewT,
@@ -260,7 +260,7 @@ __global__ void find(InputIt first,
                      Hash hash,
                      KeyEqual key_equal) {
   auto tile = cg::tiled_partition<tile_size>(cg::this_thread_block());
-  auto tid = static_cast<uint64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
+  auto tid = block_size * blockIdx.x + threadIdx.x;
   auto key_idx = tid / tile_size;
   __shared__ Value writeBuffer[block_size];
   
@@ -285,7 +285,7 @@ __global__ void find(InputIt first,
     if(tile.thread_rank() == 0) {
       *(output_begin + key_idx) = writeBuffer[threadIdx.x / tile_size];
     }
-    key_idx += (gridDim.x * static_cast<uint64_t>(blockDim.x)) / tile_size;
+    key_idx += (gridDim.x * block_size) / tile_size;
   }
 }
 
@@ -309,7 +309,7 @@ __global__ void find(InputIt first,
  * @param hash The unary function to apply to hash each key
  * @param key_equal The binary function to compare two keys for equality
  */
-template<uint32_t block_size,
+template<std::size_t block_size,
          typename InputIt, typename OutputIt, 
          typename viewT,
          typename Hash, 
@@ -320,7 +320,7 @@ __global__ void contains(InputIt first,
                          viewT view,
                          Hash hash,
                          KeyEqual key_equal) {
-  auto tid = static_cast<uint64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
+  auto tid = block_size * blockIdx.x + threadIdx.x;
   auto key_idx = tid;
   __shared__ bool writeBuffer[block_size];
   
@@ -337,7 +337,7 @@ __global__ void contains(InputIt first,
     writeBuffer[threadIdx.x] = view.contains(key, hash, key_equal);
     __syncthreads();
     *(output_begin + key_idx) = writeBuffer[threadIdx.x];
-    key_idx += gridDim.x * static_cast<uint64_t>(blockDim.x);
+    key_idx += gridDim.x * block_size;
   }
 }
 
@@ -366,7 +366,7 @@ __global__ void contains(InputIt first,
  * @param hash The unary function to apply to hash each key
  * @param key_equal The binary function to compare two keys for equality
  */
-template<uint32_t block_size, uint32_t tile_size,
+template<std::size_t block_size, uint32_t tile_size,
          typename InputIt, typename OutputIt, 
          typename viewT,
          typename Hash, 
@@ -378,7 +378,7 @@ __global__ void contains(InputIt first,
                          Hash hash,
                          KeyEqual key_equal) {
   auto tile = cg::tiled_partition<tile_size>(cg::this_thread_block());
-  auto tid = static_cast<uint64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
+  auto tid = block_size * blockIdx.x + threadIdx.x;
   auto key_idx = tid / tile_size;
   __shared__ bool writeBuffer[block_size];
   
@@ -400,7 +400,7 @@ __global__ void contains(InputIt first,
     if(tile.thread_rank() == 0) {
       *(output_begin + key_idx) = writeBuffer[threadIdx.x / tile_size];
     }
-    key_idx += (gridDim.x * static_cast<uint64_t>(blockDim.x)) / tile_size;
+    key_idx += (gridDim.x * block_size) / tile_size;
   }
 }
 

--- a/include/cuco/detail/static_map_kernels.cuh
+++ b/include/cuco/detail/static_map_kernels.cuh
@@ -39,11 +39,11 @@ __global__ void initialize(
   pair_atomic_type* const slots, Key k,
   Value v, std::size_t size) {
   
-  auto tid = threadIdx.x + blockIdx.x * blockDim.x;
+  auto tid = static_cast<uint64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
   while (tid < size) {
     new (&slots[tid].first) atomic_key_type{k};
     new (&slots[tid].second) atomic_mapped_type{v};
-    tid += gridDim.x * blockDim.x;
+    tid += gridDim.x * static_cast<uint64_t>(blockDim.x);
   }
 }
 
@@ -83,13 +83,13 @@ __global__ void insert(InputIt first,
   __shared__ typename BlockReduce::TempStorage temp_storage;
   std::size_t thread_num_successes = 0;
   
-  auto tid = blockDim.x * blockIdx.x + threadIdx.x;
+  auto tid = static_cast<uint64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
   auto it = first + tid;
   
   while (it < last) {
     typename viewT::value_type const insert_pair{*it};
     if (view.insert(insert_pair, hash, key_equal)) { thread_num_successes++; }
-    it += gridDim.x * blockDim.x;
+    it += gridDim.x * static_cast<uint64_t>(blockDim.x);
   }
 
   // compute number of successfully inserted elements for each block
@@ -143,7 +143,7 @@ __global__ void insert(InputIt first,
   std::size_t thread_num_successes = 0;
 
   auto tile = cg::tiled_partition<tile_size>(cg::this_thread_block());
-  auto tid = blockDim.x * blockIdx.x + threadIdx.x;
+  auto tid = static_cast<uint64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
   auto it = first + tid / tile_size;
   
   while (it < last) {
@@ -152,7 +152,7 @@ __global__ void insert(InputIt first,
     if (view.insert(tile, insert_pair, hash, key_equal) && tile.thread_rank() == 0) {
       thread_num_successes++;
     }
-    it += (gridDim.x * blockDim.x) / tile_size;
+    it += (gridDim.x * static_cast<uint64_t>(blockDim.x)) / tile_size;
   }
   
   // compute number of successfully inserted elements for each block
@@ -196,7 +196,7 @@ __global__ void find(InputIt first,
                      viewT view,
                      Hash hash,
                      KeyEqual key_equal) {
-  auto tid = blockDim.x * blockIdx.x + threadIdx.x;
+  auto tid = static_cast<uint64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
   auto key_idx = tid;
   __shared__ Value writeBuffer[block_size];
   
@@ -217,7 +217,7 @@ __global__ void find(InputIt first,
         : found->second.load(cuda::std::memory_order_relaxed);
     __syncthreads();
     *(output_begin + key_idx) = writeBuffer[threadIdx.x];
-    key_idx += gridDim.x * blockDim.x;
+    key_idx += gridDim.x * static_cast<uint64_t>(blockDim.x);
   }
 }
 
@@ -260,7 +260,7 @@ __global__ void find(InputIt first,
                      Hash hash,
                      KeyEqual key_equal) {
   auto tile = cg::tiled_partition<tile_size>(cg::this_thread_block());
-  auto tid = blockDim.x * blockIdx.x + threadIdx.x;
+  auto tid = static_cast<uint64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
   auto key_idx = tid / tile_size;
   __shared__ Value writeBuffer[block_size];
   
@@ -285,7 +285,7 @@ __global__ void find(InputIt first,
     if(tile.thread_rank() == 0) {
       *(output_begin + key_idx) = writeBuffer[threadIdx.x / tile_size];
     }
-    key_idx += (gridDim.x * blockDim.x) / tile_size;
+    key_idx += (gridDim.x * static_cast<uint64_t>(blockDim.x)) / tile_size;
   }
 }
 
@@ -320,7 +320,7 @@ __global__ void contains(InputIt first,
                          viewT view,
                          Hash hash,
                          KeyEqual key_equal) {
-  auto tid = blockDim.x * blockIdx.x + threadIdx.x;
+  auto tid = static_cast<uint64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
   auto key_idx = tid;
   __shared__ bool writeBuffer[block_size];
   
@@ -337,7 +337,7 @@ __global__ void contains(InputIt first,
     writeBuffer[threadIdx.x] = view.contains(key, hash, key_equal);
     __syncthreads();
     *(output_begin + key_idx) = writeBuffer[threadIdx.x];
-    key_idx += gridDim.x * blockDim.x;
+    key_idx += gridDim.x * static_cast<uint64_t>(blockDim.x);
   }
 }
 
@@ -378,7 +378,7 @@ __global__ void contains(InputIt first,
                          Hash hash,
                          KeyEqual key_equal) {
   auto tile = cg::tiled_partition<tile_size>(cg::this_thread_block());
-  auto tid = blockDim.x * blockIdx.x + threadIdx.x;
+  auto tid = static_cast<uint64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
   auto key_idx = tid / tile_size;
   __shared__ bool writeBuffer[block_size];
   
@@ -400,7 +400,7 @@ __global__ void contains(InputIt first,
     if(tile.thread_rank() == 0) {
       *(output_begin + key_idx) = writeBuffer[threadIdx.x / tile_size];
     }
-    key_idx += (gridDim.x * blockDim.x) / tile_size;
+    key_idx += (gridDim.x * static_cast<uint64_t>(blockDim.x)) / tile_size;
   }
 }
 

--- a/include/cuco/detail/static_map_kernels.cuh
+++ b/include/cuco/detail/static_map_kernels.cuh
@@ -39,7 +39,7 @@ __global__ void initialize(
   pair_atomic_type* const slots, Key k,
   Value v, std::size_t size) {
   
-  auto tid = block_size * blockIdx.x + threadIdx.x;
+  auto tid = static_cast<std::size_t>(blockDim.x) * blockIdx.x + threadIdx.x;
   while (tid < size) {
     new (&slots[tid].first) atomic_key_type{k};
     new (&slots[tid].second) atomic_mapped_type{v};

--- a/include/cuco/detail/static_map_kernels.cuh
+++ b/include/cuco/detail/static_map_kernels.cuh
@@ -83,7 +83,7 @@ __global__ void insert(InputIt first,
   __shared__ typename BlockReduce::TempStorage temp_storage;
   std::size_t thread_num_successes = 0;
   
-  auto tid = static_cast<uint64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
+  auto tid = block_size * blockIdx.x + threadIdx.x;
   auto it = first + tid;
   
   while (it < last) {

--- a/include/cuco/detail/static_map_kernels.cuh
+++ b/include/cuco/detail/static_map_kernels.cuh
@@ -34,12 +34,17 @@ namespace cg = cooperative_groups;
  * @param v Value to which all values in `slots` are initialized
  * @param size Size of the storage pointed to by `slots`
  */
-template<typename atomic_key_type, typename atomic_mapped_type, typename Key, typename Value, typename pair_atomic_type>
+template<std::size_t block_size,
+         typename atomic_key_type,
+         typename atomic_mapped_type,
+         typename Key,
+         typename Value,
+         typename pair_atomic_type>
 __global__ void initialize(
   pair_atomic_type* const slots, Key k,
   Value v, std::size_t size) {
   
-  auto tid = static_cast<std::size_t>(blockDim.x) * blockIdx.x + threadIdx.x;
+  auto tid = block_size * blockIdx.x + threadIdx.x;
   while (tid < size) {
     new (&slots[tid].first) atomic_key_type{k};
     new (&slots[tid].second) atomic_mapped_type{v};

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -65,7 +65,7 @@ class dynamic_map;
  * in the map. For example, given a range of keys specified by device-accessible
  * iterators, the bulk `insert` function will insert all keys into the map.
  *
- * The singular device-side operations allow individual threads to to perform
+ * The singular device-side operations allow individual threads to perform
  * independent insert or find/contains operations from device code. These
  * operations are accessed through non-owning, trivially copyable "view" types:
  * `device_view` and `mutable_device_view`. The `device_view` class is an

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -138,8 +138,8 @@ class static_map {
    * and sentinel values.
    *
    * The capacity of the map is fixed. Insert operations will not automatically
-   * grow the map. Attempting to insert more unique keys than the capacity of
-   * the map results in undefined behavior.
+   * grow the map. Attempting to insert equal to or more unique keys than the capacity
+   * of the map results in undefined behavior (there should be at least one empty slot).
    *
    * Performance begins to degrade significantly beyond a load factor of ~70%.
    * For best performance, choose a capacity that will keep the load factor


### PR DESCRIPTION
Fixes #71 #72 #73 #74 #75

- Fix the uint32_t overflow with 2^30 or more input keys (2^30 * 4 threads per cooperative group = 2^32, Issue #71)
- Fix the CUDA exception error if find() is executed on a 0 capacity map (Issue #72)
- Update documentation to articulate that cuco::static_map requires at least one empty slot (Issue #73)
- Update find() to return the empty value sentinel on non-existing keys (Issue #74)
- Fix find(), insert(), and contains() to immediately return if input count is 0 (Issue #75)