### PR TITLE
Move to use rapids-cmake 22.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 #=============================================================================
 cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
-file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.02/RAPIDS.cmake
+file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.04/RAPIDS.cmake
      ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
 include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
 


### PR DESCRIPTION
22.04 includes better handling for version values "0.Y" and "X.0" which cuco uses.

Currently cuco will generate a `cuco-config-version.cmake` with a version value of ".1" which is invalid. By moving
to 22.04 cuco will generate the correct version value of "0.0.1"
