### PR TITLE
Fix a bug: expose public device APIs

### DIFF
--- a/include/cuco/detail/probe_sequence_impl.cuh
+++ b/include/cuco/detail/probe_sequence_impl.cuh
@@ -108,6 +108,7 @@ class probe_sequence_impl_base {
   {
   }
 
+ public:
   /**
    * @brief Returns the capacity of the hash map.
    */
@@ -126,6 +127,7 @@ class probe_sequence_impl_base {
    */
   __device__ __forceinline__ const_iterator get_slots() const noexcept { return slots_; }
 
+ protected:
   iterator slots_;              ///< Pointer to beginning of the hash map slots
   const std::size_t capacity_;  ///< Total number of slots
 };                              // class probe_sequence_impl_base

--- a/include/cuco/detail/static_multimap/device_view_impl.inl
+++ b/include/cuco/detail/static_multimap/device_view_impl.inl
@@ -24,27 +24,6 @@ template <typename Key,
           typename Allocator,
           class ProbeSequence>
 class static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_view_impl_base {
- public:
-  /**
-   * @brief Gets the sentinel value used to represent an empty key slot.
-   *
-   * @return The sentinel value used to represent an empty key slot
-   */
-  __host__ __device__ __forceinline__ Key get_empty_key_sentinel() const noexcept
-  {
-    return empty_key_sentinel_;
-  }
-
-  /**
-   * @brief Gets the sentinel value used to represent an empty value slot.
-   *
-   * @return The sentinel value used to represent an empty value slot
-   */
-  __host__ __device__ __forceinline__ Value get_empty_value_sentinel() const noexcept
-  {
-    return empty_value_sentinel_;
-  }
-
  protected:
   // Import member type definitions from `static_multimap`
   using value_type          = value_type;
@@ -79,26 +58,6 @@ class static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_view_
       empty_key_sentinel_{empty_key_sentinel},
       empty_value_sentinel_{empty_value_sentinel}
   {
-  }
-
-  /**
-   * @brief Gets slots array.
-   *
-   * @return Slots array
-   */
-  __device__ __forceinline__ pair_atomic_type* get_slots() noexcept
-  {
-    return probe_sequence_.get_slots();
-  }
-
-  /**
-   * @brief Gets slots array.
-   *
-   * @return Slots array
-   */
-  __device__ __forceinline__ pair_atomic_type const* get_slots() const noexcept
-  {
-    return probe_sequence_.get_slots();
   }
 
   /**
@@ -162,16 +121,6 @@ class static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_view_
   }
 
   /**
-   * @brief Gets the maximum number of elements the hash map can hold.
-   *
-   * @return The maximum number of elements the hash map can hold
-   */
-  __host__ __device__ __forceinline__ std::size_t get_capacity() const noexcept
-  {
-    return probe_sequence_.get_capacity();
-  }
-
-  /**
    * @brief Load two key/value pairs from the given slot to the target pair array.
    *
    * @param arr The pair array to be loaded
@@ -187,6 +136,57 @@ class static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_view_
       auto const tmp = *reinterpret_cast<uint4 const*>(current_slot);
       memcpy(&arr[0], &tmp, 2 * sizeof(value_type));
     }
+  }
+
+ public:
+  /**
+   * @brief Gets the sentinel value used to represent an empty key slot.
+   *
+   * @return The sentinel value used to represent an empty key slot
+   */
+  __host__ __device__ __forceinline__ Key get_empty_key_sentinel() const noexcept
+  {
+    return empty_key_sentinel_;
+  }
+
+  /**
+   * @brief Gets the sentinel value used to represent an empty value slot.
+   *
+   * @return The sentinel value used to represent an empty value slot
+   */
+  __host__ __device__ __forceinline__ Value get_empty_value_sentinel() const noexcept
+  {
+    return empty_value_sentinel_;
+  }
+
+  /**
+   * @brief Gets slots array.
+   *
+   * @return Slots array
+   */
+  __device__ __forceinline__ pair_atomic_type* get_slots() noexcept
+  {
+    return probe_sequence_.get_slots();
+  }
+
+  /**
+   * @brief Gets slots array.
+   *
+   * @return Slots array
+   */
+  __device__ __forceinline__ pair_atomic_type const* get_slots() const noexcept
+  {
+    return probe_sequence_.get_slots();
+  }
+
+  /**
+   * @brief Gets the maximum number of elements the hash map can hold.
+   *
+   * @return The maximum number of elements the hash map can hold
+   */
+  __host__ __device__ __forceinline__ std::size_t get_capacity() const noexcept
+  {
+    return probe_sequence_.get_capacity();
   }
 
  private:


### PR DESCRIPTION
This is a follow-up PR of https://github.com/NVIDIA/cuCollections/pull/126. A new `device_view_base` class is added to remove redundancy and expose the following public APIs in both `device_view` and `device_mutable_view`:

- get_empty_key_sentinel()
- get_empty_value_sentinel()
- get_slots()
- get_capacity()