### PR TITLE
Erase Functionality for static_map

### DIFF
--- a/benchmarks/hash_table/static_map_bench.cu
+++ b/benchmarks/hash_table/static_map_bench.cu
@@ -90,8 +90,7 @@ static void BM_static_map_insert(::benchmark::State& state)
   thrust::device_vector<Key> d_keys(h_keys);
 
   for (auto _ : state) {
-    map_type map{size, cuco::sentinel::empty_key<Key>{-1}, 
-                       cuco::sentinel::empty_value<Value>{-1}};
+    map_type map{size, cuco::sentinel::empty_key<Key>{-1}, cuco::sentinel::empty_value<Value>{-1}};
 
     cudaEvent_t start, stop;
     cudaEventCreate(&start);
@@ -121,8 +120,7 @@ static void BM_static_map_search_all(::benchmark::State& state)
   float occupancy      = state.range(1) / float{100};
   std::size_t size     = num_keys / occupancy;
 
-  map_type map{size, cuco::sentinel::empty_key<Key>{-1}, 
-                     cuco::sentinel::empty_value<Value>{-1}};
+  map_type map{size, cuco::sentinel::empty_key<Key>{-1}, cuco::sentinel::empty_value<Value>{-1}};
   auto view = map.get_device_mutable_view();
 
   std::vector<Key> h_keys(num_keys);
@@ -163,9 +161,10 @@ static void BM_static_map_erase_all(::benchmark::State& state)
   std::size_t size     = num_keys / occupancy;
 
   // static map with erase support
-  map_type map{size, cuco::sentinel::empty_key<Key>{-1}, 
-                     cuco::sentinel::empty_value<Value>{-1},
-                     cuco::sentinel::erased_key<Key>{-2}};
+  map_type map{size,
+               cuco::sentinel::empty_key<Key>{-1},
+               cuco::sentinel::empty_value<Value>{-1},
+               cuco::sentinel::erased_key<Key>{-2}};
   auto view = map.get_device_mutable_view();
 
   std::vector<Key> h_keys(num_keys);

--- a/benchmarks/hash_table/static_map_bench.cu
+++ b/benchmarks/hash_table/static_map_bench.cu
@@ -91,12 +91,7 @@ static void BM_static_map_insert(::benchmark::State& state)
 
 
   for (auto _ : state) {
-    //state.ResumeTiming();
-    //state.PauseTiming();
     map_type map{size, -1, -1};
-  //map.insert(d_pairs.begin(), d_pairs.end());
-    //map.erase(d_keys.begin(), d_keys.end());
-    //state.ResumeTiming();
 
     cudaEvent_t start, stop;
     cudaEventCreate(&start);
@@ -109,8 +104,6 @@ static void BM_static_map_insert(::benchmark::State& state)
 
     float ms;
     cudaEventElapsedTime(&ms, start, stop);
-
-    //state.PauseTiming();
 
     state.SetIterationTime(ms / 1000);
   }
@@ -168,7 +161,8 @@ static void BM_static_map_erase_all(::benchmark::State& state)
   float occupancy      = state.range(1) / float{100};
   std::size_t size     = num_keys / occupancy;
 
-  map_type map{size, -1, -1};
+  // static map with erase support
+  map_type map{size, -1, -1, -2};
   auto view = map.get_device_mutable_view();
 
   std::vector<Key> h_keys(num_keys);
@@ -190,14 +184,11 @@ static void BM_static_map_erase_all(::benchmark::State& state)
   thrust::device_vector<cuco::pair_type<Key, Value>> d_pairs(h_pairs);
 
   for (auto _ : state) {
-    //state.ResumeTiming();
     state.PauseTiming();
     map.insert(d_pairs.begin(), d_pairs.end());
     state.ResumeTiming();
 
     map.erase(d_keys.begin(), d_keys.end());
-    
-    //state.PauseTiming();
   }
 
   state.SetBytesProcessed((sizeof(Key) + sizeof(Value)) * int64_t(state.iterations()) *
@@ -208,26 +199,12 @@ BENCHMARK_TEMPLATE(BM_static_map_insert, int32_t, int32_t, dist_type::UNIQUE)
   ->Unit(benchmark::kMillisecond)
   ->Apply(generate_size_and_occupancy)
   ->UseManualTime();
-/*
-BENCHMARK_TEMPLATE(BM_static_map_search_all, int32_t, int32_t, dist_type::UNIQUE)
-  ->Unit(benchmark::kMillisecond)
-  ->Apply(generate_size_and_occupancy);
+
 BENCHMARK_TEMPLATE(BM_static_map_erase_all, int32_t, int32_t, dist_type::UNIQUE)
   ->Unit(benchmark::kMillisecond)
   ->Apply(generate_size_and_occupancy);
-*/
-BENCHMARK_TEMPLATE(BM_static_map_insert, int64_t, int64_t, dist_type::UNIQUE)
+
+BENCHMARK_TEMPLATE(BM_static_map_insert, int32_t, int32_t, dist_type::UNIQUE)
   ->Unit(benchmark::kMillisecond)
   ->Apply(generate_size_and_occupancy)
   ->UseManualTime();
-
-/*
-BENCHMARK_TEMPLATE(BM_static_map_search_all, int64_t, int64_t, dist_type::UNIQUE)
-  ->Unit(benchmark::kMillisecond)
-  ->Apply(generate_size_and_occupancy);
-*/
-/*
-BENCHMARK_TEMPLATE(BM_static_map_erase_all, int64_t, int64_t, dist_type::UNIQUE)
-  ->Unit(benchmark::kMillisecond)
-  ->Apply(generate_size_and_occupancy);
-*/

--- a/benchmarks/hash_table/static_map_bench.cu
+++ b/benchmarks/hash_table/static_map_bench.cu
@@ -194,15 +194,17 @@ BENCHMARK_TEMPLATE(BM_static_map_insert, int32_t, int32_t, dist_type::UNIQUE)
   ->Unit(benchmark::kMillisecond)
   ->Apply(generate_size_and_occupancy);
 */
+/*
 BENCHMARK_TEMPLATE(BM_static_map_search_all, int32_t, int32_t, dist_type::UNIQUE)
   ->Unit(benchmark::kMillisecond)
   ->Apply(generate_size_and_occupancy);
   //->Iterations(1000);
-/*
+*/
+
 BENCHMARK_TEMPLATE(BM_static_map_erase_all, int32_t, int32_t, dist_type::UNIQUE)
   ->Unit(benchmark::kMillisecond)
   ->Apply(generate_size_and_occupancy);
-
+/*
 BENCHMARK_TEMPLATE(BM_static_map_insert, int64_t, int64_t, dist_type::UNIQUE)
   ->Unit(benchmark::kMillisecond)
   ->Apply(generate_size_and_occupancy);

--- a/benchmarks/hash_table/static_map_bench.cu
+++ b/benchmarks/hash_table/static_map_bench.cu
@@ -91,16 +91,28 @@ static void BM_static_map_insert(::benchmark::State& state)
 
 
   for (auto _ : state) {
-    state.ResumeTiming();
-    state.PauseTiming();
+    //state.ResumeTiming();
+    //state.PauseTiming();
     map_type map{size, -1, -1};
-    map.insert(d_pairs.begin(), d_pairs.end());
-    map.erase(d_keys.begin(), d_keys.end());
-    state.ResumeTiming();
-    
-    map.insert(d_pairs.begin(), d_pairs.end());
+  //map.insert(d_pairs.begin(), d_pairs.end());
+    //map.erase(d_keys.begin(), d_keys.end());
+    //state.ResumeTiming();
 
-    state.PauseTiming();
+    cudaEvent_t start, stop;
+    cudaEventCreate(&start);
+    cudaEventCreate(&stop);
+
+    cudaEventRecord(start);
+    map.insert(d_pairs.begin(), d_pairs.end());
+    cudaEventRecord(stop);
+    cudaEventSynchronize(stop);
+
+    float ms;
+    cudaEventElapsedTime(&ms, start, stop);
+
+    //state.PauseTiming();
+
+    state.SetIterationTime(ms / 1000);
   }
 
   state.SetBytesProcessed((sizeof(Key) + sizeof(Value)) * int64_t(state.iterations()) *
@@ -194,7 +206,8 @@ static void BM_static_map_erase_all(::benchmark::State& state)
 
 BENCHMARK_TEMPLATE(BM_static_map_insert, int32_t, int32_t, dist_type::UNIQUE)
   ->Unit(benchmark::kMillisecond)
-  ->Apply(generate_size_and_occupancy);
+  ->Apply(generate_size_and_occupancy)
+  ->UseManualTime();
 /*
 BENCHMARK_TEMPLATE(BM_static_map_search_all, int32_t, int32_t, dist_type::UNIQUE)
   ->Unit(benchmark::kMillisecond)
@@ -205,7 +218,8 @@ BENCHMARK_TEMPLATE(BM_static_map_erase_all, int32_t, int32_t, dist_type::UNIQUE)
 */
 BENCHMARK_TEMPLATE(BM_static_map_insert, int64_t, int64_t, dist_type::UNIQUE)
   ->Unit(benchmark::kMillisecond)
-  ->Apply(generate_size_and_occupancy);
+  ->Apply(generate_size_and_occupancy)
+  ->UseManualTime();
 
 /*
 BENCHMARK_TEMPLATE(BM_static_map_search_all, int64_t, int64_t, dist_type::UNIQUE)

--- a/benchmarks/hash_table/static_map_bench.cu
+++ b/benchmarks/hash_table/static_map_bench.cu
@@ -88,6 +88,7 @@ static void BM_static_map_insert(::benchmark::State& state)
 
   thrust::device_vector<cuco::pair_type<Key, Value>> d_pairs(h_pairs);
 
+
   for (auto _ : state) {
     state.ResumeTiming();
     state.PauseTiming();
@@ -143,27 +144,62 @@ static void BM_static_map_search_all(::benchmark::State& state)
                           int64_t(state.range(0)));
 }
 
+template <typename Key, typename Value, dist_type Dist>
+static void BM_static_map_erase_all(::benchmark::State& state)
+{
+  using map_type = cuco::static_map<Key, Value>;
+
+  std::size_t num_keys = state.range(0);
+  float occupancy      = state.range(1) / float{100};
+  std::size_t size     = num_keys / occupancy;
+
+  map_type map{size, -1, -1};
+  auto view = map.get_device_mutable_view();
+
+  std::vector<Key> h_keys(num_keys);
+  std::vector<Value> h_values(num_keys);
+  std::vector<cuco::pair_type<Key, Value>> h_pairs(num_keys);
+  std::vector<Value> h_results(num_keys);
+
+  generate_keys<Dist, Key>(h_keys.begin(), h_keys.end());
+
+  for (auto i = 0; i < num_keys; ++i) {
+    Key key           = h_keys[i];
+    Value val         = h_keys[i];
+    h_pairs[i].first  = key;
+    h_pairs[i].second = val;
+  }
+
+  thrust::device_vector<Key> d_keys(h_keys);
+  thrust::device_vector<bool> d_results(num_keys);
+  thrust::device_vector<cuco::pair_type<Key, Value>> d_pairs(h_pairs);
+
+  for (auto _ : state) {
+    //state.ResumeTiming();
+    state.PauseTiming();
+    map.insert(d_pairs.begin(), d_pairs.end());
+    state.ResumeTiming();
+
+    map.erase(d_keys.begin(), d_keys.end());
+    
+    //state.PauseTiming();
+  }
+
+  state.SetBytesProcessed((sizeof(Key) + sizeof(Value)) * int64_t(state.iterations()) *
+                          int64_t(state.range(0)));
+}
+
+/*
 BENCHMARK_TEMPLATE(BM_static_map_insert, int32_t, int32_t, dist_type::UNIQUE)
   ->Unit(benchmark::kMillisecond)
   ->Apply(generate_size_and_occupancy);
-
+*/
 BENCHMARK_TEMPLATE(BM_static_map_search_all, int32_t, int32_t, dist_type::UNIQUE)
   ->Unit(benchmark::kMillisecond)
   ->Apply(generate_size_and_occupancy);
-
-BENCHMARK_TEMPLATE(BM_static_map_insert, int32_t, int32_t, dist_type::UNIFORM)
-  ->Unit(benchmark::kMillisecond)
-  ->Apply(generate_size_and_occupancy);
-
-BENCHMARK_TEMPLATE(BM_static_map_search_all, int32_t, int32_t, dist_type::UNIFORM)
-  ->Unit(benchmark::kMillisecond)
-  ->Apply(generate_size_and_occupancy);
-
-BENCHMARK_TEMPLATE(BM_static_map_insert, int32_t, int32_t, dist_type::GAUSSIAN)
-  ->Unit(benchmark::kMillisecond)
-  ->Apply(generate_size_and_occupancy);
-
-BENCHMARK_TEMPLATE(BM_static_map_search_all, int32_t, int32_t, dist_type::GAUSSIAN)
+  //->Iterations(1000);
+/*
+BENCHMARK_TEMPLATE(BM_static_map_erase_all, int32_t, int32_t, dist_type::UNIQUE)
   ->Unit(benchmark::kMillisecond)
   ->Apply(generate_size_and_occupancy);
 
@@ -174,19 +210,7 @@ BENCHMARK_TEMPLATE(BM_static_map_insert, int64_t, int64_t, dist_type::UNIQUE)
 BENCHMARK_TEMPLATE(BM_static_map_search_all, int64_t, int64_t, dist_type::UNIQUE)
   ->Unit(benchmark::kMillisecond)
   ->Apply(generate_size_and_occupancy);
-
-BENCHMARK_TEMPLATE(BM_static_map_insert, int64_t, int64_t, dist_type::UNIFORM)
-  ->Unit(benchmark::kMillisecond)
-  ->Apply(generate_size_and_occupancy);
-
-BENCHMARK_TEMPLATE(BM_static_map_search_all, int64_t, int64_t, dist_type::UNIFORM)
-  ->Unit(benchmark::kMillisecond)
-  ->Apply(generate_size_and_occupancy);
-
-BENCHMARK_TEMPLATE(BM_static_map_insert, int64_t, int64_t, dist_type::GAUSSIAN)
-  ->Unit(benchmark::kMillisecond)
-  ->Apply(generate_size_and_occupancy);
-
-BENCHMARK_TEMPLATE(BM_static_map_search_all, int64_t, int64_t, dist_type::GAUSSIAN)
+*/
+BENCHMARK_TEMPLATE(BM_static_map_erase_all, int64_t, int64_t, dist_type::UNIQUE)
   ->Unit(benchmark::kMillisecond)
   ->Apply(generate_size_and_occupancy);

--- a/benchmarks/hash_table/static_map_bench.cu
+++ b/benchmarks/hash_table/static_map_bench.cu
@@ -87,14 +87,17 @@ static void BM_static_map_insert(::benchmark::State& state)
   }
 
   thrust::device_vector<cuco::pair_type<Key, Value>> d_pairs(h_pairs);
+  thrust::device_vector<Key> d_keys(h_keys);
 
 
   for (auto _ : state) {
     state.ResumeTiming();
     state.PauseTiming();
     map_type map{size, -1, -1};
+    map.insert(d_pairs.begin(), d_pairs.end());
+    map.erase(d_keys.begin(), d_keys.end());
     state.ResumeTiming();
-
+    
     map.insert(d_pairs.begin(), d_pairs.end());
 
     state.PauseTiming();
@@ -189,30 +192,28 @@ static void BM_static_map_erase_all(::benchmark::State& state)
                           int64_t(state.range(0)));
 }
 
-/*
 BENCHMARK_TEMPLATE(BM_static_map_insert, int32_t, int32_t, dist_type::UNIQUE)
   ->Unit(benchmark::kMillisecond)
   ->Apply(generate_size_and_occupancy);
-*/
 /*
 BENCHMARK_TEMPLATE(BM_static_map_search_all, int32_t, int32_t, dist_type::UNIQUE)
   ->Unit(benchmark::kMillisecond)
   ->Apply(generate_size_and_occupancy);
-  //->Iterations(1000);
-*/
-
 BENCHMARK_TEMPLATE(BM_static_map_erase_all, int32_t, int32_t, dist_type::UNIQUE)
   ->Unit(benchmark::kMillisecond)
   ->Apply(generate_size_and_occupancy);
-/*
+*/
 BENCHMARK_TEMPLATE(BM_static_map_insert, int64_t, int64_t, dist_type::UNIQUE)
   ->Unit(benchmark::kMillisecond)
   ->Apply(generate_size_and_occupancy);
 
+/*
 BENCHMARK_TEMPLATE(BM_static_map_search_all, int64_t, int64_t, dist_type::UNIQUE)
   ->Unit(benchmark::kMillisecond)
   ->Apply(generate_size_and_occupancy);
 */
+/*
 BENCHMARK_TEMPLATE(BM_static_map_erase_all, int64_t, int64_t, dist_type::UNIQUE)
   ->Unit(benchmark::kMillisecond)
   ->Apply(generate_size_and_occupancy);
+*/

--- a/benchmarks/hash_table/static_map_bench.cu
+++ b/benchmarks/hash_table/static_map_bench.cu
@@ -89,7 +89,6 @@ static void BM_static_map_insert(::benchmark::State& state)
   thrust::device_vector<cuco::pair_type<Key, Value>> d_pairs(h_pairs);
   thrust::device_vector<Key> d_keys(h_keys);
 
-
   for (auto _ : state) {
     map_type map{size, -1, -1};
 

--- a/benchmarks/hash_table/static_map_bench.cu
+++ b/benchmarks/hash_table/static_map_bench.cu
@@ -90,7 +90,8 @@ static void BM_static_map_insert(::benchmark::State& state)
   thrust::device_vector<Key> d_keys(h_keys);
 
   for (auto _ : state) {
-    map_type map{size, -1, -1};
+    map_type map{size, cuco::sentinel::empty_key<Key>{-1}, 
+                       cuco::sentinel::empty_value<Value>{-1}};
 
     cudaEvent_t start, stop;
     cudaEventCreate(&start);
@@ -120,7 +121,8 @@ static void BM_static_map_search_all(::benchmark::State& state)
   float occupancy      = state.range(1) / float{100};
   std::size_t size     = num_keys / occupancy;
 
-  map_type map{size, -1, -1};
+  map_type map{size, cuco::sentinel::empty_key<Key>{-1}, 
+                     cuco::sentinel::empty_value<Value>{-1}};
   auto view = map.get_device_mutable_view();
 
   std::vector<Key> h_keys(num_keys);
@@ -161,7 +163,9 @@ static void BM_static_map_erase_all(::benchmark::State& state)
   std::size_t size     = num_keys / occupancy;
 
   // static map with erase support
-  map_type map{size, -1, -1, -2};
+  map_type map{size, cuco::sentinel::empty_key<Key>{-1}, 
+                     cuco::sentinel::empty_value<Value>{-1},
+                     cuco::sentinel::erased_key<Key>{-2}};
   auto view = map.get_device_mutable_view();
 
   std::vector<Key> h_keys(num_keys);

--- a/examples/static_map/custom_type_example.cu
+++ b/examples/static_map/custom_type_example.cu
@@ -91,8 +91,9 @@ int main(void)
   // Construct a map with 100,000 slots using the given empty key/value sentinels. Note the
   // capacity is chosen knowing we will insert 80,000 keys, for an load factor of 80%.
   cuco::static_map<custom_key_type, custom_value_type> map{
-    100'000, cuco::sentinel::empty_key<custom_key_type>{empty_key_sentinel}, 
-             cuco::sentinel::empty_value<custom_value_type>{empty_value_sentinel}};
+    100'000,
+    cuco::sentinel::empty_key<custom_key_type>{empty_key_sentinel},
+    cuco::sentinel::empty_value<custom_value_type>{empty_value_sentinel}};
 
   // Inserts 80,000 pairs into the map by using the custom hasher and custom equality callable
   map.insert(pairs_begin, pairs_begin + num_pairs, custom_hash{}, custom_key_equals{});

--- a/examples/static_map/custom_type_example.cu
+++ b/examples/static_map/custom_type_example.cu
@@ -91,7 +91,8 @@ int main(void)
   // Construct a map with 100,000 slots using the given empty key/value sentinels. Note the
   // capacity is chosen knowing we will insert 80,000 keys, for an load factor of 80%.
   cuco::static_map<custom_key_type, custom_value_type> map{
-    100'000, empty_key_sentinel, empty_value_sentinel};
+    100'000, cuco::sentinel::empty_key<custom_key_type>{empty_key_sentinel}, 
+             cuco::sentinel::empty_value<custom_value_type>{empty_value_sentinel}};
 
   // Inserts 80,000 pairs into the map by using the custom hasher and custom equality callable
   map.insert(pairs_begin, pairs_begin + num_pairs, custom_hash{}, custom_key_equals{});

--- a/examples/static_map/custom_type_example.cu
+++ b/examples/static_map/custom_type_example.cu
@@ -92,8 +92,8 @@ int main(void)
   // capacity is chosen knowing we will insert 80,000 keys, for an load factor of 80%.
   cuco::static_map<custom_key_type, custom_value_type> map{
     100'000,
-    cuco::sentinel::empty_key<custom_key_type>{empty_key_sentinel},
-    cuco::sentinel::empty_value<custom_value_type>{empty_value_sentinel}};
+    cuco::sentinel::empty_key{empty_key_sentinel},
+    cuco::sentinel::empty_value{empty_value_sentinel}};
 
   // Inserts 80,000 pairs into the map by using the custom hasher and custom equality callable
   map.insert(pairs_begin, pairs_begin + num_pairs, custom_hash{}, custom_key_equals{});

--- a/examples/static_map/static_map_example.cu
+++ b/examples/static_map/static_map_example.cu
@@ -33,7 +33,8 @@ int main(void)
   cudaStream_t str;
   cudaStreamCreate(&str);
   cuco::static_map<int, int> map{
-    100'000, empty_key_sentinel, empty_value_sentinel, cuco::cuda_allocator<char>{}, str};
+    100'000, cuco::sentinel::empty_key<int>{empty_key_sentinel}, 
+             cuco::sentinel::empty_value<int>{empty_value_sentinel}, cuco::cuda_allocator<char>{}, str};
 
   thrust::device_vector<thrust::pair<int, int>> pairs(50'000);
 

--- a/examples/static_map/static_map_example.cu
+++ b/examples/static_map/static_map_example.cu
@@ -33,8 +33,8 @@ int main(void)
   cudaStream_t str;
   cudaStreamCreate(&str);
   cuco::static_map<int, int> map{100'000,
-                                 cuco::sentinel::empty_key<int>{empty_key_sentinel},
-                                 cuco::sentinel::empty_value<int>{empty_value_sentinel},
+                                 cuco::sentinel::empty_key{empty_key_sentinel},
+                                 cuco::sentinel::empty_value{empty_value_sentinel},
                                  cuco::cuda_allocator<char>{},
                                  str};
 

--- a/examples/static_map/static_map_example.cu
+++ b/examples/static_map/static_map_example.cu
@@ -32,9 +32,11 @@ int main(void)
   // for an load factor of 50%.
   cudaStream_t str;
   cudaStreamCreate(&str);
-  cuco::static_map<int, int> map{
-    100'000, cuco::sentinel::empty_key<int>{empty_key_sentinel}, 
-             cuco::sentinel::empty_value<int>{empty_value_sentinel}, cuco::cuda_allocator<char>{}, str};
+  cuco::static_map<int, int> map{100'000,
+                                 cuco::sentinel::empty_key<int>{empty_key_sentinel},
+                                 cuco::sentinel::empty_value<int>{empty_value_sentinel},
+                                 cuco::cuda_allocator<char>{},
+                                 str};
 
   thrust::device_vector<thrust::pair<int, int>> pairs(50'000);
 

--- a/include/cuco/detail/dynamic_map.inl
+++ b/include/cuco/detail/dynamic_map.inl
@@ -30,9 +30,10 @@ dynamic_map<Key, Value, Scope, Allocator>::dynamic_map(std::size_t initial_capac
     alloc_{alloc}
 {
   submaps_.push_back(std::make_unique<static_map<Key, Value, Scope, Allocator>>(
-    initial_capacity, 
-    sentinel::empty_key<Key>{empty_key_sentinel}, 
-    sentinel::empty_value<Value>{empty_value_sentinel}, alloc));
+    initial_capacity,
+    sentinel::empty_key<Key>{empty_key_sentinel},
+    sentinel::empty_value<Value>{empty_value_sentinel},
+    alloc));
   submap_views_.push_back(submaps_[0]->get_device_view());
   submap_mutable_views_.push_back(submaps_[0]->get_device_mutable_view());
 
@@ -61,9 +62,10 @@ void dynamic_map<Key, Value, Scope, Allocator>::reserve(std::size_t n)
     else {
       submap_capacity = capacity_;
       submaps_.push_back(std::make_unique<static_map<Key, Value, Scope, Allocator>>(
-        submap_capacity, 
-        sentinel::empty_key<Key>{empty_key_sentinel_}, 
-        sentinel::empty_value<Value>{empty_value_sentinel_}, alloc_));
+        submap_capacity,
+        sentinel::empty_key<Key>{empty_key_sentinel_},
+        sentinel::empty_value<Value>{empty_value_sentinel_},
+        alloc_));
       submap_views_.push_back(submaps_[submap_idx]->get_device_view());
       submap_mutable_views_.push_back(submaps_[submap_idx]->get_device_mutable_view());
 

--- a/include/cuco/detail/dynamic_map.inl
+++ b/include/cuco/detail/dynamic_map.inl
@@ -30,7 +30,9 @@ dynamic_map<Key, Value, Scope, Allocator>::dynamic_map(std::size_t initial_capac
     alloc_{alloc}
 {
   submaps_.push_back(std::make_unique<static_map<Key, Value, Scope, Allocator>>(
-    initial_capacity, empty_key_sentinel, empty_value_sentinel, alloc));
+    initial_capacity, 
+    sentinel::empty_key<Key>{empty_key_sentinel}, 
+    sentinel::empty_value<Value>{empty_value_sentinel}, alloc));
   submap_views_.push_back(submaps_[0]->get_device_view());
   submap_mutable_views_.push_back(submaps_[0]->get_device_mutable_view());
 
@@ -59,7 +61,9 @@ void dynamic_map<Key, Value, Scope, Allocator>::reserve(std::size_t n)
     else {
       submap_capacity = capacity_;
       submaps_.push_back(std::make_unique<static_map<Key, Value, Scope, Allocator>>(
-        submap_capacity, empty_key_sentinel_, empty_value_sentinel_, alloc_));
+        submap_capacity, 
+        sentinel::empty_key<Key>{empty_key_sentinel_}, 
+        sentinel::empty_value<Value>{empty_value_sentinel_}, alloc_));
       submap_views_.push_back(submaps_[submap_idx]->get_device_view());
       submap_mutable_views_.push_back(submaps_[submap_idx]->get_device_mutable_view());
 

--- a/include/cuco/detail/error.hpp
+++ b/include/cuco/detail/error.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/cuco/detail/error.hpp
+++ b/include/cuco/detail/error.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,3 +80,23 @@ struct cuda_error : public std::runtime_error {
     cudaError_t const status = (expr); \
     assert(cudaSuccess == status);     \
   } while (0)
+
+/**
+ * @brief Macro for checking runtime conditions that throws an exception when
+ * a condition is violated.
+ *
+ * Example usage:
+ *
+ * @code
+ * CUCO_RUNTIME_EXPECTS(key == value, "Key value mismatch");
+ * @endcode
+ *
+ * @param[in] cond Expression that evaluates to true or false
+ * @param[in] reason String literal description of the reason that cond is
+ * expected to be true
+ * @throw std::runtime_error if the condition evaluates to false.
+ */
+#define CUCO_RUNTIME_EXPECTS(cond, reason)                           \
+  (!!(cond)) ? static_cast<void>(0)                                  \
+             : throw std::runtime_error("cuco failure at: " __FILE__ \
+                                       ":" CUCO_STRINGIFY(__LINE__) ": " reason)

--- a/include/cuco/detail/error.hpp
+++ b/include/cuco/detail/error.hpp
@@ -99,4 +99,4 @@ struct cuda_error : public std::runtime_error {
 #define CUCO_RUNTIME_EXPECTS(cond, reason)                           \
   (!!(cond)) ? static_cast<void>(0)                                  \
              : throw std::runtime_error("cuco failure at: " __FILE__ \
-                                       ":" CUCO_STRINGIFY(__LINE__) ": " reason)
+                                        ":" CUCO_STRINGIFY(__LINE__) ": " reason)

--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -59,9 +59,8 @@ static_map<Key, Value, Scope, Allocator>::static_map(
     slot_allocator_{alloc},
     counter_allocator_{alloc}
 {
-  CUCO_RUNTIME_EXPECTS(
-    empty_key_sentinel_ != erased_key_sentinel_,
-    "The empty key sentinel and erased key sentinel cannot be the same value.");
+  CUCO_RUNTIME_EXPECTS(empty_key_sentinel_ != erased_key_sentinel_,
+                       "The empty key sentinel and erased key sentinel cannot be the same value.");
 
   slots_         = std::allocator_traits<slot_allocator_type>::allocate(slot_allocator_, capacity_);
   num_successes_ = std::allocator_traits<counter_allocator_type>::allocate(counter_allocator_, 1);
@@ -152,9 +151,8 @@ template <typename InputIt, typename Hash, typename KeyEqual>
 void static_map<Key, Value, Scope, Allocator>::erase(
   InputIt first, InputIt last, Hash hash, KeyEqual key_equal, cudaStream_t stream)
 {
-  CUCO_RUNTIME_EXPECTS(
-    get_empty_key_sentinel() != get_erased_key_sentinel(),
-    "You must provide a unique erased key sentinel value at map construction.");
+  CUCO_RUNTIME_EXPECTS(get_empty_key_sentinel() != get_erased_key_sentinel(),
+                       "You must provide a unique erased key sentinel value at map construction.");
 
   auto num_keys = std::distance(first, last);
   if (num_keys == 0) { return; }

--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -537,7 +537,7 @@ __device__ bool static_map<Key, Value, Scope, Allocator>::device_mutable_view::e
     auto const slot_is_empty =
       detail::bitwise_compare(existing_key, this->get_empty_key_sentinel());
 
-    auto const exists = g.any(not slot_is_empty and key_equal(existing_key, k));
+    auto const exists = g.ballot(not slot_is_empty and key_equal(existing_key, k));
 
     // Key exists, return true if successfully deleted
     if (exists) {
@@ -566,7 +566,7 @@ __device__ bool static_map<Key, Value, Scope, Allocator>::device_mutable_view::e
     }
     
     // empty slot found, but key not found, must not be in the map
-    if (g.ballot(slot_is_empty)) { return false; }
+    if(g.ballot(slot_is_empty)) { return false; }
   
     current_slot = next_slot(g, current_slot);
   }

--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -59,6 +59,10 @@ static_map<Key, Value, Scope, Allocator>::static_map(
     slot_allocator_{alloc},
     counter_allocator_{alloc}
 {
+  CUCO_RUNTIME_EXPECTS(
+    empty_key_sentinel_ != erased_key_sentinel_,
+    "The empty key sentinel and erased key sentinel cannot be the same value.");
+
   slots_         = std::allocator_traits<slot_allocator_type>::allocate(slot_allocator_, capacity_);
   num_successes_ = std::allocator_traits<counter_allocator_type>::allocate(counter_allocator_, 1);
 
@@ -148,10 +152,9 @@ template <typename InputIt, typename Hash, typename KeyEqual>
 void static_map<Key, Value, Scope, Allocator>::erase(
   InputIt first, InputIt last, Hash hash, KeyEqual key_equal, cudaStream_t stream)
 {
-  if (get_empty_key_sentinel() == get_erased_key_sentinel())
-    CUCO_RUNTIME_EXPECTS(
-      get_empty_key_sentinel() != get_erased_key_sentinel(),
-      "You must provide a unique erased key sentinel value at map construction.");
+  CUCO_RUNTIME_EXPECTS(
+    get_empty_key_sentinel() != get_erased_key_sentinel(),
+    "You must provide a unique erased key sentinel value at map construction.");
 
   auto num_keys = std::distance(first, last);
   if (num_keys == 0) { return; }

--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -20,11 +20,12 @@
 namespace cuco {
 
 template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
-static_map<Key, Value, Scope, Allocator>::static_map(std::size_t capacity,
-                                                     sentinel::empty_key<Key> empty_key_sentinel,
-                                                     sentinel::empty_value<Value> empty_value_sentinel,
-                                                     Allocator const& alloc,
-                                                     cudaStream_t stream)
+static_map<Key, Value, Scope, Allocator>::static_map(
+  std::size_t capacity,
+  sentinel::empty_key<Key> empty_key_sentinel,
+  sentinel::empty_value<Value> empty_value_sentinel,
+  Allocator const& alloc,
+  cudaStream_t stream)
   : capacity_{std::max(capacity, std::size_t{1})},  // to avoid dereferencing a nullptr (Issue #72)
     empty_key_sentinel_{empty_key_sentinel.value},
     empty_value_sentinel_{empty_value_sentinel.value},
@@ -44,12 +45,13 @@ static_map<Key, Value, Scope, Allocator>::static_map(std::size_t capacity,
 }
 
 template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
-static_map<Key, Value, Scope, Allocator>::static_map(std::size_t capacity,
-                                                     sentinel::empty_key<Key> empty_key_sentinel,
-                                                     sentinel::empty_value<Value> empty_value_sentinel,
-                                                     sentinel::erased_key<Key> erased_key_sentinel,
-                                                     Allocator const& alloc,
-                                                     cudaStream_t stream)
+static_map<Key, Value, Scope, Allocator>::static_map(
+  std::size_t capacity,
+  sentinel::empty_key<Key> empty_key_sentinel,
+  sentinel::empty_value<Value> empty_value_sentinel,
+  sentinel::erased_key<Key> erased_key_sentinel,
+  Allocator const& alloc,
+  cudaStream_t stream)
   : capacity_{std::max(capacity, std::size_t{1})},  // to avoid dereferencing a nullptr (Issue #72)
     empty_key_sentinel_{empty_key_sentinel.value},
     empty_value_sentinel_{empty_value_sentinel.value},

--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -657,7 +657,7 @@ __device__ bool static_map<Key, Value, Scope, Allocator>::device_view::contains(
   while (true) {
     auto const existing_key = current_slot->first.load(cuda::std::memory_order_relaxed);
 
-    if (detail::bitwise_compare(existing_key, this->erased_key_sentinel_)) { return false; }
+    if (detail::bitwise_compare(existing_key, this->empty_key_sentinel_)) { return false; }
 
     if (key_equal(existing_key, k)) { return true; }
 

--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -147,7 +147,8 @@ void static_map<Key, Value, Scope, Allocator>::erase(
   InputIt first, InputIt last, Hash hash, KeyEqual key_equal, cudaStream_t stream)
 {
   if (get_empty_key_sentinel() == get_erased_key_sentinel())
-    CUCO_RUNTIME_EXPECTS(get_empty_key_sentinel() != get_erased_key_sentinel(),
+    CUCO_RUNTIME_EXPECTS(
+      get_empty_key_sentinel() != get_erased_key_sentinel(),
       "You must provide a unique erased key sentinel value at map construction.");
 
   auto num_keys = std::distance(first, last);
@@ -156,8 +157,8 @@ void static_map<Key, Value, Scope, Allocator>::erase(
   auto constexpr block_size = 128;
   auto constexpr stride     = 1;
   auto constexpr tile_size  = 4;
-  auto const grid_size  = (tile_size * num_keys + stride * block_size - 1) / (stride * block_size);
-  auto view             = get_device_mutable_view();
+  auto const grid_size = (tile_size * num_keys + stride * block_size - 1) / (stride * block_size);
+  auto view            = get_device_mutable_view();
 
   // TODO: memset an atomic variable is unsafe
   static_assert(sizeof(std::size_t) == sizeof(atomic_ctr_type));
@@ -439,16 +440,15 @@ __device__ bool static_map<Key, Value, Scope, Allocator>::device_mutable_view::e
     make_pair<Key, Value>(this->get_erased_key_sentinel(), this->get_empty_value_sentinel());
 
   while (true) {
-    //auto existing_key   = current_slot->first.load(cuda::std::memory_order_relaxed);
-    //auto existing_value = current_slot->second.load(cuda::std::memory_order_relaxed);
-    
+    // auto existing_key   = current_slot->first.load(cuda::std::memory_order_relaxed);
+    // auto existing_value = current_slot->second.load(cuda::std::memory_order_relaxed);
+
     static_assert(sizeof(Key) == sizeof(atomic_key_type));
     static_assert(sizeof(Value) == sizeof(atomic_mapped_type));
     // TODO: Replace reinterpret_cast with atomic ref when available.
     value_type slot_contents = *reinterpret_cast<value_type const*>(current_slot);
-    auto existing_key = slot_contents.first;
-    auto existing_value = slot_contents.second;
-
+    auto existing_key        = slot_contents.first;
+    auto existing_value      = slot_contents.second;
 
     // Key doesn't exist, return false
     if (detail::bitwise_compare(existing_key, this->get_empty_key_sentinel())) { return false; }
@@ -492,8 +492,8 @@ __device__ bool static_map<Key, Value, Scope, Allocator>::device_mutable_view::e
     static_assert(sizeof(Value) == sizeof(atomic_mapped_type));
     // TODO: Replace reinterpret_cast with atomic ref when available.
     value_type slot_contents = *reinterpret_cast<value_type const*>(current_slot);
-    auto existing_key = slot_contents.first;
-    auto existing_value = slot_contents.second;
+    auto existing_key        = slot_contents.first;
+    auto existing_value      = slot_contents.second;
 
     auto const slot_is_empty =
       detail::bitwise_compare(existing_key, this->get_empty_key_sentinel());

--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -17,14 +17,38 @@
 #include <cuco/detail/bitwise_compare.cuh>
 
 namespace cuco {
-
+  
 template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
 static_map<Key, Value, Scope, Allocator>::static_map(std::size_t capacity,
                                                      Key empty_key_sentinel,
                                                      Value empty_value_sentinel,
                                                      Allocator const& alloc,
-                                                     cudaStream_t stream,
-                                                     Key erased_key_sentinel)
+                                                     cudaStream_t stream)
+  : capacity_{std::max(capacity, std::size_t{1})},  // to avoid dereferencing a nullptr (Issue #72)
+    empty_key_sentinel_{empty_key_sentinel},
+    empty_value_sentinel_{empty_value_sentinel},
+    erased_key_sentinel_{empty_key_sentinel},
+    slot_allocator_{alloc},
+    counter_allocator_{alloc}
+{
+  slots_         = std::allocator_traits<slot_allocator_type>::allocate(slot_allocator_, capacity_);
+  num_successes_ = std::allocator_traits<counter_allocator_type>::allocate(counter_allocator_, 1);
+
+  auto constexpr block_size = 256;
+  auto constexpr stride     = 4;
+  auto const grid_size      = (capacity_ + stride * block_size - 1) / (stride * block_size);
+  detail::initialize<block_size, atomic_key_type, atomic_mapped_type>
+    <<<grid_size, block_size, 0, stream>>>(
+      slots_, empty_key_sentinel, empty_value_sentinel, capacity_);
+}
+
+template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
+static_map<Key, Value, Scope, Allocator>::static_map(std::size_t capacity,
+                                                     Key empty_key_sentinel,
+                                                     Value empty_value_sentinel,
+                                                     Key erased_key_sentinel,
+                                                     Allocator const& alloc,
+                                                     cudaStream_t stream)
   : capacity_{std::max(capacity, std::size_t{1})},  // to avoid dereferencing a nullptr (Issue #72)
     empty_key_sentinel_{empty_key_sentinel},
     empty_value_sentinel_{empty_value_sentinel},
@@ -121,6 +145,9 @@ template <typename InputIt, typename Hash, typename KeyEqual>
 void static_map<Key, Value, Scope, Allocator>::erase(
   InputIt first, InputIt last, Hash hash, KeyEqual key_equal, cudaStream_t stream)
 {
+  if(get_empty_key_sentinel() == get_erased_key_sentinel())
+    throw std::runtime_error("Runtime error: You must provide a unique erased key sentinel value at map construction.\n");
+
   auto num_keys = std::distance(first, last);
   if (num_keys == 0) { return; }
 
@@ -193,36 +220,6 @@ template <typename Key, typename Value, cuda::thread_scope Scope, typename Alloc
 template <typename KeyEqual>
 __device__ static_map<Key, Value, Scope, Allocator>::device_mutable_view::insert_result
 static_map<Key, Value, Scope, Allocator>::device_mutable_view::packed_cas(
-  iterator current_slot, value_type const& insert_pair, KeyEqual key_equal) noexcept
-{
-  auto expected_key   = this->get_empty_key_sentinel();
-  auto expected_value = this->get_empty_value_sentinel();
-
-  cuco::detail::pair_converter<value_type> expected_pair{
-    cuco::make_pair(expected_key, expected_value)};
-  cuco::detail::pair_converter<value_type> new_pair{insert_pair};
-
-  auto slot =
-    reinterpret_cast<cuda::atomic<typename cuco::detail::pair_converter<value_type>::packed_type>*>(
-      current_slot);
-
-  bool success = slot->compare_exchange_strong(
-    expected_pair.packed, new_pair.packed, cuda::std::memory_order_relaxed);
-  if (success) {
-    return insert_result::SUCCESS;
-  }
-  // duplicate present during insert
-  else if (key_equal(insert_pair.first, expected_pair.pair.first)) {
-    return insert_result::DUPLICATE;
-  }
-
-  return insert_result::CONTINUE;
-}
-
-template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
-template <typename KeyEqual>
-__device__ static_map<Key, Value, Scope, Allocator>::device_mutable_view::insert_result
-static_map<Key, Value, Scope, Allocator>::device_mutable_view::packed_cas(
   iterator current_slot, value_type const& insert_pair, KeyEqual key_equal, Key expected_key) noexcept
 {
   auto expected_value = this->get_empty_value_sentinel();
@@ -244,44 +241,6 @@ static_map<Key, Value, Scope, Allocator>::device_mutable_view::packed_cas(
   else if (key_equal(insert_pair.first, expected_pair.pair.first)) {
     return insert_result::DUPLICATE;
   }
-
-  return insert_result::CONTINUE;
-}
-
-template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
-template <typename KeyEqual>
-__device__ static_map<Key, Value, Scope, Allocator>::device_mutable_view::insert_result
-static_map<Key, Value, Scope, Allocator>::device_mutable_view::back_to_back_cas(
-  iterator current_slot, value_type const& insert_pair, KeyEqual key_equal) noexcept
-{
-  using cuda::std::memory_order_relaxed;
-
-  auto expected_key   = this->get_empty_key_sentinel();
-  auto expected_value = this->get_empty_value_sentinel();
-
-  // Back-to-back CAS for 8B/8B key/value pairs
-  auto& slot_key   = current_slot->first;
-  auto& slot_value = current_slot->second;
-
-  bool key_success =
-    slot_key.compare_exchange_strong(expected_key, insert_pair.first, memory_order_relaxed);
-  bool value_success =
-    slot_value.compare_exchange_strong(expected_value, insert_pair.second, memory_order_relaxed);
-
-  if (key_success) {
-    while (not value_success) {
-      value_success =
-        slot_value.compare_exchange_strong(expected_value = this->get_empty_value_sentinel(),
-                                           insert_pair.second,
-                                           memory_order_relaxed);
-    }
-    return insert_result::SUCCESS;
-  } else if (value_success) {
-    slot_value.store(this->get_empty_value_sentinel(), memory_order_relaxed);
-  }
-
-  // our key was already present in the slot, so our key is a duplicate
-  if (key_equal(insert_pair.first, expected_key)) { return insert_result::DUPLICATE; }
 
   return insert_result::CONTINUE;
 }
@@ -315,32 +274,6 @@ static_map<Key, Value, Scope, Allocator>::device_mutable_view::back_to_back_cas(
     return insert_result::SUCCESS;
   } else if (value_success) {
     slot_value.store(this->get_empty_value_sentinel(), memory_order_relaxed);
-  }
-
-  // our key was already present in the slot, so our key is a duplicate
-  if (key_equal(insert_pair.first, expected_key)) { return insert_result::DUPLICATE; }
-
-  return insert_result::CONTINUE;
-}
-
-template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
-template <typename KeyEqual>
-__device__ static_map<Key, Value, Scope, Allocator>::device_mutable_view::insert_result
-static_map<Key, Value, Scope, Allocator>::device_mutable_view::cas_dependent_write(
-  iterator current_slot, value_type const& insert_pair, KeyEqual key_equal) noexcept
-{
-  using cuda::std::memory_order_relaxed;
-  auto expected_key = this->get_empty_key_sentinel();
-
-  auto& slot_key = current_slot->first;
-
-  auto const key_success =
-    slot_key.compare_exchange_strong(expected_key, insert_pair.first, memory_order_relaxed);
-
-  if (key_success) {
-    auto& slot_value = current_slot->second;
-    slot_value.store(insert_pair.second, memory_order_relaxed);
-    return insert_result::SUCCESS;
   }
 
   // our key was already present in the slot, so our key is a duplicate
@@ -516,7 +449,6 @@ __device__ bool static_map<Key, Value, Scope, Allocator>::device_mutable_view::e
         current_slot->second.compare_exchange_strong(existing_value, insert_pair.second, cuda::std::memory_order_relaxed);
         return current_slot->first.compare_exchange_strong(existing_key, insert_pair.first, cuda::std::memory_order_relaxed);
       }
-      // simple CAS
     }
   
     current_slot = next_slot(current_slot);
@@ -707,7 +639,7 @@ __device__ bool static_map<Key, Value, Scope, Allocator>::device_view::contains(
   while (true) {
     auto const existing_key = current_slot->first.load(cuda::std::memory_order_relaxed);
 
-    if (detail::bitwise_compare(existing_key, this->empty_key_sentinel_)) { return false; }
+    if (detail::bitwise_compare(existing_key, this->erased_key_sentinel_)) { return false; }
 
     if (key_equal(existing_key, k)) { return true; }
 

--- a/include/cuco/detail/static_map_kernels.cuh
+++ b/include/cuco/detail/static_map_kernels.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/cuco/detail/static_map_kernels.cuh
+++ b/include/cuco/detail/static_map_kernels.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -165,7 +165,7 @@ template <std::size_t block_size,
 __global__ void erase(
   InputIt first, InputIt last, atomicT* num_successes, viewT view, Hash hash, KeyEqual key_equal)
 {
-  typedef cub::BlockReduce<std::size_t, block_size> BlockReduce;
+  using BlockReduce = cub::BlockReduce<std::size_t, block_size>;
   __shared__ typename BlockReduce::TempStorage temp_storage;
   std::size_t thread_num_successes = 0;
 
@@ -173,8 +173,7 @@ __global__ void erase(
   auto it  = first + tid;
 
   while (it < last) {
-    auto k{*it};
-    if (view.erase(k, hash, key_equal)) { thread_num_successes++; }
+    if (view.erase(*it, hash, key_equal)) { thread_num_successes++; }
     it += gridDim.x * block_size;
   }
 
@@ -203,8 +202,7 @@ __global__ void erase(
   auto it   = first + tid / tile_size;
 
   while (it < last) {
-    auto k{*it};
-    if (view.erase(tile, k, hash, key_equal) && tile.thread_rank() == 0) { thread_num_successes++; }
+    if (view.erase(tile, *it, hash, key_equal) and tile.thread_rank() == 0) { thread_num_successes++; }
     it += (gridDim.x * block_size) / tile_size;
   }
 

--- a/include/cuco/detail/static_map_kernels.cuh
+++ b/include/cuco/detail/static_map_kernels.cuh
@@ -202,7 +202,9 @@ __global__ void erase(
   auto it   = first + tid / tile_size;
 
   while (it < last) {
-    if (view.erase(tile, *it, hash, key_equal) and tile.thread_rank() == 0) { thread_num_successes++; }
+    if (view.erase(tile, *it, hash, key_equal) and tile.thread_rank() == 0) {
+      thread_num_successes++;
+    }
     it += (gridDim.x * block_size) / tile_size;
   }
 

--- a/include/cuco/detail/static_map_kernels.cuh
+++ b/include/cuco/detail/static_map_kernels.cuh
@@ -184,6 +184,36 @@ __global__ void erase(
   if (threadIdx.x == 0) { *num_successes += block_num_successes; }
 }
 
+template <std::size_t block_size,
+          uint32_t tile_size,
+          typename InputIt,
+          typename atomicT,
+          typename viewT,
+          typename Hash,
+          typename KeyEqual>
+__global__ void erase(
+  InputIt first, InputIt last, atomicT* num_successes, viewT view, Hash hash, KeyEqual key_equal)
+{
+  typedef cub::BlockReduce<std::size_t, block_size> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+  std::size_t thread_num_successes = 0;
+
+  auto tile = cg::tiled_partition<tile_size>(cg::this_thread_block());
+  auto tid = block_size * blockIdx.x + threadIdx.x;
+  auto it  = first + tid / tile_size;
+
+  while (it < last) {
+    auto k{*it};
+    if (view.erase(tile, k, hash, key_equal) && tile.thread_rank() == 0) { thread_num_successes++; }
+    it += (gridDim.x * block_size) / tile_size;
+  }
+
+  // compute number of successfully inserted elements for each block
+  // and atomically add to the grand total
+  std::size_t block_num_successes = BlockReduce(temp_storage).Sum(thread_num_successes);
+  if (threadIdx.x == 0) { *num_successes += block_num_successes; }
+}
+
 /**
  * @brief Inserts key/value pairs in the range `[first, first + n)` if `pred` of the
  * corresponding stencil returns true.

--- a/include/cuco/detail/static_map_kernels.cuh
+++ b/include/cuco/detail/static_map_kernels.cuh
@@ -199,8 +199,8 @@ __global__ void erase(
   std::size_t thread_num_successes = 0;
 
   auto tile = cg::tiled_partition<tile_size>(cg::this_thread_block());
-  auto tid = block_size * blockIdx.x + threadIdx.x;
-  auto it  = first + tid / tile_size;
+  auto tid  = block_size * blockIdx.x + threadIdx.x;
+  auto it   = first + tid / tile_size;
 
   while (it < last) {
     auto k{*it};

--- a/include/cuco/detail/static_map_kernels.cuh
+++ b/include/cuco/detail/static_map_kernels.cuh
@@ -180,7 +180,9 @@ __global__ void erase(
   // compute number of successfully inserted elements for each block
   // and atomically add to the grand total
   std::size_t block_num_successes = BlockReduce(temp_storage).Sum(thread_num_successes);
-  if (threadIdx.x == 0) { *num_successes += block_num_successes; }
+  if (threadIdx.x == 0) { 
+    num_successes->fetch_add(block_num_successes, cuda::std::memory_order_relaxed);
+  }
 }
 
 template <std::size_t block_size,
@@ -211,7 +213,9 @@ __global__ void erase(
   // compute number of successfully inserted elements for each block
   // and atomically add to the grand total
   std::size_t block_num_successes = BlockReduce(temp_storage).Sum(thread_num_successes);
-  if (threadIdx.x == 0) { *num_successes += block_num_successes; }
+  if (threadIdx.x == 0) { 
+    num_successes->fetch_add(block_num_successes, cuda::std::memory_order_relaxed);
+  }
 }
 
 /**

--- a/include/cuco/detail/static_map_kernels.cuh
+++ b/include/cuco/detail/static_map_kernels.cuh
@@ -180,7 +180,7 @@ __global__ void erase(
   // compute number of successfully inserted elements for each block
   // and atomically add to the grand total
   std::size_t block_num_successes = BlockReduce(temp_storage).Sum(thread_num_successes);
-  if (threadIdx.x == 0) { 
+  if (threadIdx.x == 0) {
     num_successes->fetch_add(block_num_successes, cuda::std::memory_order_relaxed);
   }
 }
@@ -213,7 +213,7 @@ __global__ void erase(
   // compute number of successfully inserted elements for each block
   // and atomically add to the grand total
   std::size_t block_num_successes = BlockReduce(temp_storage).Sum(thread_num_successes);
-  if (threadIdx.x == 0) { 
+  if (threadIdx.x == 0) {
     num_successes->fetch_add(block_num_successes, cuda::std::memory_order_relaxed);
   }
 }

--- a/include/cuco/sentinel.hpp
+++ b/include/cuco/sentinel.hpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace cuco {
+namespace sentinel {
+
+template <typename T>
+struct empty_key {
+  T value;
+};
+
+template <typename T>
+struct empty_value {
+  T value;
+};
+
+template <typename T>
+struct erased_key {
+  T value;
+};
+
+} // namespace sentinel
+} // namespace cuco

--- a/include/cuco/sentinel.hpp
+++ b/include/cuco/sentinel.hpp
@@ -32,5 +32,5 @@ struct erased_key {
   T value;
 };
 
-} // namespace sentinel
-} // namespace cuco
+}  // namespace sentinel
+}  // namespace cuco

--- a/include/cuco/sentinel.hpp
+++ b/include/cuco/sentinel.hpp
@@ -14,21 +14,26 @@
  * limitations under the License.
  */
 
+#pragma once
+
 namespace cuco {
 namespace sentinel {
 
 template <typename T>
 struct empty_key {
+  __host__ __device__ empty_key(T v) : value{v} {}
   T value;
 };
 
 template <typename T>
 struct empty_value {
+  __host__ __device__ empty_value(T v) : value{v} {}
   T value;
 };
 
 template <typename T>
 struct erased_key {
+  __host__ __device__ erased_key(T v) : value{v} {}
   T value;
 };
 

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -164,6 +164,17 @@ class static_map {
 
   static_map(static_map const&) = delete;
   static_map(static_map&&)      = delete;
+  
+  template<typename T1, typename T2>
+  static_map(std::size_t, T1 , T2,
+             Allocator const& = Allocator{},
+             cudaStream_t     = 0) = delete;
+             
+  template<typename T1, typename T2, typename T3>
+  static_map(std::size_t, T1, T2, T3,
+             Allocator const&  = Allocator{},
+             cudaStream_t      = 0) = delete;
+  
   static_map& operator=(static_map const&) = delete;
   static_map& operator=(static_map&&) = delete;
 

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -695,6 +695,13 @@ class static_map {
     __device__ insert_result packed_cas(iterator current_slot,
                                         value_type const& insert_pair,
                                         KeyEqual key_equal) noexcept;
+    
+    template <typename KeyEqual>
+    __device__ insert_result packed_cas(iterator current_slot,
+                                        value_type const& insert_pair,
+                                        KeyEqual key_equal,
+                                        Key expected_key) noexcept;
+
 
     /**
      * @brief Inserts the specified key/value pair with two back-to-back CAS operations.
@@ -710,6 +717,12 @@ class static_map {
     __device__ insert_result back_to_back_cas(iterator current_slot,
                                               value_type const& insert_pair,
                                               KeyEqual key_equal) noexcept;
+    
+    template <typename KeyEqual>
+    __device__ insert_result back_to_back_cas(iterator current_slot,
+                                              value_type const& insert_pair,
+                                              KeyEqual key_equal,
+                                              Key expected_key) noexcept;
 
     /**
      * @brief Inserts the specified key/value pair with a CAS of the key and a dependent write of
@@ -726,6 +739,12 @@ class static_map {
     __device__ insert_result cas_dependent_write(iterator current_slot,
                                                  value_type const& insert_pair,
                                                  KeyEqual key_equal) noexcept;
+    
+    template <typename KeyEqual>
+    __device__ insert_result cas_dependent_write(iterator current_slot,
+                                                 value_type const& insert_pair,
+                                                 KeyEqual key_equal,
+                                                 Key expected_key) noexcept;
 
    public:
     template <typename CG>

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -164,17 +164,13 @@ class static_map {
 
   static_map(static_map const&) = delete;
   static_map(static_map&&)      = delete;
-  
-  template<typename T1, typename T2>
-  static_map(std::size_t, T1 , T2,
-             Allocator const& = Allocator{},
-             cudaStream_t     = 0) = delete;
-             
-  template<typename T1, typename T2, typename T3>
-  static_map(std::size_t, T1, T2, T3,
-             Allocator const&  = Allocator{},
-             cudaStream_t      = 0) = delete;
-  
+
+  template <typename T1, typename T2>
+  static_map(std::size_t, T1, T2, Allocator const& = Allocator{}, cudaStream_t = 0) = delete;
+
+  template <typename T1, typename T2, typename T3>
+  static_map(std::size_t, T1, T2, T3, Allocator const& = Allocator{}, cudaStream_t = 0) = delete;
+
   static_map& operator=(static_map const&) = delete;
   static_map& operator=(static_map&&) = delete;
 

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -293,8 +293,8 @@ class static_map {
   /**
    * @brief Erases keys in the range `[first, last)`.
    *
-   * For each key `k` in `[first, last)`, if `contains(k) == true), removes `k` and it's 
-   * associated value from the map. Else, no effect. 
+   * For each key `k` in `[first, last)`, if `contains(k) == true), removes `k` and it's
+   * associated value from the map. Else, no effect.
    *
    *  Side-effects:
    *  - `contains(k) == false`

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -293,6 +293,15 @@ class static_map {
   /**
    * @brief Erases keys in the range `[first, last)`.
    *
+   * For each key `k` in `[first, last)`, if `contains(k) == true), removes `k` and it's 
+   * associated value from the map. Else, no effect. 
+   *
+   *  Side-effects:
+   *  - `contains(k) == false`
+   *  - `find(k) == end()`
+   *  - `insert({k,v}) == true`
+   *  - `get_size()` is reduced by the total number of erased keys
+   *
    * This function synchronizes `stream`.
    *
    * @tparam InputIt Device accessible input iterator whose `value_type` is

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -372,8 +372,8 @@ class static_map {
     using const_iterator = pair_atomic_type const*;
     using slot_type      = slot_type;
 
-    Key empty_key_sentinel_{};  ///< Key value that represents an empty slot
-    Key erased_key_sentinel_{}; ///< Key value that represents an erased slot
+    Key empty_key_sentinel_{};      ///< Key value that represents an empty slot
+    Key erased_key_sentinel_{};     ///< Key value that represents an erased slot
     Value empty_value_sentinel_{};  ///< Initial Value of empty slot
     pair_atomic_type* slots_{};     ///< Pointer to flat slots storage
     std::size_t capacity_{};        ///< Total number of slots

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -211,7 +211,7 @@ class static_map {
    * @brief Constructs a fixed-size map with erase capability.
    * empty_key_sentinel and erased_key_sentinel must be different values.
    *
-   * @throw std::runtime error if the empty key sentinel and erased key sentinel 
+   * @throw std::runtime error if the empty key sentinel and erased key sentinel
    * are the same value
    */
   static_map(std::size_t capacity,
@@ -305,7 +305,7 @@ class static_map {
    * @param key_equal The binary function to compare two keys for equality
    * @param stream Stream used for executing the kernels
    *
-   * @throw std::runtime_error if a unique erased key sentinel value was not 
+   * @throw std::runtime_error if a unique erased key sentinel value was not
    * provided at construction
    */
   template <typename InputIt,

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -208,8 +208,11 @@ class static_map {
              cudaStream_t stream    = 0);
 
   /**
-   * @brief Construct a fixed-size map with erase capability
+   * @brief Constructs a fixed-size map with erase capability.
    * empty_key_sentinel and erased_key_sentinel must be different values.
+   *
+   * @throw std::runtime error if the empty key sentinel and erased key sentinel 
+   * are the same value
    */
   static_map(std::size_t capacity,
              sentinel::empty_key<Key> empty_key_sentinel,
@@ -301,6 +304,9 @@ class static_map {
    * @param hash The unary function to apply to hash each key
    * @param key_equal The binary function to compare two keys for equality
    * @param stream Stream used for executing the kernels
+   *
+   * @throw std::runtime_error if a unique erased key sentinel value was not 
+   * provided at construction
    */
   template <typename InputIt,
             typename Hash     = cuco::detail::MurmurHash3_32<key_type>,

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -35,11 +35,11 @@
 #include <cuda/barrier>
 #endif
 
-#include <cuco/sentinel.hpp>
 #include <cuco/detail/error.hpp>
 #include <cuco/detail/hash_functions.cuh>
 #include <cuco/detail/pair.cuh>
 #include <cuco/detail/static_map_kernels.cuh>
+#include <cuco/sentinel.hpp>
 
 namespace cuco {
 

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -41,17 +41,23 @@
 #include <cuco/detail/static_map_kernels.cuh>
 
 namespace cuco {
-  
-namespace sentinel {
-  template <typename T>
-  struct empty_key{T value; };
 
-  template <typename T>
-  struct empty_value{T value; };
-    
-  template <typename T>
-  struct erased_key{T value; };
-} // namespace sentinel
+namespace sentinel {
+template <typename T>
+struct empty_key {
+  T value;
+};
+
+template <typename T>
+struct empty_value {
+  T value;
+};
+
+template <typename T>
+struct erased_key {
+  T value;
+};
+}  // namespace sentinel
 
 template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
 class dynamic_map;
@@ -82,7 +88,7 @@ class dynamic_map;
  * in the map. For example, given a range of keys specified by device-accessible
  * iterators, the bulk `insert` function will insert all keys into the map. Note that in order
  * for a `static_map` instance to support `erase`, the user must provide an `erased_key_sentinel`
- * which is distinct from the `empty_key_sentinel` at construction. If `erase` is called on a 
+ * which is distinct from the `empty_key_sentinel` at construction. If `erase` is called on a
  * `static_map` which was not constructed in this way, a runtime error will be generated.
  *
  * The singular device-side operations allow individual threads to perform
@@ -92,7 +98,7 @@ class dynamic_map;
  * immutable view that allows only non-modifying operations such as `find` or
  * `contains`. The `mutable_device_view` class only allows `insert` and `erase` operations.
  * The two types are separate to prevent erroneous concurrent insert/erase/find
- * operations. Note that the device-side `erase` may only be called if the corresponding 
+ * operations. Note that the device-side `erase` may only be called if the corresponding
  * `mutable_device_view` was constructed with a user-provided `erased_key_sentinel`. It is
  * up to the user to ensure this condition is met.
  *
@@ -105,7 +111,8 @@ class dynamic_map;
  * // Constructs a map with 100,000 slots using -1 and -1 as the empty key/value
  * // sentinels. The supplied erased key sentinel of -2 must be a different value from the empty
  * // key sentinel. If erase functionality is not needed, you may elect to not supply an erased
- * // key sentinel to the constructor. Note the capacity is chosen knowing we will insert 50,000 keys,
+ * // key sentinel to the constructor. Note the capacity is chosen knowing we will insert 50,000
+ * keys,
  * // for an load factor of 50%.
  * static_map<int, int> m{100'000, empty_key_sentinel, empty_value_sentinel, erased_value_sentinel};
  *
@@ -185,8 +192,6 @@ class static_map {
   {
     return cuco::detail::is_packable<value_type>();
   }
-
-  
 
   /**
    * @brief Construct a fixed-size map with the specified capacity and sentinel values.
@@ -717,9 +722,11 @@ class static_map {
                                             sentinel::empty_key<Key> empty_key_sentinel,
                                             sentinel::empty_value<Value> empty_value_sentinel,
                                             sentinel::erased_key<Key> erased_key_sentinel) noexcept
-      : device_view_base{
-          slots, capacity, 
-          empty_key_sentinel.value, empty_value_sentinel.value, erased_key_sentinel.value}
+      : device_view_base{slots,
+                         capacity,
+                         empty_key_sentinel.value,
+                         empty_value_sentinel.value,
+                         erased_key_sentinel.value}
     {
     }
 
@@ -796,11 +803,11 @@ class static_map {
     {
       device_view_base::initialize_slots(
         g, slots, capacity, empty_key_sentinel.value, empty_value_sentinel.value);
-      return device_mutable_view{
-        slots, capacity, 
-        empty_key_sentinel, 
-        empty_value_sentinel, 
-        sentinel::erased_key<Key>{empty_key_sentinel.value}};
+      return device_mutable_view{slots,
+                                 capacity,
+                                 empty_key_sentinel,
+                                 empty_value_sentinel,
+                                 sentinel::erased_key<Key>{empty_key_sentinel.value}};
     }
 
     /* Features erase support */
@@ -918,8 +925,11 @@ class static_map {
                                     sentinel::empty_key<Key> empty_key_sentinel,
                                     sentinel::empty_value<Value> empty_value_sentinel,
                                     sentinel::erased_key<Key> erased_key_sentinel) noexcept
-      : device_view_base{
-          slots, capacity, empty_key_sentinel.value, empty_value_sentinel.value, erased_key_sentinel.value}
+      : device_view_base{slots,
+                         capacity,
+                         empty_key_sentinel.value,
+                         empty_value_sentinel.value,
+                         erased_key_sentinel.value}
     {
     }
 
@@ -1002,11 +1012,12 @@ class static_map {
       g.sync();
 #endif
 
-      return device_view(memory_to_use,
-                         source_device_view.get_capacity(),
-                         sentinel::empty_key<Key>{source_device_view.get_empty_key_sentinel()},
-                         sentinel::empty_value<Value>{source_device_view.get_empty_value_sentinel()},
-                         sentinel::erased_key<Key>{source_device_view.get_erased_key_sentinel()});
+      return device_view(
+        memory_to_use,
+        source_device_view.get_capacity(),
+        sentinel::empty_key<Key>{source_device_view.get_empty_key_sentinel()},
+        sentinel::empty_value<Value>{source_device_view.get_empty_value_sentinel()},
+        sentinel::erased_key<Key>{source_device_view.get_erased_key_sentinel()});
     }
 
     /**
@@ -1201,11 +1212,11 @@ class static_map {
    */
   device_view get_device_view() const noexcept
   {
-    return device_view(
-      slots_, capacity_, 
-      sentinel::empty_key<Key>{empty_key_sentinel_}, 
-      sentinel::empty_value<Value>{empty_value_sentinel_}, 
-      sentinel::erased_key<Key>{erased_key_sentinel_});
+    return device_view(slots_,
+                       capacity_,
+                       sentinel::empty_key<Key>{empty_key_sentinel_},
+                       sentinel::empty_value<Value>{empty_value_sentinel_},
+                       sentinel::erased_key<Key>{erased_key_sentinel_});
   }
 
   /**
@@ -1215,11 +1226,11 @@ class static_map {
    */
   device_mutable_view get_device_mutable_view() const noexcept
   {
-    return device_mutable_view(
-      slots_, capacity_, 
-      sentinel::empty_key<Key>{empty_key_sentinel_}, 
-      sentinel::empty_value<Value>{empty_value_sentinel_}, 
-      sentinel::erased_key<Key>{erased_key_sentinel_});
+    return device_mutable_view(slots_,
+                               capacity_,
+                               sentinel::empty_key<Key>{empty_key_sentinel_},
+                               sentinel::empty_value<Value>{empty_value_sentinel_},
+                               sentinel::erased_key<Key>{erased_key_sentinel_});
   }
 
  private:

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -373,7 +373,7 @@ class static_map {
     using slot_type      = slot_type;
 
     Key empty_key_sentinel_{};  ///< Key value that represents an empty slot
-    Key erased_key_sentinel_{};
+    Key erased_key_sentinel_{}; ///< Key value that represents an erased slot
     Value empty_value_sentinel_{};  ///< Initial Value of empty slot
     pair_atomic_type* slots_{};     ///< Pointer to flat slots storage
     std::size_t capacity_{};        ///< Total number of slots

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -35,29 +35,13 @@
 #include <cuda/barrier>
 #endif
 
+#include <cuco/sentinel.hpp>
 #include <cuco/detail/error.hpp>
 #include <cuco/detail/hash_functions.cuh>
 #include <cuco/detail/pair.cuh>
 #include <cuco/detail/static_map_kernels.cuh>
 
 namespace cuco {
-
-namespace sentinel {
-template <typename T>
-struct empty_key {
-  T value;
-};
-
-template <typename T>
-struct empty_value {
-  T value;
-};
-
-template <typename T>
-struct erased_key {
-  T value;
-};
-}  // namespace sentinel
 
 template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
 class dynamic_map;

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -815,6 +815,16 @@ class static_map {
     __device__ bool erase(key_type const& k,
                            Hash hash          = Hash{},
                            KeyEqual key_equal = KeyEqual{}) noexcept;
+
+    template <typename CG,
+              typename Hash     = cuco::detail::MurmurHash3_32<key_type>,
+              typename KeyEqual = thrust::equal_to<key_type>>
+    __device__ bool erase(
+      CG const& g, 
+      key_type const& k, 
+      Hash hash = Hash{}, 
+      KeyEqual key_equal = KeyEqual{}) noexcept;
+
   };  // class device mutable view
 
   /**

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -297,9 +297,9 @@ class static_map {
             typename KeyEqual = thrust::equal_to<key_type>>
   void erase(InputIt first,
              InputIt last,
-             Hash hash              = Hash{},
-             KeyEqual key_equal     = KeyEqual{},
-             cudaStream_t stream    = 0);
+             Hash hash           = Hash{},
+             KeyEqual key_equal  = KeyEqual{},
+             cudaStream_t stream = 0);
 
   /**
    * @brief Finds the values corresponding to all keys in the range `[first, last)`.
@@ -372,7 +372,7 @@ class static_map {
     using const_iterator = pair_atomic_type const*;
     using slot_type      = slot_type;
 
-    Key empty_key_sentinel_{};      ///< Key value that represents an empty slot
+    Key empty_key_sentinel_{};  ///< Key value that represents an empty slot
     Key erased_key_sentinel_{};
     Value empty_value_sentinel_{};  ///< Initial Value of empty slot
     pair_atomic_type* slots_{};     ///< Pointer to flat slots storage
@@ -579,8 +579,11 @@ class static_map {
     {
       return empty_value_sentinel_;
     }
-  
-    __host__ __device__ Key get_erased_key_sentinel() const noexcept { return erased_key_sentinel_; }
+
+    __host__ __device__ Key get_erased_key_sentinel() const noexcept
+    {
+      return erased_key_sentinel_;
+    }
 
     /**
      * @brief Returns iterator to the first slot.
@@ -693,7 +696,8 @@ class static_map {
                                             Key empty_key_sentinel,
                                             Value empty_value_sentinel,
                                             Key erased_key_sentinel) noexcept
-      : device_view_base{slots, capacity, empty_key_sentinel, empty_value_sentinel, erased_key_sentinel}
+      : device_view_base{
+          slots, capacity, empty_key_sentinel, empty_value_sentinel, erased_key_sentinel}
     {
     }
 
@@ -760,7 +764,6 @@ class static_map {
                                                  Key expected_key) noexcept;
 
    public:
-   
     template <typename CG>
     __device__ static device_mutable_view make_from_uninitialized_slots(
       CG g,
@@ -771,7 +774,8 @@ class static_map {
     {
       device_view_base::initialize_slots(
         g, slots, capacity, empty_key_sentinel, empty_value_sentinel);
-      return device_mutable_view{slots, capacity, empty_key_sentinel, empty_value_sentinel, empty_key_sentinel};
+      return device_mutable_view{
+        slots, capacity, empty_key_sentinel, empty_value_sentinel, empty_key_sentinel};
     }
 
     /* Features erase support */
@@ -786,7 +790,8 @@ class static_map {
     {
       device_view_base::initialize_slots(
         g, slots, capacity, empty_key_sentinel, empty_value_sentinel);
-      return device_mutable_view{slots, capacity, empty_key_sentinel, empty_value_sentinel, erased_key_sentinel};
+      return device_mutable_view{
+        slots, capacity, empty_key_sentinel, empty_value_sentinel, erased_key_sentinel};
     }
 
     /**
@@ -838,21 +843,20 @@ class static_map {
                            value_type const& insert_pair,
                            Hash hash          = Hash{},
                            KeyEqual key_equal = KeyEqual{}) noexcept;
-    
+
     template <typename Hash     = cuco::detail::MurmurHash3_32<key_type>,
               typename KeyEqual = thrust::equal_to<key_type>>
     __device__ bool erase(key_type const& k,
-                           Hash hash          = Hash{},
-                           KeyEqual key_equal = KeyEqual{}) noexcept;
+                          Hash hash          = Hash{},
+                          KeyEqual key_equal = KeyEqual{}) noexcept;
 
     template <typename CG,
               typename Hash     = cuco::detail::MurmurHash3_32<key_type>,
               typename KeyEqual = thrust::equal_to<key_type>>
-    __device__ bool erase(
-      CG const& g, 
-      key_type const& k, 
-      Hash hash = Hash{}, 
-      KeyEqual key_equal = KeyEqual{}) noexcept;
+    __device__ bool erase(CG const& g,
+                          key_type const& k,
+                          Hash hash          = Hash{},
+                          KeyEqual key_equal = KeyEqual{}) noexcept;
 
   };  // class device mutable view
 
@@ -889,7 +893,8 @@ class static_map {
                                     Key empty_key_sentinel,
                                     Value empty_value_sentinel,
                                     Key erased_key_sentinel) noexcept
-      : device_view_base{slots, capacity, empty_key_sentinel, empty_value_sentinel, erased_key_sentinel}
+      : device_view_base{
+          slots, capacity, empty_key_sentinel, empty_value_sentinel, erased_key_sentinel}
     {
     }
 
@@ -1171,7 +1176,8 @@ class static_map {
    */
   device_view get_device_view() const noexcept
   {
-    return device_view(slots_, capacity_, empty_key_sentinel_, empty_value_sentinel_, erased_key_sentinel_);
+    return device_view(
+      slots_, capacity_, empty_key_sentinel_, empty_value_sentinel_, erased_key_sentinel_);
   }
 
   /**
@@ -1181,7 +1187,8 @@ class static_map {
    */
   device_mutable_view get_device_mutable_view() const noexcept
   {
-    return device_mutable_view(slots_, capacity_, empty_key_sentinel_, empty_value_sentinel_, erased_key_sentinel_);
+    return device_mutable_view(
+      slots_, capacity_, empty_key_sentinel_, empty_value_sentinel_, erased_key_sentinel_);
   }
 
  private:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ endfunction(ConfigureTest)
 ###################################################################################################
 # - static_map tests ------------------------------------------------------------------------------
 ConfigureTest(STATIC_MAP_TEST
+    static_map/erase_test.cu
     static_map/custom_type_test.cu
     static_map/key_sentinel_test.cu
     static_map/shared_memory_test.cu

--- a/tests/static_map/custom_type_test.cu
+++ b/tests/static_map/custom_type_test.cu
@@ -104,9 +104,8 @@ TEMPLATE_TEST_CASE_SIG("User defined key and value type",
 
   constexpr std::size_t num      = 100;
   constexpr std::size_t capacity = num * 2;
-  cuco::static_map<Key, Value> map{capacity,
-                                   cuco::sentinel::empty_key{sentinel_key},
-                                   cuco::sentinel::empty_value{sentinel_value}};
+  cuco::static_map<Key, Value> map{
+    capacity, cuco::sentinel::empty_key{sentinel_key}, cuco::sentinel::empty_value{sentinel_value}};
 
   thrust::device_vector<Key> insert_keys(num);
   thrust::device_vector<Value> insert_values(num);

--- a/tests/static_map/custom_type_test.cu
+++ b/tests/static_map/custom_type_test.cu
@@ -105,8 +105,8 @@ TEMPLATE_TEST_CASE_SIG("User defined key and value type",
   constexpr std::size_t num      = 100;
   constexpr std::size_t capacity = num * 2;
   cuco::static_map<Key, Value> map{capacity,
-                                   cuco::sentinel::empty_key<Key>{sentinel_key},
-                                   cuco::sentinel::empty_value<Value>{sentinel_value}};
+                                   cuco::sentinel::empty_key{sentinel_key},
+                                   cuco::sentinel::empty_value{sentinel_value}};
 
   thrust::device_vector<Key> insert_keys(num);
   thrust::device_vector<Value> insert_values(num);

--- a/tests/static_map/custom_type_test.cu
+++ b/tests/static_map/custom_type_test.cu
@@ -104,8 +104,8 @@ TEMPLATE_TEST_CASE_SIG("User defined key and value type",
 
   constexpr std::size_t num      = 100;
   constexpr std::size_t capacity = num * 2;
-  cuco::static_map<Key, Value> map{capacity, 
-                                   cuco::sentinel::empty_key<Key>{sentinel_key}, 
+  cuco::static_map<Key, Value> map{capacity,
+                                   cuco::sentinel::empty_key<Key>{sentinel_key},
                                    cuco::sentinel::empty_value<Value>{sentinel_value}};
 
   thrust::device_vector<Key> insert_keys(num);

--- a/tests/static_map/custom_type_test.cu
+++ b/tests/static_map/custom_type_test.cu
@@ -104,8 +104,9 @@ TEMPLATE_TEST_CASE_SIG("User defined key and value type",
 
   constexpr std::size_t num      = 100;
   constexpr std::size_t capacity = num * 2;
-  cuco::static_map<Key, Value> map{
-    capacity, cuco::sentinel::empty_key{sentinel_key}, cuco::sentinel::empty_value{sentinel_value}};
+  cuco::static_map<Key, Value> map{capacity,
+                                   cuco::sentinel::empty_key<Key>{sentinel_key},
+                                   cuco::sentinel::empty_value<Value>{sentinel_value}};
 
   thrust::device_vector<Key> insert_keys(num);
   thrust::device_vector<Value> insert_values(num);

--- a/tests/static_map/custom_type_test.cu
+++ b/tests/static_map/custom_type_test.cu
@@ -104,7 +104,9 @@ TEMPLATE_TEST_CASE_SIG("User defined key and value type",
 
   constexpr std::size_t num      = 100;
   constexpr std::size_t capacity = num * 2;
-  cuco::static_map<Key, Value> map{capacity, sentinel_key, sentinel_value};
+  cuco::static_map<Key, Value> map{capacity, 
+                                   cuco::sentinel::empty_key<Key>{sentinel_key}, 
+                                   cuco::sentinel::empty_value<Value>{sentinel_value}};
 
   thrust::device_vector<Key> insert_keys(num);
   thrust::device_vector<Value> insert_values(num);

--- a/tests/static_map/duplicate_keys_test.cu
+++ b/tests/static_map/duplicate_keys_test.cu
@@ -34,7 +34,8 @@ TEMPLATE_TEST_CASE_SIG("Duplicate keys",
                        (int64_t, int64_t))
 {
   constexpr std::size_t num_keys{500'000};
-  cuco::static_map<Key, Value> map{num_keys * 2, -1, -1};
+  cuco::static_map<Key, Value> map{
+    num_keys * 2, cuco::sentinel::empty_key<Key>{-1}, cuco::sentinel::empty_value<Value>{-1}};
 
   auto m_view = map.get_device_mutable_view();
   auto view   = map.get_device_view();

--- a/tests/static_map/erase_test.cu
+++ b/tests/static_map/erase_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/static_map/erase_test.cu
+++ b/tests/static_map/erase_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/static_map/erase_test.cu
+++ b/tests/static_map/erase_test.cu
@@ -71,6 +71,19 @@ TEMPLATE_TEST_CASE_SIG(
     REQUIRE(cuco::test::all_of(d_keys_exist.begin(),
                                 d_keys_exist.end(),
                                 [] __device__(const bool key_found) { return key_found; }));
+
+    map.erase(d_keys.begin(), d_keys.begin() + num_keys/2);
+    map.contains(d_keys.begin(), d_keys.end(), d_keys_exist.begin());
+    
+    REQUIRE(cuco::test::none_of(d_keys_exist.begin(),
+                                d_keys_exist.begin() + num_keys/2,
+                                [] __device__(const bool key_found) { return key_found; }));
+
+    REQUIRE(cuco::test::all_of(d_keys_exist.begin() + num_keys/2,
+                                d_keys_exist.end(),
+                                [] __device__(const bool key_found) { return key_found; }));
+                            
+    
     
   }
 }

--- a/tests/static_map/erase_test.cu
+++ b/tests/static_map/erase_test.cu
@@ -38,7 +38,7 @@ TEMPLATE_TEST_CASE_SIG(
   thrust::device_vector<Value> d_values(num_keys);
   thrust::device_vector<bool> d_keys_exist(num_keys);
 
-  thrust::sequence(thrust::device, d_keys.begin(), d_keys.end());
+  thrust::sequence(thrust::device, d_keys.begin(), d_keys.end(), 1);
   thrust::sequence(thrust::device, d_values.begin(), d_values.end(), 1);
     
   auto pairs_begin =

--- a/tests/static_map/erase_test.cu
+++ b/tests/static_map/erase_test.cu
@@ -29,8 +29,8 @@ TEMPLATE_TEST_CASE_SIG("erase key", "", ((typename T), T), (int32_t), (int64_t))
   constexpr std::size_t num_keys = 1'000'000;
   constexpr std::size_t capacity = 1'100'000;
 
-  cuco::static_map<Key, Value> map{capacity, 
-                                   cuco::sentinel::empty_key<Key>{-1}, 
+  cuco::static_map<Key, Value> map{capacity,
+                                   cuco::sentinel::empty_key<Key>{-1},
                                    cuco::sentinel::empty_value<Value>{-1},
                                    cuco::sentinel::erased_key<Key>{-2}};
 

--- a/tests/static_map/erase_test.cu
+++ b/tests/static_map/erase_test.cu
@@ -28,7 +28,11 @@ TEMPLATE_TEST_CASE_SIG("erase key", "", ((typename T), T), (int32_t), (int64_t))
 
   constexpr std::size_t num_keys = 1'000'000;
   constexpr std::size_t capacity = 1'100'000;
-  cuco::static_map<Key, Value> map{capacity, -1, -1, -2};
+
+  cuco::static_map<Key, Value> map{capacity, 
+                                   cuco::sentinel::empty_key<Key>{-1}, 
+                                   cuco::sentinel::empty_value<Value>{-1},
+                                   cuco::sentinel::erased_key<Key>{-2}};
 
   auto m_view = map.get_device_mutable_view();
   auto view   = map.get_device_view();

--- a/tests/static_map/erase_test.cu
+++ b/tests/static_map/erase_test.cu
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch2/catch.hpp>
+#include <thrust/device_vector.h>
+
+#include <cuco/static_map.cuh>
+
+#include <utils.hpp>
+
+
+TEMPLATE_TEST_CASE_SIG(
+  "erase key", "", ((typename T), T), (int32_t), (int64_t))
+{
+  using Key   = T;
+  using Value = T;
+  
+  auto num_keys = 1E6;
+  cuco::static_map<Key, Value> map{num_keys * 2, -1, -1};
+
+  auto m_view = map.get_device_mutable_view();
+  auto view   = map.get_device_view();
+
+  thrust::device_vector<Key> d_keys(num_keys);
+  thrust::device_vector<Value> d_values(num_keys);
+  thrust::device_vector<bool> d_keys_exist(num_keys);
+
+  thrust::sequence(thrust::device, d_keys.begin(), d_keys.end());
+  thrust::sequence(thrust::device, d_values.begin(), d_values.end(), 1);
+    
+  auto pairs_begin =
+    thrust::make_zip_iterator(thrust::make_tuple(d_keys.begin(), d_values.begin()));
+
+  SECTION(
+    "Check basic insert/erase")
+  {
+    map.insert(pairs_begin, pairs_begin + num_keys);
+
+    REQUIRE(map.get_size() == num_keys);
+
+    map.erase(d_keys.begin(), d_keys.end());
+
+    REQUIRE(map.get_size() == 0);
+
+    map.contains(d_keys.begin(), d_keys.end(), d_keys_exist.begin());
+
+    REQUIRE(cuco::test::none_of(d_keys_exist.begin(),
+                                d_keys_exist.end(),
+                                [] __device__(const bool key_found) { return key_found; }));
+
+      /*
+    REQUIRE(cuco::test::all_of(
+      pairs_begin,
+      pairs_begin + num_keys,
+      [m_view] __device__(cuco::pair_type<Key, Value> const& pair) mutable {
+        return m_view.insert(pair);
+      }));
+
+    REQUIRE(cuco::test::all_of(
+      d_keys.begin(),
+      d_keys_begin + num_keys,
+      [m_view] __device__(cuco::key_type<Key> const& key) mutable {
+        return m_view.erase(key);
+      }));
+      */
+  }
+}

--- a/tests/static_map/erase_test.cu
+++ b/tests/static_map/erase_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,9 @@ TEMPLATE_TEST_CASE_SIG("erase key", "", ((typename T), T), (int32_t), (int64_t))
   using Key   = T;
   using Value = T;
 
-  unsigned long num_keys = 1'000'000;
-  cuco::static_map<Key, Value> map{num_keys * 1.1, -1, -1, -2};
+  constexpr std::size_t num_keys = 1'000'000;
+  constexpr std::size_t capacity = 1'100'000;
+  cuco::static_map<Key, Value> map{capacity, -1, -1, -2};
 
   auto m_view = map.get_device_mutable_view();
   auto view   = map.get_device_view();
@@ -81,16 +82,5 @@ TEMPLATE_TEST_CASE_SIG("erase key", "", ((typename T), T), (int32_t), (int64_t))
 
     map.erase(d_keys.begin() + num_keys / 2, d_keys.end());
     REQUIRE(map.get_size() == 0);
-
-    map.insert(pairs_begin, pairs_begin + num_keys / 2);
-    map.insert(pairs_begin + num_keys / 2, pairs_begin + num_keys);
-
-    map.erase(d_keys.begin(), d_keys.begin() + num_keys / 2);
-
-    map.contains(d_keys.begin() + num_keys / 2, d_keys.end(), d_keys_exist.begin());
-
-    REQUIRE(cuco::test::all_of(d_keys_exist.begin(),
-                               d_keys_exist.begin() + num_keys / 2,
-                               [] __device__(const bool key_found) { return key_found; }));
   }
 }

--- a/tests/static_map/key_sentinel_test.cu
+++ b/tests/static_map/key_sentinel_test.cu
@@ -36,9 +36,8 @@ TEMPLATE_TEST_CASE_SIG(
   using Value = T;
 
   constexpr std::size_t num_keys{SIZE};
-  cuco::static_map<Key, Value> map{SIZE * 2, 
-                                   cuco::sentinel::empty_key<Key>{-1}, 
-                                   cuco::sentinel::empty_value<Value>{-1}};
+  cuco::static_map<Key, Value> map{
+    SIZE * 2, cuco::sentinel::empty_key<Key>{-1}, cuco::sentinel::empty_value<Value>{-1}};
 
   auto m_view = map.get_device_mutable_view();
   auto view   = map.get_device_view();

--- a/tests/static_map/key_sentinel_test.cu
+++ b/tests/static_map/key_sentinel_test.cu
@@ -36,7 +36,9 @@ TEMPLATE_TEST_CASE_SIG(
   using Value = T;
 
   constexpr std::size_t num_keys{SIZE};
-  cuco::static_map<Key, Value> map{SIZE * 2, -1, -1};
+  cuco::static_map<Key, Value> map{SIZE * 2, 
+                                   cuco::sentinel::empty_key<Key>{-1}, 
+                                   cuco::sentinel::empty_value<Value>{-1}};
 
   auto m_view = map.get_device_mutable_view();
   auto view   = map.get_device_view();

--- a/tests/static_map/shared_memory_test.cu
+++ b/tests/static_map/shared_memory_test.cu
@@ -88,8 +88,8 @@ TEMPLATE_TEST_CASE_SIG("Shared memory static map",
   // operator yet
   std::vector<std::unique_ptr<MapType>> maps;
   for (std::size_t map_id = 0; map_id < number_of_maps; ++map_id) {
-    maps.push_back(std::make_unique<MapType>(map_capacity, cuco::sentinel::empty_key<Key>{-1}, 
-                                                           cuco::sentinel::empty_value<Value>{-1}));
+    maps.push_back(std::make_unique<MapType>(
+      map_capacity, cuco::sentinel::empty_key<Key>{-1}, cuco::sentinel::empty_value<Value>{-1}));
   }
 
   thrust::device_vector<bool> d_keys_exist(number_of_maps * elements_in_map);
@@ -155,9 +155,11 @@ __global__ void shared_memory_hash_table_kernel(bool* key_found)
   using map_type = typename cuco::static_map<K, V, cuda::thread_scope_block>::device_mutable_view;
   using find_map_type = typename cuco::static_map<K, V, cuda::thread_scope_block>::device_view;
   __shared__ typename map_type::slot_type slots[N];
-  auto map = map_type::make_from_uninitialized_slots(cg::this_thread_block(), &slots[0], N, 
-    cuco::sentinel::empty_key<K>{-1}, 
-    cuco::sentinel::empty_value<V>{-1});
+  auto map = map_type::make_from_uninitialized_slots(cg::this_thread_block(),
+                                                     &slots[0],
+                                                     N,
+                                                     cuco::sentinel::empty_key<K>{-1},
+                                                     cuco::sentinel::empty_value<V>{-1});
 
   auto g            = cg::this_thread_block();
   std::size_t index = threadIdx.x + blockIdx.x * blockDim.x;

--- a/tests/static_map/shared_memory_test.cu
+++ b/tests/static_map/shared_memory_test.cu
@@ -88,7 +88,8 @@ TEMPLATE_TEST_CASE_SIG("Shared memory static map",
   // operator yet
   std::vector<std::unique_ptr<MapType>> maps;
   for (std::size_t map_id = 0; map_id < number_of_maps; ++map_id) {
-    maps.push_back(std::make_unique<MapType>(map_capacity, -1, -1));
+    maps.push_back(std::make_unique<MapType>(map_capacity, cuco::sentinel::empty_key<Key>{-1}, 
+                                                           cuco::sentinel::empty_value<Value>{-1}));
   }
 
   thrust::device_vector<bool> d_keys_exist(number_of_maps * elements_in_map);
@@ -154,7 +155,9 @@ __global__ void shared_memory_hash_table_kernel(bool* key_found)
   using map_type = typename cuco::static_map<K, V, cuda::thread_scope_block>::device_mutable_view;
   using find_map_type = typename cuco::static_map<K, V, cuda::thread_scope_block>::device_view;
   __shared__ typename map_type::slot_type slots[N];
-  auto map = map_type::make_from_uninitialized_slots(cg::this_thread_block(), &slots[0], N, -1, -1);
+  auto map = map_type::make_from_uninitialized_slots(cg::this_thread_block(), &slots[0], N, 
+    cuco::sentinel::empty_key<K>{-1}, 
+    cuco::sentinel::empty_value<V>{-1});
 
   auto g            = cg::this_thread_block();
   std::size_t index = threadIdx.x + blockIdx.x * blockDim.x;

--- a/tests/static_map/stream_test.cu
+++ b/tests/static_map/stream_test.cu
@@ -33,7 +33,10 @@ TEMPLATE_TEST_CASE_SIG("Unique sequence of keys on given stream",
   cudaStreamCreate(&stream);
 
   constexpr std::size_t num_keys{500'000};
-  cuco::static_map<Key, Value> map{1'000'000, -1, -1, cuco::cuda_allocator<char>{}, stream};
+  cuco::static_map<Key, Value> map{1'000'000, 
+                                   cuco::sentinel::empty_key<Key>{-1}, 
+                                   cuco::sentinel::empty_value<Value>{-1}, 
+                                   cuco::cuda_allocator<char>{}, stream};
 
   auto m_view = map.get_device_mutable_view();
   auto view   = map.get_device_view();

--- a/tests/static_map/stream_test.cu
+++ b/tests/static_map/stream_test.cu
@@ -33,10 +33,11 @@ TEMPLATE_TEST_CASE_SIG("Unique sequence of keys on given stream",
   cudaStreamCreate(&stream);
 
   constexpr std::size_t num_keys{500'000};
-  cuco::static_map<Key, Value> map{1'000'000, 
-                                   cuco::sentinel::empty_key<Key>{-1}, 
-                                   cuco::sentinel::empty_value<Value>{-1}, 
-                                   cuco::cuda_allocator<char>{}, stream};
+  cuco::static_map<Key, Value> map{1'000'000,
+                                   cuco::sentinel::empty_key<Key>{-1},
+                                   cuco::sentinel::empty_value<Value>{-1},
+                                   cuco::cuda_allocator<char>{},
+                                   stream};
 
   auto m_view = map.get_device_mutable_view();
   auto view   = map.get_device_view();

--- a/tests/static_map/unique_sequence_test.cu
+++ b/tests/static_map/unique_sequence_test.cu
@@ -30,7 +30,9 @@ TEMPLATE_TEST_CASE_SIG("Unique sequence of keys",
                        (int64_t, int64_t))
 {
   constexpr std::size_t num_keys{500'000};
-  cuco::static_map<Key, Value> map{1'000'000, -1, -1};
+  cuco::static_map<Key, Value> map{1'000'000, 
+                                  cuco::sentinel::empty_key<Key>{-1}, 
+                                  cuco::sentinel::empty_value<Value>{-1}};
 
   auto m_view = map.get_device_mutable_view();
   auto view   = map.get_device_view();

--- a/tests/static_map/unique_sequence_test.cu
+++ b/tests/static_map/unique_sequence_test.cu
@@ -30,9 +30,8 @@ TEMPLATE_TEST_CASE_SIG("Unique sequence of keys",
                        (int64_t, int64_t))
 {
   constexpr std::size_t num_keys{500'000};
-  cuco::static_map<Key, Value> map{1'000'000, 
-                                  cuco::sentinel::empty_key<Key>{-1}, 
-                                  cuco::sentinel::empty_value<Value>{-1}};
+  cuco::static_map<Key, Value> map{
+    1'000'000, cuco::sentinel::empty_key<Key>{-1}, cuco::sentinel::empty_value<Value>{-1}};
 
   auto m_view = map.get_device_mutable_view();
   auto view   = map.get_device_view();


### PR DESCRIPTION
Erase functionality is now supported for `static_map` via the use of an additional sentinel value. Erased slots can be reused during future insertions. Users can specify that they want erase functionality by providing an `erased_key_sentinel` during construction. Included below are some plots showing the performance of `erase` and demonstrating that neither `insert` nor `find` incur a performance regression as a result of adding erase support. For each plot, `num_keys=1E8`.
![Insert throughput vs  load_factor](https://user-images.githubusercontent.com/46684817/158914118-4002af42-05c6-4a93-a2aa-09a4b949d9ed.png)
![Search-all throughput vs  load_factor](https://user-images.githubusercontent.com/46684817/158914134-eb41810b-f433-41d0-b86d-69b340b9fa75.png)
![Erase-all Throughput vs  Load factor (Gaussian 32-bit K_V pairs)](https://user-images.githubusercontent.com/46684817/158914138-ce68a07b-3d1b-4f8a-b582-c2554c75e55d.png)
![Erase-all Throughput vs  Load factor (Gaussian 64-bit K_V pairs)](https://user-images.githubusercontent.com/46684817/158914142-90319994-294e-4d66-843e-84bd61101b97.png)
![Erase-none vs  Load Factor (unique 64-bit K_V pairs)](https://user-images.githubusercontent.com/46684817/158914155-8efd4e6b-bc60-47f4-88fd-1214b79cc6b9.png)
![Erase-none vs  Load Factor (unique 32-bit K_V pairs)](https://user-images.githubusercontent.com/46684817/158914162-40d79f79-00cc-476b-8aab-698f52f448ef.png)
