### PR TITLE
[FIX] Get Thrust via `rapids_cpm_thrust`

### DIFF
--- a/cmake/thirdparty/get_thrust.cmake
+++ b/cmake/thirdparty/get_thrust.cmake
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -13,17 +13,10 @@
 # =============================================================================
 
 # Use CPM to find or clone thrust
-function(find_and_configure_thrust VERSION)
-    rapids_cpm_find(
-        Thrust             ${VERSION}
-        BUILD_EXPORT_SET   cuco-exports
-        CPM_ARGS
-            GIT_REPOSITORY https://github.com/NVIDIA/thrust.git
-            GIT_TAG        ${VERSION}
-            GIT_SHALLOW    TRUE
-            OPTIONS        "THRUST_INSTALL OFF"
-    )
-    thrust_create_target(cuco::Thrust FROM_OPTIONS)
+function(find_and_configure_thrust)
+    include(${rapids-cmake-dir}/cpm/thrust.cmake)
+    rapids_cpm_thrust(NAMESPACE cuco
+                      BUILD_EXPORT_SET cuco-exports)
 endfunction()
 
-find_and_configure_thrust(1.15.0)
+find_and_configure_thrust()


### PR DESCRIPTION
* Get Thrust via `rapids_cpm_thrust`
* Don't immediately create the `cuco::Thrust` target, as this will be done by `cuco-config.cmake`

Fix an issue where including two projects that both use CPM to load `cuco` fails to configure with this error:
```cmake
CMake Error at thrust-config.cmake:176 (add_library):
  add_library cannot create imported target "cuco::Thrust" because another
  target with the same name already exists.
```
