### PR TITLE
Allocator takes no stream argument

### DIFF
--- a/include/cuco/allocator.hpp
+++ b/include/cuco/allocator.hpp
@@ -32,17 +32,14 @@ class cuda_allocator {
   {
   }
 
-  value_type* allocate(std::size_t n, cudaStream_t stream = 0)
+  value_type* allocate(std::size_t n)
   {
     value_type* p;
     CUCO_CUDA_TRY(cudaMalloc(&p, sizeof(value_type) * n));
     return p;
   }
 
-  void deallocate(value_type* p, std::size_t, cudaStream_t stream = 0)
-  {
-    CUCO_CUDA_TRY(cudaFree(p));
-  }
+  void deallocate(value_type* p, std::size_t) { CUCO_CUDA_TRY(cudaFree(p)); }
 };
 
 template <typename T, typename U>

--- a/include/cuco/detail/static_multimap/static_multimap.inl
+++ b/include/cuco/detail/static_multimap/static_multimap.inl
@@ -54,8 +54,8 @@ static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::static_multimap(
     stream_{stream},
     delete_counter_{counter_allocator_, stream_},
     delete_slots_{slot_allocator_, capacity_, stream_},
-    d_counter_{counter_allocator_.allocate(1, stream_), delete_counter_},
-    slots_{slot_allocator_.allocate(capacity_, stream_), delete_slots_}
+    d_counter_{counter_allocator_.allocate(1), delete_counter_},
+    slots_{slot_allocator_.allocate(capacity_), delete_slots_}
 {
   auto constexpr block_size = 128;
   auto constexpr stride     = 4;

--- a/include/cuco/detail/static_multimap/static_multimap.inl
+++ b/include/cuco/detail/static_multimap/static_multimap.inl
@@ -51,9 +51,8 @@ static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::static_multimap(
     empty_value_sentinel_{empty_value_sentinel},
     counter_allocator_{alloc},
     slot_allocator_{alloc},
-    stream_{stream},
-    delete_counter_{counter_allocator_, stream_},
-    delete_slots_{slot_allocator_, capacity_, stream_},
+    delete_counter_{counter_allocator_},
+    delete_slots_{slot_allocator_, capacity_},
     d_counter_{counter_allocator_.allocate(1), delete_counter_},
     slots_{slot_allocator_.allocate(capacity_), delete_slots_}
 {
@@ -61,7 +60,7 @@ static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::static_multimap(
   auto constexpr stride     = 4;
   auto const grid_size      = (get_capacity() + stride * block_size - 1) / (stride * block_size);
 
-  detail::initialize<atomic_key_type, atomic_mapped_type><<<grid_size, block_size, 0, stream_>>>(
+  detail::initialize<atomic_key_type, atomic_mapped_type><<<grid_size, block_size, 0, stream>>>(
     slots_.get(), empty_key_sentinel, empty_value_sentinel, get_capacity());
 }
 

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -536,7 +536,7 @@ class static_multimap {
 
     counter_deleter(counter_deleter const&) = default;
 
-    void operator()(atomic_ctr_type* ptr) { allocator.deallocate(ptr, 1, stream); }
+    void operator()(atomic_ctr_type* ptr) { allocator.deallocate(ptr, 1); }
 
     counter_allocator_type& allocator;
     cudaStream_t& stream;
@@ -553,7 +553,7 @@ class static_multimap {
 
     slot_deleter(slot_deleter const&) = default;
 
-    void operator()(pair_atomic_type* ptr) { allocator.deallocate(ptr, capacity, stream); }
+    void operator()(pair_atomic_type* ptr) { allocator.deallocate(ptr, capacity); }
 
     slot_allocator_type& allocator;
     size_t& capacity;

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -532,24 +532,20 @@ class static_multimap {
    * @brief Custom deleter for unique pointer of device counter.
    */
   struct counter_deleter {
-    counter_deleter(counter_allocator_type& a, cudaStream_t& s) : allocator{a}, stream{s} {}
+    counter_deleter(counter_allocator_type& a) : allocator{a} {}
 
     counter_deleter(counter_deleter const&) = default;
 
     void operator()(atomic_ctr_type* ptr) { allocator.deallocate(ptr, 1); }
 
     counter_allocator_type& allocator;
-    cudaStream_t& stream;
   };
 
   /**
    * @brief Custom deleter for unique pointer of slots.
    */
   struct slot_deleter {
-    slot_deleter(slot_allocator_type& a, size_t& c, cudaStream_t& s)
-      : allocator{a}, capacity{c}, stream{s}
-    {
-    }
+    slot_deleter(slot_allocator_type& a, size_t& c) : allocator{a}, capacity{c} {}
 
     slot_deleter(slot_deleter const&) = default;
 
@@ -557,7 +553,6 @@ class static_multimap {
 
     slot_allocator_type& allocator;
     size_t& capacity;
-    cudaStream_t& stream;
   };
 
   class device_view_impl_base;
@@ -1146,7 +1141,6 @@ class static_multimap {
   Value empty_value_sentinel_{};                ///< Initial value of empty slot
   slot_allocator_type slot_allocator_{};        ///< Allocator used to allocate slots
   counter_allocator_type counter_allocator_{};  ///< Allocator used to allocate counters
-  cudaStream_t stream_{};                       ///< CUDA stream used for ctor/dtor
   counter_deleter delete_counter_;              ///< Custom counter deleter
   slot_deleter delete_slots_;                   ///< Custom slots deleter
   std::unique_ptr<atomic_ctr_type, counter_deleter> d_counter_{};  ///< Preallocated device counter


### PR DESCRIPTION
This PR fixes a bug when users pass an allocator taking no stream argument. It removes `stream_` member variable in `cuco::static_multimap` since it's no longer required in ctor/dtor.