### PR TITLE
Make all headers self-contained

### DIFF
--- a/benchmarks/hash_table/dynamic_map_bench.cu
+++ b/benchmarks/hash_table/dynamic_map_bench.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 
-#include <benchmark/benchmark.h>
+#include <synchronization.hpp>
+
 #include <cuco/dynamic_map.cuh>
+
+#include <benchmark/benchmark.h>
+
 #include <iostream>
 #include <random>
-#include <synchronization.hpp>
 
 enum class dist_type { UNIQUE, UNIFORM, GAUSSIAN };
 

--- a/benchmarks/hash_table/static_map_bench.cu
+++ b/benchmarks/hash_table/static_map_bench.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 
-#include "cuco/static_map.cuh"
+#include <cuco/static_map.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/for_each.h>
+
 #include <benchmark/benchmark.h>
+
 #include <fstream>
 #include <iostream>
 #include <random>
-#include <thrust/device_vector.h>
-#include <thrust/for_each.h>
 
 enum class dist_type { UNIQUE, UNIFORM, GAUSSIAN };
 

--- a/benchmarks/hash_table/static_map_bench.cu
+++ b/benchmarks/hash_table/static_map_bench.cu
@@ -202,63 +202,61 @@ static void BM_static_map_erase_all(::benchmark::State& state)
   state.SetBytesProcessed((sizeof(Key) + sizeof(Value)) * int64_t(state.iterations()) *
                           int64_t(state.range(0)));
 }
-/*
+
 BENCHMARK_TEMPLATE(BM_static_map_insert, int32_t, int32_t, dist_type::UNIQUE)
   ->Unit(benchmark::kMillisecond)
   ->Apply(generate_size_and_occupancy)
   ->UseManualTime();
-  */
 
 BENCHMARK_TEMPLATE(BM_static_map_search_all, int32_t, int32_t, dist_type::UNIQUE)
   ->Unit(benchmark::kMillisecond)
   ->Apply(generate_size_and_occupancy);
-/*
 
 BENCHMARK_TEMPLATE(BM_static_map_insert, int32_t, int32_t, dist_type::UNIFORM)
-->Unit(benchmark::kMillisecond)
-->Apply(generate_size_and_occupancy)
-->UseManualTime();
+  ->Unit(benchmark::kMillisecond)
+  ->Apply(generate_size_and_occupancy)
+  ->UseManualTime();
 
 BENCHMARK_TEMPLATE(BM_static_map_search_all, int32_t, int32_t, dist_type::UNIFORM)
-->Unit(benchmark::kMillisecond)
-->Apply(generate_size_and_occupancy);
+  ->Unit(benchmark::kMillisecond)
+  ->Apply(generate_size_and_occupancy);
 
 BENCHMARK_TEMPLATE(BM_static_map_insert, int32_t, int32_t, dist_type::GAUSSIAN)
-->Unit(benchmark::kMillisecond)
-->Apply(generate_size_and_occupancy)
-->UseManualTime();
+  ->Unit(benchmark::kMillisecond)
+  ->Apply(generate_size_and_occupancy)
+  ->UseManualTime();
 
 BENCHMARK_TEMPLATE(BM_static_map_search_all, int32_t, int32_t, dist_type::GAUSSIAN)
-->Unit(benchmark::kMillisecond)
-->Apply(generate_size_and_occupancy);
+  ->Unit(benchmark::kMillisecond)
+  ->Apply(generate_size_and_occupancy);
 
 BENCHMARK_TEMPLATE(BM_static_map_insert, int64_t, int64_t, dist_type::UNIQUE)
-->Unit(benchmark::kMillisecond)
-->Apply(generate_size_and_occupancy)
-->UseManualTime();
+  ->Unit(benchmark::kMillisecond)
+  ->Apply(generate_size_and_occupancy)
+  ->UseManualTime();
 
 BENCHMARK_TEMPLATE(BM_static_map_search_all, int64_t, int64_t, dist_type::UNIQUE)
-->Unit(benchmark::kMillisecond)
-->Apply(generate_size_and_occupancy);
+  ->Unit(benchmark::kMillisecond)
+  ->Apply(generate_size_and_occupancy);
 
 BENCHMARK_TEMPLATE(BM_static_map_insert, int64_t, int64_t, dist_type::UNIFORM)
-->Unit(benchmark::kMillisecond)
-->Apply(generate_size_and_occupancy)
-->UseManualTime();
+  ->Unit(benchmark::kMillisecond)
+  ->Apply(generate_size_and_occupancy)
+  ->UseManualTime();
 
 BENCHMARK_TEMPLATE(BM_static_map_search_all, int64_t, int64_t, dist_type::UNIFORM)
-->Unit(benchmark::kMillisecond)
-->Apply(generate_size_and_occupancy);
+  ->Unit(benchmark::kMillisecond)
+  ->Apply(generate_size_and_occupancy);
 
 BENCHMARK_TEMPLATE(BM_static_map_insert, int64_t, int64_t, dist_type::GAUSSIAN)
-->Unit(benchmark::kMillisecond)
-->Apply(generate_size_and_occupancy)
-->UseManualTime();
+  ->Unit(benchmark::kMillisecond)
+  ->Apply(generate_size_and_occupancy)
+  ->UseManualTime();
 
 BENCHMARK_TEMPLATE(BM_static_map_search_all, int64_t, int64_t, dist_type::GAUSSIAN)
-->Unit(benchmark::kMillisecond)
-->Apply(generate_size_and_occupancy);
+  ->Unit(benchmark::kMillisecond)
+  ->Apply(generate_size_and_occupancy);
 
 BENCHMARK_TEMPLATE(BM_static_map_erase_all, int32_t, int32_t, dist_type::UNIQUE)
-->Unit(benchmark::kMillisecond)
-->Apply(generate_size_and_occupancy);*/
+  ->Unit(benchmark::kMillisecond)
+  ->Apply(generate_size_and_occupancy);

--- a/benchmarks/hash_table/static_multimap/count_bench.cu
+++ b/benchmarks/hash_table/static_multimap/count_bench.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-#include <random>
-
-#include <nvbench/nvbench.cuh>
-#include <thrust/device_vector.h>
+#include <key_generator.hpp>
 
 #include <cuco/static_multimap.cuh>
-#include <key_generator.hpp>
+
+#include <nvbench/nvbench.cuh>
+
+#include <thrust/device_vector.h>
 
 /**
  * @brief A benchmark evaluating multi-value `count` performance:

--- a/benchmarks/hash_table/static_multimap/insert_bench.cu
+++ b/benchmarks/hash_table/static_multimap/insert_bench.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-#include <random>
-
-#include <nvbench/nvbench.cuh>
-#include <thrust/device_vector.h>
+#include <key_generator.hpp>
 
 #include <cuco/static_multimap.cuh>
-#include <key_generator.hpp>
+
+#include <nvbench/nvbench.cuh>
+
+#include <thrust/device_vector.h>
 
 /**
  * @brief A benchmark evaluating multi-value `insert` performance:

--- a/benchmarks/hash_table/static_multimap/optimal_retrieve_bench.cu
+++ b/benchmarks/hash_table/static_multimap/optimal_retrieve_bench.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
+#include <cuco/static_multimap.cuh>
+
 #include <nvbench/nvbench.cuh>
 
-#include <random>
 #include <thrust/device_vector.h>
-
-#include "cuco/static_multimap.cuh"
 
 /**
  * @brief Generates input keys by a given number of repetitions per key.

--- a/benchmarks/hash_table/static_multimap/pair_retrieve_bench.cu
+++ b/benchmarks/hash_table/static_multimap/pair_retrieve_bench.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-#include <random>
-
-#include <nvbench/nvbench.cuh>
-#include <thrust/device_vector.h>
-#include <thrust/iterator/discard_iterator.h>
+#include <key_generator.hpp>
 
 #include <cuco/static_multimap.cuh>
-#include <key_generator.hpp>
+
+#include <nvbench/nvbench.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/iterator/discard_iterator.h>
 
 namespace {
 // Custom pair equal

--- a/benchmarks/hash_table/static_multimap/query_bench.cu
+++ b/benchmarks/hash_table/static_multimap/query_bench.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-#include <random>
-
-#include <nvbench/nvbench.cuh>
-#include <thrust/device_vector.h>
+#include <key_generator.hpp>
 
 #include <cuco/static_multimap.cuh>
-#include <key_generator.hpp>
+
+#include <nvbench/nvbench.cuh>
+
+#include <thrust/device_vector.h>
 
 /**
  * @brief A benchmark evaluating multi-value query (`count` + `retrieve`) performance:

--- a/benchmarks/hash_table/static_multimap/retrieve_bench.cu
+++ b/benchmarks/hash_table/static_multimap/retrieve_bench.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-#include <cuco/static_multimap.cuh>
 #include <key_generator.hpp>
 
-#include <thrust/device_vector.h>
+#include <cuco/static_multimap.cuh>
 
 #include <nvbench/nvbench.cuh>
 
-#include <random>
+#include <thrust/device_vector.h>
 
 /**
  * @brief A benchmark evaluating multi-value `retrieve` performance:

--- a/benchmarks/synchronization.hpp
+++ b/benchmarks/synchronization.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 
 // Google Benchmark library
 #include <benchmark/benchmark.h>
+
 #include <cuda_runtime_api.h>
 
 #define BENCH_CUDA_TRY(call)                                                         \

--- a/examples/static_map/custom_type_example.cu
+++ b/examples/static_map/custom_type_example.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+#include <cuco/static_map.cuh>
+
 #include <thrust/device_vector.h>
 #include <thrust/logical.h>
 #include <thrust/transform.h>
-
-#include <cuco/static_map.cuh>
 
 // User-defined key type
 #ifdef CUCO_NO_INDEPENDENT_THREADS

--- a/examples/static_map/static_map_example.cu
+++ b/examples/static_map/static_map_example.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-#include <limits>
+#include <cuco/static_map.cuh>
 
 #include <thrust/device_vector.h>
 #include <thrust/sequence.h>
 #include <thrust/transform.h>
 
-#include <cuco/static_map.cuh>
+#include <limits>
 
 int main(void)
 {

--- a/examples/static_multimap/static_multimap_example.cu
+++ b/examples/static_multimap/static_multimap_example.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-#include <limits>
+#include <cuco/static_multimap.cuh>
 
 #include <thrust/device_vector.h>
 #include <thrust/sequence.h>
 #include <thrust/transform.h>
 
-#include <cuco/static_multimap.cuh>
+#include <limits>
 
 int main(void)
 {

--- a/include/cuco/detail/dynamic_map_kernels.cuh
+++ b/include/cuco/detail/dynamic_map_kernels.cuh
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <cub/cub.cuh>
+#include <cub/block/block_reduce.cuh>
 
 #include <cuda/std/atomic>
 

--- a/include/cuco/detail/dynamic_map_kernels.cuh
+++ b/include/cuco/detail/dynamic_map_kernels.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include <cub/cub.cuh>
+
+#include <cuda/std/atomic>
+
+#include <cooperative_groups.h>
 
 namespace cuco {
 namespace detail {

--- a/include/cuco/detail/error.hpp
+++ b/include/cuco/detail/error.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cuda_runtime_api.h>
+
 #include <stdexcept>
 #include <string>
 

--- a/include/cuco/detail/pair.cuh
+++ b/include/cuco/detail/pair.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/cuco/detail/pair.cuh
+++ b/include/cuco/detail/pair.cuh
@@ -20,6 +20,7 @@
 #include <thrust/pair.h>
 #include <thrust/tuple.h>
 
+#include <algorithm>
 #include <tuple>
 #include <type_traits>
 

--- a/include/cuco/detail/pair.cuh
+++ b/include/cuco/detail/pair.cuh
@@ -19,6 +19,7 @@
 #include <thrust/device_reference.h>
 #include <thrust/pair.h>
 #include <thrust/tuple.h>
+
 #include <tuple>
 #include <type_traits>
 

--- a/include/cuco/detail/probe_sequence_impl.cuh
+++ b/include/cuco/detail/probe_sequence_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 #pragma once
 
-#include <cuda/std/atomic>
-
 #include <cuco/detail/hash_functions.cuh>
 #include <cuco/detail/pair.cuh>
+
+#include <cuda/std/atomic>
 
 namespace cuco {
 namespace detail {

--- a/include/cuco/detail/static_map_kernels.cuh
+++ b/include/cuco/detail/static_map_kernels.cuh
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <cub/cub.cuh>
+#include <cub/block/block_reduce.cuh>
 
 #include <cuda/std/atomic>
 

--- a/include/cuco/detail/static_map_kernels.cuh
+++ b/include/cuco/detail/static_map_kernels.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include <cub/cub.cuh>
+
+#include <cuda/std/atomic>
+
+#include <cooperative_groups.h>
 
 namespace cuco {
 namespace detail {

--- a/include/cuco/detail/static_multimap/kernels.cuh
+++ b/include/cuco/detail/static_multimap/kernels.cuh
@@ -18,7 +18,7 @@
 
 #include <thrust/type_traits/is_contiguous_iterator.h>
 
-#include <cub/cub.cuh>
+#include <cub/block/block_reduce.cuh>
 
 #include <cuda/std/atomic>
 

--- a/include/cuco/detail/static_multimap/kernels.cuh
+++ b/include/cuco/detail/static_multimap/kernels.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
-#include <cooperative_groups/memcpy_async.h>
+#include <cuco/detail/pair.cuh>
+
 #include <thrust/type_traits/is_contiguous_iterator.h>
 
-#include <cuco/detail/pair.cuh>
+#include <cub/cub.cuh>
+
+#include <cooperative_groups/memcpy_async.h>
 
 namespace cuco {
 namespace detail {

--- a/include/cuco/detail/static_multimap/kernels.cuh
+++ b/include/cuco/detail/static_multimap/kernels.cuh
@@ -20,6 +20,8 @@
 
 #include <cub/cub.cuh>
 
+#include <cuda/std/atomic>
+
 #include <cooperative_groups/memcpy_async.h>
 
 namespace cuco {

--- a/include/cuco/detail/static_multimap/static_multimap.inl
+++ b/include/cuco/detail/static_multimap/static_multimap.inl
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+#include <cuco/detail/utils.hpp>
+
 #include <thrust/count.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/tuple.h>
-
-#include <cuco/detail/utils.hpp>
 
 namespace {
 /**

--- a/include/cuco/detail/static_multimap/static_multimap.inl
+++ b/include/cuco/detail/static_multimap/static_multimap.inl
@@ -20,6 +20,8 @@
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/tuple.h>
 
+#include <iterator>
+
 namespace {
 /**
  * @brief Device functor used to determine if a slot is filled.

--- a/include/cuco/dynamic_map.cuh
+++ b/include/cuco/dynamic_map.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,16 @@
 
 #pragma once
 
-#include <cooperative_groups.h>
-#include <cub/cub.cuh>
 #include <cuco/detail/dynamic_map_kernels.cuh>
 #include <cuco/detail/error.hpp>
 #include <cuco/static_map.cuh>
-#include <cuda/std/atomic>
+
 #include <thrust/device_vector.h>
+#include <thrust/functional.h>
+
+#include <cuda/std/atomic>
+
+#include <memory>
 
 namespace cuco {
 

--- a/include/cuco/dynamic_map.cuh
+++ b/include/cuco/dynamic_map.cuh
@@ -25,7 +25,10 @@
 
 #include <cuda/std/atomic>
 
+#include <cstddef>
 #include <memory>
+#include <type_traits>
+#include <vector>
 
 namespace cuco {
 

--- a/include/cuco/sentinel.hpp
+++ b/include/cuco/sentinel.hpp
@@ -21,19 +21,19 @@ namespace sentinel {
 
 template <typename T>
 struct empty_key {
-  __host__ __device__ empty_key(T v) : value{v} {}
+  constexpr empty_key(T v) : value{v} {}
   T value;
 };
 
 template <typename T>
 struct empty_value {
-  __host__ __device__ empty_value(T v) : value{v} {}
+  constexpr empty_value(T v) : value{v} {}
   T value;
 };
 
 template <typename T>
 struct erased_key {
-  __host__ __device__ erased_key(T v) : value{v} {}
+  constexpr erased_key(T v) : value{v} {}
   T value;
 };
 

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,16 @@
 
 #pragma once
 
-#include <cooperative_groups.h>
-#include <cub/cub.cuh>
-#include <cuda/std/atomic>
-#include <memory>
-#include <thrust/distance.h>
-#include <thrust/functional.h>
-
 #include <cuco/allocator.hpp>
+#include <cuco/detail/error.hpp>
+#include <cuco/detail/hash_functions.cuh>
+#include <cuco/detail/pair.cuh>
+#include <cuco/detail/static_map_kernels.cuh>
 #include <cuco/traits.hpp>
 
+#include <thrust/functional.h>
+
+#include <cuda/std/atomic>
 #if defined(CUDART_VERSION) && (CUDART_VERSION >= 11000) && defined(__CUDA_ARCH__) && \
   (__CUDA_ARCH__ >= 700)
 #define CUCO_HAS_CUDA_BARRIER
@@ -35,10 +35,7 @@
 #include <cuda/barrier>
 #endif
 
-#include <cuco/detail/error.hpp>
-#include <cuco/detail/hash_functions.cuh>
-#include <cuco/detail/pair.cuh>
-#include <cuco/detail/static_map_kernels.cuh>
+#include <memory>
 
 namespace cuco {
 

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -42,7 +42,10 @@
 
 #include <cooperative_groups.h>
 
+#include <cstddef>
 #include <memory>
+#include <type_traits>
+#include <utility>
 
 namespace cuco {
 

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,16 @@
 
 #pragma once
 
-#include <cooperative_groups.h>
-#include <cub/cub.cuh>
-#include <memory>
-#include <thrust/distance.h>
-#include <thrust/functional.h>
-
 #include <cuco/allocator.hpp>
+#include <cuco/detail/error.hpp>
+#include <cuco/detail/prime.hpp>
+#include <cuco/detail/static_multimap/kernels.cuh>
 #include <cuco/probe_sequences.cuh>
 #include <cuco/traits.hpp>
 
+#include <thrust/functional.h>
+
+#include <cuda/std/atomic>
 #if defined(CUDART_VERSION) && (CUDART_VERSION >= 11000) && defined(__CUDA_ARCH__) && \
   (__CUDA_ARCH__ >= 700)
 #define CUCO_HAS_CUDA_BARRIER
@@ -40,9 +40,9 @@
 #include <cuda/barrier>
 #endif
 
-#include <cuco/detail/error.hpp>
-#include <cuco/detail/prime.hpp>
-#include <cuco/detail/static_multimap/kernels.cuh>
+#include <cooperative_groups.h>
+
+#include <memory>
 
 namespace cuco {
 

--- a/tests/dynamic_map/unique_sequence_test.cu
+++ b/tests/dynamic_map/unique_sequence_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-#include <catch2/catch.hpp>
-#include <thrust/device_vector.h>
+#include <utils.hpp>
 
 #include <cuco/dynamic_map.cuh>
 
-#include <utils.hpp>
+#include <thrust/device_vector.h>
+
+#include <catch2/catch.hpp>
 
 TEMPLATE_TEST_CASE_SIG("Unique sequence of keys",
                        "",

--- a/tests/static_map/custom_type_test.cu
+++ b/tests/static_map/custom_type_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,15 @@
  * limitations under the License.
  */
 
-#include <catch2/catch.hpp>
-#include <thrust/device_vector.h>
+#include <utils.hpp>
 
 #include <cuco/static_map.cuh>
 
-#include <utils.hpp>
+#include <thrust/device_vector.h>
+
+#include <catch2/catch.hpp>
+
+#include <tuple>
 
 // User-defined key type
 template <typename T>

--- a/tests/static_map/key_sentinel_test.cu
+++ b/tests/static_map/key_sentinel_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-#include <catch2/catch.hpp>
-#include <thrust/device_vector.h>
+#include <utils.hpp>
 
 #include <cuco/static_map.cuh>
 
-#include <utils.hpp>
+#include <thrust/device_vector.h>
+
+#include <catch2/catch.hpp>
 
 #define SIZE 10
 __device__ int A[SIZE];

--- a/tests/static_map/shared_memory_test.cu
+++ b/tests/static_map/shared_memory_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-#include <limits>
-
-#include <catch2/catch.hpp>
-#include <thrust/device_vector.h>
+#include <utils.hpp>
 
 #include <cuco/static_map.cuh>
 
-#include <utils.hpp>
+#include <thrust/device_vector.h>
+
+#include <catch2/catch.hpp>
+
+#include <limits>
 
 template <typename MapType, int CAPACITY>
 __global__ void shared_memory_test_kernel(

--- a/tests/static_map/stream_test.cu
+++ b/tests/static_map/stream_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-#include <catch2/catch.hpp>
-#include <thrust/device_vector.h>
+#include <utils.hpp>
 
 #include <cuco/static_map.cuh>
 
-#include <utils.hpp>
+#include <thrust/device_vector.h>
+
+#include <catch2/catch.hpp>
 
 TEMPLATE_TEST_CASE_SIG("Unique sequence of keys on given stream",
                        "",

--- a/tests/static_map/unique_sequence_test.cu
+++ b/tests/static_map/unique_sequence_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-#include <catch2/catch.hpp>
-#include <thrust/device_vector.h>
+#include <utils.hpp>
 
 #include <cuco/static_map.cuh>
 
-#include <utils.hpp>
+#include <thrust/device_vector.h>
+
+#include <catch2/catch.hpp>
 
 TEMPLATE_TEST_CASE_SIG("Unique sequence of keys",
                        "",

--- a/tests/static_multimap/custom_pair_retrieve_test.cu
+++ b/tests/static_multimap/custom_pair_retrieve_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,17 @@
  * limitations under the License.
  */
 
-#include <catch2/catch.hpp>
-#include <thrust/device_vector.h>
-#include <thrust/iterator/discard_iterator.h>
+#include <utils.hpp>
 
 #include <cuco/static_multimap.cuh>
 
-#include <utils.hpp>
+#include <thrust/device_vector.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/discard_iterator.h>
+
+#include <catch2/catch.hpp>
+
+#include <cooperative_groups.h>
 
 // Custom pair equal
 template <typename Key, typename Value>

--- a/tests/static_multimap/custom_type_test.cu
+++ b/tests/static_multimap/custom_type_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-#include <catch2/catch.hpp>
-#include <thrust/device_vector.h>
+#include <utils.hpp>
 
 #include <cuco/static_multimap.cuh>
 
-#include <utils.hpp>
+#include <thrust/device_vector.h>
+#include <thrust/iterator/counting_iterator.h>
+
+#include <catch2/catch.hpp>
+
+#include <tuple>
 
 // User-defined key type
 struct key_pair {

--- a/tests/static_multimap/insert_if_test.cu
+++ b/tests/static_multimap/insert_if_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-#include <catch2/catch.hpp>
-#include <thrust/device_vector.h>
+#include <utils.hpp>
 
 #include <cuco/static_multimap.cuh>
 
-#include <utils.hpp>
+#include <thrust/device_vector.h>
+
+#include <catch2/catch.hpp>
 
 template <typename Key, typename Map, typename PairIt, typename KeyIt>
 __inline__ void test_insert_if(Map& map, PairIt pair_begin, KeyIt key_begin, std::size_t size)

--- a/tests/static_multimap/multiplicity_test.cu
+++ b/tests/static_multimap/multiplicity_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-#include <catch2/catch.hpp>
-#include <thrust/device_vector.h>
+#include <utils.hpp>
 
 #include <cuco/static_multimap.cuh>
 
-#include <utils.hpp>
+#include <thrust/device_vector.h>
+
+#include <catch2/catch.hpp>
 
 template <typename Map>
 __inline__ void test_multiplicity_two(Map& map, std::size_t num_items)

--- a/tests/static_multimap/non_match_test.cu
+++ b/tests/static_multimap/non_match_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-#include <catch2/catch.hpp>
-#include <thrust/device_vector.h>
+#include <utils.hpp>
 
 #include <cuco/static_multimap.cuh>
 
-#include <utils.hpp>
+#include <thrust/device_vector.h>
+
+#include <catch2/catch.hpp>
 
 template <typename Key, typename Value, typename Map, typename PairIt, typename KeyIt>
 __inline__ void test_non_matches(Map& map, PairIt pair_begin, KeyIt key_begin, std::size_t num_keys)

--- a/tests/static_multimap/pair_function_test.cu
+++ b/tests/static_multimap/pair_function_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-#include <catch2/catch.hpp>
-#include <thrust/device_vector.h>
-#include <thrust/iterator/discard_iterator.h>
+#include <utils.hpp>
 
 #include <cuco/static_multimap.cuh>
 
-#include <utils.hpp>
+#include <thrust/device_vector.h>
+#include <thrust/iterator/discard_iterator.h>
+
+#include <catch2/catch.hpp>
 
 // Custom pair equal
 template <typename Key, typename Value>

--- a/tests/utils.hpp
+++ b/tests/utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/utils.hpp
+++ b/tests/utils.hpp
@@ -16,9 +16,11 @@
 
 #pragma once
 
+#include <utils.cuh>
+
 #include <thrust/functional.h>
 
-#include <utils.cuh>
+#include <cooperative_groups.h>
 
 namespace cuco {
 namespace test {


### PR DESCRIPTION
Closes #140 

This PR reorders header groups in `cuco` and add missing headers to make sure all headers are self-contained. 

To be merged after #155 and #156.