### PR TITLE
Fix compiler warnings about exceptions always invoking std::terminate and suboject linkage

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -39,7 +39,7 @@ function(ConfigureBench BENCH_NAME BENCH_SRC)
                                         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/gbenchmarks")
     target_include_directories(${BENCH_NAME} PRIVATE
                                              "${CMAKE_CURRENT_SOURCE_DIR}")
-    target_compile_options(${BENCH_NAME} PRIVATE --expt-extended-lambda --expt-relaxed-constexpr)
+    target_compile_options(${BENCH_NAME} PRIVATE --expt-extended-lambda --expt-relaxed-constexpr -Xcompiler -Wno-subobject-linkage)
     target_link_libraries(${BENCH_NAME} PRIVATE 
                                         benchmark benchmark_main 
                                         pthread 

--- a/benchmarks/synchronization.hpp
+++ b/benchmarks/synchronization.hpp
@@ -24,8 +24,13 @@
   do {                                                                               \
     auto const status = (call);                                                      \
     if (cudaSuccess != status) { throw std::runtime_error("CUDA error detected."); } \
-  } while (0);
+  } while (0)
 
+#define BENCH_ASSERT_CUDA_SUCCESS(expr) \
+  do {                                  \
+    cudaError_t const status = (expr);  \
+    assert(cudaSuccess == status);      \
+  } while (0)
 /**
  * @brief  This class serves as a wrapper for using `cudaEvent_t` as the user
  * defined timer within the framework of google benchmark
@@ -110,13 +115,13 @@ class cuda_event_timer {
    */
   ~cuda_event_timer()
   {
-    BENCH_CUDA_TRY(cudaEventRecord(stop_, stream_));
-    BENCH_CUDA_TRY(cudaEventSynchronize(stop_));
+    BENCH_ASSERT_CUDA_SUCCESS(cudaEventRecord(stop_, stream_));
+    BENCH_ASSERT_CUDA_SUCCESS(cudaEventSynchronize(stop_));
     float milliseconds = 0.0f;
-    BENCH_CUDA_TRY(cudaEventElapsedTime(&milliseconds, start_, stop_));
+    BENCH_ASSERT_CUDA_SUCCESS(cudaEventElapsedTime(&milliseconds, start_, stop_));
     p_state->SetIterationTime(milliseconds / (1000.0f));
-    BENCH_CUDA_TRY(cudaEventDestroy(start_));
-    BENCH_CUDA_TRY(cudaEventDestroy(stop_));
+    BENCH_ASSERT_CUDA_SUCCESS(cudaEventDestroy(start_));
+    BENCH_ASSERT_CUDA_SUCCESS(cudaEventDestroy(stop_));
   }
 
  private:

--- a/include/cuco/detail/dynamic_map.inl
+++ b/include/cuco/detail/dynamic_map.inl
@@ -40,7 +40,7 @@ dynamic_map<Key, Value, Scope, Allocator>::dynamic_map(std::size_t initial_capac
 template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
 dynamic_map<Key, Value, Scope, Allocator>::~dynamic_map()
 {
-  CUCO_CUDA_TRY(cudaFree(num_successes_));
+  CUCO_ASSERT_CUDA_SUCCESS(cudaFree(num_successes_));
 }
 
 template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>

--- a/include/cuco/detail/dynamic_map.inl
+++ b/include/cuco/detail/dynamic_map.inl
@@ -124,7 +124,7 @@ void dynamic_map<Key, Value, Scope, Allocator>::insert(InputIt first,
 template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
 template <typename InputIt, typename OutputIt, typename Hash, typename KeyEqual>
 void dynamic_map<Key, Value, Scope, Allocator>::find(
-  InputIt first, InputIt last, OutputIt output_begin, Hash hash, KeyEqual key_equal) noexcept
+  InputIt first, InputIt last, OutputIt output_begin, Hash hash, KeyEqual key_equal)
 {
   auto num_keys         = std::distance(first, last);
   auto const block_size = 128;
@@ -140,7 +140,7 @@ void dynamic_map<Key, Value, Scope, Allocator>::find(
 template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
 template <typename InputIt, typename OutputIt, typename Hash, typename KeyEqual>
 void dynamic_map<Key, Value, Scope, Allocator>::contains(
-  InputIt first, InputIt last, OutputIt output_begin, Hash hash, KeyEqual key_equal) noexcept
+  InputIt first, InputIt last, OutputIt output_begin, Hash hash, KeyEqual key_equal)
 {
   auto num_keys         = std::distance(first, last);
   auto const block_size = 128;

--- a/include/cuco/detail/error.hpp
+++ b/include/cuco/detail/error.hpp
@@ -79,4 +79,4 @@ struct cuda_error : public std::runtime_error {
   do {                                 \
     cudaError_t const status = (expr); \
     assert(cudaSuccess == status);     \
-  } while (0);
+  } while (0)

--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -83,7 +83,7 @@ void static_map<Key, Value, Scope, Allocator>::insert(InputIt first,
 template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
 template <typename InputIt, typename OutputIt, typename Hash, typename KeyEqual>
 void static_map<Key, Value, Scope, Allocator>::find(
-  InputIt first, InputIt last, OutputIt output_begin, Hash hash, KeyEqual key_equal) noexcept
+  InputIt first, InputIt last, OutputIt output_begin, Hash hash, KeyEqual key_equal) 
 {
   auto num_keys         = std::distance(first, last);
   auto const block_size = 128;

--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -51,7 +51,7 @@ template <typename Key, typename Value, cuda::thread_scope Scope, typename Alloc
 static_map<Key, Value, Scope, Allocator>::~static_map()
 {
   std::allocator_traits<slot_allocator_type>::deallocate(slot_allocator_, slots_, capacity_);
-  CUCO_CUDA_TRY(cudaFree(num_successes_));
+  CUCO_ASSERT_CUDA_SUCCESS(cudaFree(num_successes_));
 }
 
 template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>

--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -100,7 +100,7 @@ void static_map<Key, Value, Scope, Allocator>::find(
 template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
 template <typename InputIt, typename OutputIt, typename Hash, typename KeyEqual>
 void static_map<Key, Value, Scope, Allocator>::contains(
-  InputIt first, InputIt last, OutputIt output_begin, Hash hash, KeyEqual key_equal) noexcept
+  InputIt first, InputIt last, OutputIt output_begin, Hash hash, KeyEqual key_equal)
 {
   auto num_keys         = std::distance(first, last);
   auto const block_size = 128;

--- a/include/cuco/dynamic_map.cuh
+++ b/include/cuco/dynamic_map.cuh
@@ -189,7 +189,7 @@ class dynamic_map {
             InputIt last,
             OutputIt output_begin,
             Hash hash          = Hash{},
-            KeyEqual key_equal = KeyEqual{}) noexcept;
+            KeyEqual key_equal = KeyEqual{});
 
   /**
    * @brief Indicates whether the keys in the range `[first, last)` are contained in the map.
@@ -216,7 +216,7 @@ class dynamic_map {
                 InputIt last,
                 OutputIt output_begin,
                 Hash hash          = Hash{},
-                KeyEqual key_equal = KeyEqual{}) noexcept;
+                KeyEqual key_equal = KeyEqual{});
 
   /**
    * @brief Gets the current number of elements in the map

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -239,7 +239,7 @@ class static_map {
                 InputIt last,
                 OutputIt output_begin,
                 Hash hash          = Hash{},
-                KeyEqual key_equal = KeyEqual{}) noexcept;
+                KeyEqual key_equal = KeyEqual{});
 
  private:
   class device_view_base {

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -212,7 +212,7 @@ class static_map {
             InputIt last,
             OutputIt output_begin,
             Hash hash          = Hash{},
-            KeyEqual key_equal = KeyEqual{}) noexcept;
+            KeyEqual key_equal = KeyEqual{});
 
   /**
    * @brief Indicates whether the keys in the range `[first, last)` are contained in the map.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,7 +41,7 @@ function(ConfigureTest TEST_NAME TEST_SRC)
     set_target_properties(${TEST_NAME} PROPERTIES
                                        CUDA_ARCHITECTURES ${GPU_ARCHS}
                                        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests")
-    target_compile_options(${TEST_NAME} PRIVATE --expt-extended-lambda --expt-relaxed-constexpr)
+    target_compile_options(${TEST_NAME} PRIVATE --expt-extended-lambda --expt-relaxed-constexpr -Xcompiler -Wno-subobject-linkage)
     catch_discover_tests(${TEST_NAME})
 endfunction(ConfigureTest)
 


### PR DESCRIPTION
- [x] Removed `noexcept` from functions that weren't actually `noexcept`
- [x] Use `assert` in dtors to check success of CUDA runtime APIs instead of throwing 
- [x] Add `-Wno-suboject-linkage` to compile flags for tests/benchmarks to silence warnings about using device lambdas in anonymous namespace (see https://github.com/catchorg/Catch2/issues/1875 and https://github.com/NVIDIA/thrust/issues/1058)
