### PR TITLE
Use rapids_cpm_libcudacxx to support installed libcudacxx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ add_library(cuco::cuco ALIAS cuco)
 target_include_directories(cuco INTERFACE
     INTERFACE   $<BUILD_INTERFACE:${CUCO_SOURCE_DIR}/include>
                 $<INSTALL_INTERFACE:include>)
-target_link_libraries(cuco INTERFACE libcudacxx CUDA::toolkit $<BUILD_INTERFACE:cuco::Thrust>)
+target_link_libraries(cuco INTERFACE CUDA::toolkit $<BUILD_INTERFACE:cuco::Thrust>)
 target_compile_features(cuco INTERFACE cxx_std_17 cuda_std_17)
 
 ###################################################################################################
@@ -108,7 +108,7 @@ endif(BUILD_EXAMPLES)
 ###################################################################################################
 # - Install targets -------------------------------------------------------------------------------
 
-install(TARGETS cuco libcudacxx EXPORT cuco-exports)
+install(TARGETS cuco EXPORT cuco-exports)
 install(DIRECTORY include/cuco/ DESTINATION include/cuco)
 install(FILES ${CUCO_BINARY_DIR}/include/cuco/version_config.hpp DESTINATION include/cuco)
 
@@ -131,7 +131,7 @@ structures tailored for efficient use with GPUs.
 rapids_export(
     INSTALL cuco
     EXPORT_SET cuco-exports
-    GLOBAL_TARGETS cuco libcudacxx
+    GLOBAL_TARGETS cuco
     NAMESPACE cuco::
     DOCUMENTATION doc_string)
 
@@ -146,7 +146,7 @@ endif()
 rapids_export(
     BUILD cuco
     EXPORT_SET cuco-exports
-    GLOBAL_TARGETS cuco libcudacxx
+    GLOBAL_TARGETS cuco
     NAMESPACE cuco::
     DOCUMENTATION doc_string
     FINAL_CODE_BLOCK code_string)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ add_library(cuco::cuco ALIAS cuco)
 target_include_directories(cuco INTERFACE
     INTERFACE   $<BUILD_INTERFACE:${CUCO_SOURCE_DIR}/include>
                 $<INSTALL_INTERFACE:include>)
-target_link_libraries(cuco INTERFACE CUDA::toolkit $<BUILD_INTERFACE:cuco::Thrust>)
+target_link_libraries(cuco INTERFACE libcudacxx::libcudacxx CUDA::toolkit $<BUILD_INTERFACE:cuco::Thrust>)
 target_compile_features(cuco INTERFACE cxx_std_17 cuda_std_17)
 
 ###################################################################################################

--- a/cmake/thirdparty/get_libcudacxx.cmake
+++ b/cmake/thirdparty/get_libcudacxx.cmake
@@ -13,22 +13,12 @@
 # =============================================================================
 
 # Use CPM to find or clone thrust
-function(find_and_configure_libcudacxx VERSION)
-    rapids_cpm_find(
-        libcudacxx         ${VERSION}
-        CPM_ARGS
-            GIT_REPOSITORY https://github.com/NVIDIA/libcudacxx.git
-            GIT_TAG        ${VERSION}
-            GIT_SHALLOW    TRUE
-            DOWNLOAD_ONLY  TRUE
-    )
-    # TODO: Once libcu++ exports a target, use that instead
-    add_library(libcudacxx INTERFACE)
-    target_include_directories(libcudacxx
-        INTERFACE   $<BUILD_INTERFACE:${libcudacxx_SOURCE_DIR}/include>
-                    $<INSTALL_INTERFACE:include/cuco/libcudacxx>)
-    install(DIRECTORY ${libcudacxx_SOURCE_DIR}/include/ DESTINATION include/cuco/libcudacxx)
-    install(DIRECTORY ${libcudacxx_SOURCE_DIR}/libcxx/include/ DESTINATION include/cuco/libcxx/include)
+function(find_and_configure_libcudacxx)
+    include(${rapids-cmake-dir}/cpm/libcudacxx.cmake)
+
+    rapids_cpm_libcudacxx(BUILD_EXPORT_SET cuco-exports
+                          INSTALL_EXPORT_SET cuco-exports)
+
 endfunction()
 
-find_and_configure_libcudacxx(1.4.0)
+find_and_configure_libcudacxx()


### PR DESCRIPTION
Currently if an installed version of libcudacxx is found, the install paths computed in get_libcudacxx are wrong. Resolve this issue by instead using rapids-cmake
