### PR TITLE
Add `static_map::retrieve_all`

### DIFF
--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -20,7 +20,6 @@
 #include <thrust/copy.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/tuple.h>
 
 namespace cuco {
 

--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -157,7 +157,7 @@ std::pair<KeyOut, ValueOut> static_map<Key, Value, Scope, Allocator>::retrieve_a
   auto const zipped_out_end =
     thrust::copy_if(thrust::cuda::par.on(stream), begin, end, zipped_out_begin, filled);
   auto const num = std::distance(zipped_out_begin, zipped_out_end);
-  return std::pair(keys_out + num, values_out + num);
+  return std::make_pair(keys_out + num, values_out + num);
 }
 
 template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>

--- a/include/cuco/detail/utils.cuh
+++ b/include/cuco/detail/utils.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,28 @@ __device__ __forceinline__ int32_t count_least_significant_bits(uint32_t x, int3
 {
   return __popc(x & (1 << n) - 1);
 }
+
+/**
+ * @brief Converts `cuco::pair` to `thrust::tuple` to allow assigning to a zip iterator.
+ */
+template <typename Key, typename Value>
+struct slot_to_tuple {
+  template <typename S>
+  __device__ thrust::tuple<Key, Value> operator()(S const& s)
+  {
+    return thrust::tuple<Key, Value>(s.first, s.second);
+  }
+};
+
+template <typename Key>
+struct slot_is_filled {
+  Key empty_key_sentinel;
+  template <typename S>
+  __device__ bool operator()(S const& s)
+  {
+    return thrust::get<0>(s) != empty_key_sentinel;
+  }
+};
 
 }  // namespace detail
 }  // namespace cuco

--- a/include/cuco/detail/utils.cuh
+++ b/include/cuco/detail/utils.cuh
@@ -39,6 +39,9 @@ struct slot_to_tuple {
   }
 };
 
+/**
+ * @brief Device functor returning whether the input slot `s` is filled.
+ */
 template <typename Key>
 struct slot_is_filled {
   Key empty_key_sentinel;

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -303,7 +303,7 @@ class static_map {
    * consistent between subsequent calls to `retrieve_all`.
    *
    * Behavior is undefined if the range beginning at `keys_out` or `values_out` is less than
-   * `size()`
+   * `get_size()`
    *
    * @tparam KeyOut Device accessible random access output iterator whose `value_type` is
    * convertible from `key_type`.
@@ -312,9 +312,12 @@ class static_map {
    * @param keys_out Beginning output iterator for keys
    * @param values_out Beginning output iterator for values
    * @param stream CUDA stream used for this operation
+   * @return Pair of iterators indicating the last elements in the output
    */
   template <typename KeyOut, typename ValueOut>
-  void retrieve_all(KeyOut keys_out, ValueOut values_out, cudaStream_t stream = 0);
+  std::pair<KeyOut, ValueOut> retrieve_all(KeyOut keys_out,
+                                           ValueOut values_out,
+                                           cudaStream_t stream = 0);
 
   /**
    * @brief Indicates whether the keys in the range

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -302,8 +302,7 @@ class static_map {
    * The order in which keys are returned is implementation defined and not guaranteed to be
    * consistent between subsequent calls to `retrieve_all`.
    *
-   * Behavior is undefined if the range beginning at `keys_out` or `values_out` is not large enough
-   * to contain the number of keys in the map.
+   * Behavior is undefined if the range beginning at `keys_out` or `values_out` is less than `size()`
    *
    * @tparam KeyOut Device accessible random access output iterator whose `value_type` is
    * convertible from `key_type`.

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -297,6 +297,26 @@ class static_map {
             cudaStream_t stream = 0);
 
   /**
+   * @brief Retrieves all of the keys and their associated values.
+   *
+   * The order in which keys are returned is implementation defined and not guaranteed to be
+   * consistent between subsequent calls to `retrieve_all`.
+   *
+   * Behavior is undefined if the range beginning at `keys_out` or `values_out` is not large enough
+   * to contain the number of keys in the map.
+   *
+   * @tparam KeyOut Device accessible random access output iterator whose `value_type` is
+   * convertible from `key_type`.
+   * @tparam ValueOut Device accesible random access output iterator whose `value_type` is
+   * convertible from `mapped_type`.
+   * @param keys_out Beginning output iterator for keys
+   * @param values_out Beginning output iterator for values
+   * @param stream CUDA stream used for this operation
+   */
+  template <typename KeyOut, typename ValueOut>
+  void retrieve_all(KeyOut keys_out, ValueOut values_out, cudaStream_t stream = 0);
+
+  /**
    * @brief Indicates whether the keys in the range
    * `[first, last)` are contained in the map.
    *

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -302,7 +302,8 @@ class static_map {
    * The order in which keys are returned is implementation defined and not guaranteed to be
    * consistent between subsequent calls to `retrieve_all`.
    *
-   * Behavior is undefined if the range beginning at `keys_out` or `values_out` is less than `size()`
+   * Behavior is undefined if the range beginning at `keys_out` or `values_out` is less than
+   * `size()`
    *
    * @tparam KeyOut Device accessible random access output iterator whose `value_type` is
    * convertible from `key_type`.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -55,6 +55,7 @@ endfunction(ConfigureTest)
 # - static_map tests ------------------------------------------------------------------------------
 ConfigureTest(STATIC_MAP_TEST
     static_map/custom_type_test.cu
+    static_map/duplicate_keys_test.cu
     static_map/key_sentinel_test.cu
     static_map/shared_memory_test.cu
     static_map/stream_test.cu

--- a/tests/static_map/duplicate_keys_test.cu
+++ b/tests/static_map/duplicate_keys_test.cu
@@ -59,7 +59,7 @@ TEMPLATE_TEST_CASE_SIG("Duplicate keys",
     auto values_begin = thrust::make_discard_iterator();
 
     // Retrieve all from an empty map
-    auto [empty_key_end, _] = map.retrieve_all(unique_keys.begin(), values_begin);
+    auto empty_key_end = map.retrieve_all(unique_keys.begin(), values_begin).first;
     REQUIRE(std::distance(unique_keys.begin(), empty_key_end) == 0);
 
     map.insert(pairs_begin, pairs_begin + num_keys);
@@ -67,7 +67,7 @@ TEMPLATE_TEST_CASE_SIG("Duplicate keys",
     auto const num_entries = map.get_size();
     REQUIRE(num_entries == gold);
 
-    auto [key_out_end, value_out_end] = map.retrieve_all(unique_keys.begin(), values_begin);
+    auto key_out_end = map.retrieve_all(unique_keys.begin(), values_begin).first;
     REQUIRE(std::distance(unique_keys.begin(), key_out_end) == gold);
 
     thrust::sort(thrust::device, unique_keys.begin(), unique_keys.end());

--- a/tests/static_map/duplicate_keys_test.cu
+++ b/tests/static_map/duplicate_keys_test.cu
@@ -19,6 +19,7 @@
 #include <cuco/static_map.cuh>
 
 #include <thrust/device_vector.h>
+#include <thrust/functional.h>
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/sort.h>
 
@@ -68,7 +69,7 @@ TEMPLATE_TEST_CASE_SIG("Duplicate keys",
     REQUIRE(cuco::test::equal(unique_keys.begin(),
                               unique_keys.end(),
                               thrust::make_counting_iterator<Key>(0),
-                              [] __device__(Key const lhs, Key const rhs) { return lhs == rhs; }));
+                              thrust::equal_to<Key>{}));
   }
 
   SECTION("Tests of contains")

--- a/tests/static_map/duplicate_keys_test.cu
+++ b/tests/static_map/duplicate_keys_test.cu
@@ -63,9 +63,10 @@ TEMPLATE_TEST_CASE_SIG("Duplicate keys",
     thrust::device_vector<Key> unique_keys(num_entries);
     auto values_begin = thrust::make_discard_iterator();
 
-    map.retrieve_all(unique_keys.begin(), values_begin);
-    thrust::sort(thrust::device, unique_keys.begin(), unique_keys.end());
+    auto [key_out_end, value_out_end] = map.retrieve_all(unique_keys.begin(), values_begin);
+    REQUIRE(std::distance(unique_keys.begin(), key_out_end) == map.get_size());
 
+    thrust::sort(thrust::device, unique_keys.begin(), unique_keys.end());
     REQUIRE(cuco::test::equal(unique_keys.begin(),
                               unique_keys.end(),
                               thrust::make_counting_iterator<Key>(0),

--- a/tests/static_map/duplicate_keys_test.cu
+++ b/tests/static_map/duplicate_keys_test.cu
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <utils.hpp>
+
+#include <cuco/static_map.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/iterator/discard_iterator.h>
+#include <thrust/sort.h>
+
+#include <catch2/catch.hpp>
+
+TEMPLATE_TEST_CASE_SIG("Duplicate keys",
+                       "",
+                       ((typename Key, typename Value), Key, Value),
+                       (int32_t, int32_t),
+                       (int32_t, int64_t),
+                       (int64_t, int32_t),
+                       (int64_t, int64_t))
+{
+  constexpr std::size_t num_keys{500'000};
+  cuco::static_map<Key, Value> map{num_keys * 2, -1, -1};
+
+  auto m_view = map.get_device_mutable_view();
+  auto view   = map.get_device_view();
+
+  thrust::device_vector<Key> d_keys(num_keys);
+  thrust::device_vector<Value> d_values(num_keys);
+
+  thrust::sequence(thrust::device, d_keys.begin(), d_keys.end());
+  thrust::sequence(thrust::device, d_values.begin(), d_values.end());
+
+  auto pairs_begin = thrust::make_transform_iterator(
+    thrust::make_counting_iterator<int>(0),
+    [] __device__(auto i) { return cuco::pair_type<Key, Value>(i / 2, i); });
+
+  thrust::device_vector<Value> d_results(num_keys);
+  thrust::device_vector<bool> d_contained(num_keys);
+
+  // bulk function test cases
+  SECTION("Retrieve all entries after insertion")
+  {
+    map.insert(pairs_begin, pairs_begin + num_keys);
+
+    auto const num_entries = map.get_size();
+    REQUIRE(num_entries == num_keys / 2);
+
+    thrust::device_vector<Key> unique_keys(num_entries);
+    auto values_begin = thrust::make_discard_iterator();
+
+    map.retrieve_all(unique_keys.begin(), values_begin);
+    thrust::sort(thrust::device, unique_keys.begin(), unique_keys.end());
+
+    REQUIRE(cuco::test::equal(unique_keys.begin(),
+                              unique_keys.end(),
+                              thrust::make_counting_iterator<Key>(0),
+                              [] __device__(Key const lhs, Key const rhs) { return lhs == rhs; }));
+  }
+
+  SECTION("Tests of contains")
+  {
+    map.insert(pairs_begin, pairs_begin + num_keys);
+    map.contains(d_keys.begin(), d_keys.end(), d_contained.begin());
+
+    REQUIRE(cuco::test::all_of(d_contained.begin(),
+                               d_contained.begin() + num_keys / 2,
+                               [] __device__(bool const& b) { return b; }));
+
+    REQUIRE(cuco::test::none_of(d_contained.begin() + num_keys / 2,
+                                d_contained.end(),
+                                [] __device__(bool const& b) { return b; }));
+  }
+}

--- a/tests/utils.hpp
+++ b/tests/utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,11 @@
 
 #pragma once
 
+#include <utils.cuh>
+
 #include <thrust/functional.h>
 
-#include <utils.cuh>
+#include <cooperative_groups.h>
 
 namespace cuco {
 namespace test {


### PR DESCRIPTION
This PR adds a new API: `static_map::retrieve_all` which retrieves all entries in `static_map`. It could be used to help `cudf::groupby::hash` refactoring.