### PR TITLE
Fix issues with pair

### DIFF
--- a/include/cuco/detail/pair.cuh
+++ b/include/cuco/detail/pair.cuh
@@ -133,6 +133,8 @@ using pair_type = cuco::pair<K, V>;
 template <typename F, typename S>
 __host__ __device__ pair_type<F, S> make_pair(F&& f, S&& s) noexcept
 {
-  return pair_type<F, S>{std::forward<F>(f), std::forward<S>(s)};
+  using decayed_F = std::decay_t<F>;
+  using decayed_S = std::decay_t<S>;
+  return pair_type<decayed_F, decayed_S>{std::forward<decayed_F>(f), std::forward<decayed_S>(s)};
 }
 }  // namespace cuco

--- a/include/cuco/detail/pair.cuh
+++ b/include/cuco/detail/pair.cuh
@@ -75,8 +75,8 @@ struct is_thrust_pair_like_impl<T,
 
 template <typename T>
 struct is_thrust_pair_like
-  : is_thrust_pair_like_impl<
-      std::remove_reference_t<decltype(thrust::raw_reference_cast(std::declval<T>()))>> {
+  : is_thrust_pair_like_impl<std::remove_const_t< // remove_const to WAR Thrust bug https://github.com/NVIDIA/thrust/issues/1456
+      std::remove_reference_t<decltype(thrust::raw_reference_cast(std::declval<T>()))>>> {
 };
 
 }  // namespace detail

--- a/include/cuco/detail/pair.cuh
+++ b/include/cuco/detail/pair.cuh
@@ -131,7 +131,7 @@ using pair_type = cuco::pair<K, V>;
  * @return pair_type with first element `f` and second element `s`.
  */
 template <typename F, typename S>
-__host__ __device__ pair_type<F, S> make_pair(F&& f, S&& s) noexcept
+__host__ __device__ auto make_pair(F&& f, S&& s) noexcept
 {
   using decayed_F = std::decay_t<F>;
   using decayed_S = std::decay_t<S>;


### PR DESCRIPTION
- [x] WAR https://github.com/NVIDIA/thrust/issues/1456 by using `remove_const` in `is_thrust_pair_like`
- [x] Correct `make_pair` to use `decay_t` for the element types