### PR TITLE
Auto formatting via `pre-commit.ci`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ ci:
 
 repos:
       - repo: https://github.com/pre-commit/mirrors-clang-format
-        rev: v11.1.0
+        rev: v13.0.0
         hooks:
               - id: clang-format
                 files: \.(cu|cuh|h|hpp|cpp|inl)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,18 @@
+ci:
+    autofix_commit_msg: |
+      [pre-commit.ci] auto code formatting
+    autofix_prs: true
+    autoupdate_branch: ''
+    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+    autoupdate_schedule: quarterly
+    skip: []
+    submodules: false
+
 repos:
       - repo: https://github.com/pre-commit/mirrors-clang-format
         rev: v11.1.0
         hooks:
               - id: clang-format
-                # Using the pre-commit stage to simplify invocation of all
-                # other hooks simultaneously (via any other hook stage).  This
-                # can be removed if we also move to running clang-format
-                # entirely through pre-commit.
-                stages: [commit]
-                name: clang-format
-                description: Format files with ClangFormat.
-                entry: clang-format
-                language: system
                 files: \.(cu|cuh|h|hpp|cpp|inl)$
                 'types_or': [file]
                 args: ['-fallback-style=none', '-style=file', '-i']

--- a/README.md
+++ b/README.md
@@ -86,32 +86,8 @@ Binaries will be built into:
 
 ## Code Formatting
 
-`cuCollections` uses [`pre-commit`](https://pre-commit.com/) along with [`mirrors-clang-format`](https://github.com/pre-commit/mirrors-clang-format) to format the C++/CUDA files.
-To install `pre-commit` via `conda` or `pip`:
-
-```bash
-conda install -c conda-forge pre_commit
-```
-
-```bash
-pip install pre-commit
-```
-
-and then running:
-```bash
-pre-commit install
-```
-
-from the root of the `cuCollections` repository. Now code formatting will be run each time you commit changes.
-
-Optionally, you may wish to manually format the code:
-```bash
-pre-commit run clang-format --all-files
-```
-
-### Caveats
-`mirrors-clang-format` guarantees the correct version of `clang-format` and avoids version mismatches.
-Users should **_NOT_** use `clang-format` directly on the command line to format the code.
+`cuCollections` uses [`pre-commit.ci`](https://pre-commit.ci/) along with [`mirrors-clang-format`](https://github.com/pre-commit/mirrors-clang-format) to automatically format involved C++/CUDA files in a pull request.
+Users should enable the `Allow edits by maintainers` option to get auto-formatting to work.
 
 
 ## Data Structures

--- a/README.md
+++ b/README.md
@@ -86,8 +86,35 @@ Binaries will be built into:
 
 ## Code Formatting
 
-`cuCollections` uses [`pre-commit.ci`](https://pre-commit.ci/) along with [`mirrors-clang-format`](https://github.com/pre-commit/mirrors-clang-format) to automatically format involved C++/CUDA files in a pull request.
+By default, `cuCollections` uses [`pre-commit.ci`](https://pre-commit.ci/) along with [`mirrors-clang-format`](https://github.com/pre-commit/mirrors-clang-format) to automatically format the C++/CUDA files in a pull request.
 Users should enable the `Allow edits by maintainers` option to get auto-formatting to work.
+
+### Pre-commit hook
+Optionally, you may wish to setup a [`pre-commit`](https://pre-commit.com/) hook to automatically run `clang-format` when you make a git commit. This can be done by installing `pre-commit` via `conda` or `pip`:
+
+```bash
+conda install -c conda-forge pre_commit
+```
+
+```bash
+pip install pre-commit
+```
+
+and then running:
+```bash
+pre-commit install
+```
+
+from the root of the `cuCollections` repository. Now code formatting will be run each time you commit changes.
+
+You may also wish to manually format the code:
+```bash
+pre-commit run clang-format --all-files
+```
+
+### Caveats
+`mirrors-clang-format` guarantees the correct version of `clang-format` and avoids version mismatches.
+Users should **_NOT_** use `clang-format` directly on the command line to format the code.
 
 
 ## Data Structures


### PR DESCRIPTION
This PR uses [`pre-commit.ci`](https://pre-commit.ci/) to enable automatic style fixing for commits in a PR. Users should allow edits by maintainers to get auto-formatting to work.