### PR TITLE
[WIP] Declare non-template functions in bitwise_compare.cuh as inline

### DIFF
--- a/include/cuco/detail/bitwise_compare.cuh
+++ b/include/cuco/detail/bitwise_compare.cuh
@@ -19,7 +19,7 @@
 
 namespace cuco {
 namespace detail {
-__host__ __device__ int cuda_memcmp(void const* __lhs, void const* __rhs, size_t __count)
+__host__ __device__ inline int cuda_memcmp(void const* __lhs, void const* __rhs, size_t __count)
 {
   auto __lhs_c = reinterpret_cast<unsigned char const*>(__lhs);
   auto __rhs_c = reinterpret_cast<unsigned char const*>(__rhs);
@@ -42,7 +42,7 @@ struct bitwise_compare_impl {
 
 template <>
 struct bitwise_compare_impl<4> {
-  __host__ __device__ static bool compare(char const* lhs, char const* rhs)
+  __host__ __device__ inline static bool compare(char const* lhs, char const* rhs)
   {
     return *reinterpret_cast<uint32_t const*>(lhs) == *reinterpret_cast<uint32_t const*>(rhs);
   }
@@ -50,7 +50,7 @@ struct bitwise_compare_impl<4> {
 
 template <>
 struct bitwise_compare_impl<8> {
-  __host__ __device__ static bool compare(char const* lhs, char const* rhs)
+  __host__ __device__ inline static bool compare(char const* lhs, char const* rhs)
   {
     return *reinterpret_cast<uint64_t const*>(lhs) == *reinterpret_cast<uint64_t const*>(rhs);
   }


### PR DESCRIPTION
Mark template specializations and non-template functions in bitwise_compare.cuh as inline to avoid ODR issues. PR #96 removed an invalid `constexpr` specification on these functions but failed to replace the implicit `inline` specification to prevent ODR violations in libraries attempting to consume cuCollections. This broke the build for cuML and likely other consumers.This PR marks the necessary functions as `inline` in order to enforce ODR, which allows the cuML build to proceed.