### PR TITLE
Match all possible pascal archs in CMake

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -22,7 +22,7 @@ ConfigureExample(CUSTOM_TYPE_EXAMPLE "${CMAKE_CURRENT_SOURCE_DIR}/static_map/cus
 ConfigureExample(STATIC_MULTIMAP_EXAMPLE "${CMAKE_CURRENT_SOURCE_DIR}/static_multimap/static_multimap_example.cu")
 
 foreach(arch IN LISTS CMAKE_CUDA_ARCHITECTURES)
-    if("${arch}" MATCHES "60")
+    if("${arch}" MATCHES "^6")
       target_compile_definitions(CUSTOM_TYPE_EXAMPLE PRIVATE CUCO_NO_INDEPENDENT_THREADS)
       break()
     endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,7 +41,7 @@ set(STATIC_MAP_TEST_SRC
 ConfigureTest(STATIC_MAP_TEST "${STATIC_MAP_TEST_SRC}")
 
 foreach(arch IN LISTS CMAKE_CUDA_ARCHITECTURES)
-    if("${arch}" MATCHES "60")
+    if("${arch}" MATCHES "^6")
       target_compile_definitions(STATIC_MAP_TEST PRIVATE CUCO_NO_INDEPENDENT_THREADS)
       break()
     endif()


### PR DESCRIPTION
This PR fixes a small regex match bug in CMake. `CUCO_NO_INDEPENDENT_THREADS` is defined if `arch` starts with `6` as opposed to `60`. Thus all possible Pascal architecture codes (`60`, `61` and `62`) will be checked.