### PR TITLE
Add trait for is_bitwise_comparable

### DIFF
--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -63,8 +63,8 @@ struct is_bitwise_comparable : std::false_type {
 
 /// By default, only types with unique object representations are allowed
 template <typename T>
-  struct is_bitwise_comparable < T,
-  std::enable_if_t<std::has_unique_object_representations_v<T>> : std::true_type {
+struct is_bitwise_comparable<T, std::enable_if_t<std::has_unique_object_representations_v<T>>>
+  : std::true_type {
 };
 
 /**

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -61,6 +61,7 @@ template <typename T, typename = void>
 struct is_bitwise_comparable : std::false_type {
 };
 
+/// By default, only types with unique object representations are allowed
 template <typename T>
   struct is_bitwise_comparable < T,
   std::enable_if_t<std::has_unique_object_representations_v<T>> : std::true_type {
@@ -85,14 +86,12 @@ template <typename T>
  * concurrent insert and find) from threads in device code.
  *
  * Current limitations:
- * - Requires keys and values that are trivially copyable and have unique object representations
+ * - Requires keys and values that where `cuco::is_bitwise_comparable<T>::value` is true
  *    - Comparisons against the "sentinel" values will always be done with bitwise comparisons.
- *      Therefore, the objects must have unique, bitwise object representations (e.g., no padding
- *      bits).
  * - Does not support erasing keys
  * - Capacity is fixed and will not grow automatically
- * - Requires the user to specify sentinel values for both key and mapped value
- * to indicate empty slots
+ * - Requires the user to specify sentinel values for both key and mapped value to indicate empty
+ * slots
  * - Does not support concurrent insert and find operations
  *
  * The `static_map` supports two types of operations:

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -158,7 +158,7 @@ class static_map {
 
   static_assert(
     is_bitwise_comparable<Value>::value,
-    "Key type must have unique object representations or have been explicitly declared as safe for "
+    "Value type must have unique object representations or have been explicitly declared as safe for "
     "bitwise comparison via specialization of cuco::is_bitwise_comparable<Value>.");
 
   friend class dynamic_map<Key, Value, Scope, Allocator>;


### PR DESCRIPTION
Recently I changed it so the only supported Key/Value types were ones where `has_unique_object_representations_v<T>` was true. However, this disallows any floating point types, which is too restrictive for many valid use cases.

Therefore, I added a trait, `cuco::is_bitwise_comparable` that allows for user-defined specializations to declare that a type `T` is safe for bitwise comparison. 