### PR TITLE
Move cuCollections to libcudacxx 1.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 #=============================================================================
 cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
-file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-21.12/RAPIDS.cmake
+file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.02/RAPIDS.cmake
      ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
 include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
 

--- a/cmake/thirdparty/get_libcudacxx.cmake
+++ b/cmake/thirdparty/get_libcudacxx.cmake
@@ -15,18 +15,7 @@
 # Use CPM to find or clone libcudacxx
 function(find_and_configure_libcudacxx)
     include(${rapids-cmake-dir}/cpm/libcudacxx.cmake)
-    include(${rapids-cmake-dir}/cpm/package_override.cmake)
 
-    file(WRITE ${CMAKE_BINARY_DIR}/libcudacxx.json [=[
-      {
-      "packages" : {
-      "libcudacxx" : {
-      "version" : "1.7.0",
-      "git_url" : "https://github.com/NVIDIA/libcudacxx.git",
-      "git_tag" : "1.7.0-ea"
-      }}
-    }]=])
-    rapids_cpm_package_override(${CMAKE_BINARY_DIR}/libcudacxx.json)
     rapids_cpm_libcudacxx(BUILD_EXPORT_SET cuco-exports
                           INSTALL_EXPORT_SET cuco-exports)
     set(LIBCUDACXX_INCLUDE_DIR "${libcudacxx_SOURCE_DIR}/include" PARENT_SCOPE)


### PR DESCRIPTION
Previously was on 1.7.0-ea, but can use rapids-cmake now that https://github.com/rapidsai/rapids-cmake/pull/143 has been merged.
