### PR TITLE
Make sentinel constructors constexpr

### DIFF
--- a/include/cuco/sentinel.cuh
+++ b/include/cuco/sentinel.cuh
@@ -21,19 +21,19 @@ namespace sentinel {
 
 template <typename T>
 struct empty_key {
-  constexpr empty_key(T v) : value{v} {}
+  __host__ __device__ constexpr empty_key(T v) : value{v} {}
   T value;
 };
 
 template <typename T>
 struct empty_value {
-  constexpr empty_value(T v) : value{v} {}
+  __host__ __device__ constexpr empty_value(T v) : value{v} {}
   T value;
 };
 
 template <typename T>
 struct erased_key {
-  constexpr erased_key(T v) : value{v} {}
+  __host__ __device__ constexpr erased_key(T v) : value{v} {}
   T value;
 };
 

--- a/include/cuco/sentinel.hpp
+++ b/include/cuco/sentinel.hpp
@@ -21,19 +21,19 @@ namespace sentinel {
 
 template <typename T>
 struct empty_key {
-  __host__ __device__ empty_key(T v) : value{v} {}
+  constexpr empty_key(T v) : value{v} {}
   T value;
 };
 
 template <typename T>
 struct empty_value {
-  __host__ __device__ empty_value(T v) : value{v} {}
+  constexpr empty_value(T v) : value{v} {}
   T value;
 };
 
 template <typename T>
 struct erased_key {
-  __host__ __device__ erased_key(T v) : value{v} {}
+  constexpr erased_key(T v) : value{v} {}
   T value;
 };
 

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -39,7 +39,7 @@
 #include <cuco/detail/hash_functions.cuh>
 #include <cuco/detail/pair.cuh>
 #include <cuco/detail/static_map_kernels.cuh>
-#include <cuco/sentinel.hpp>
+#include <cuco/sentinel.cuh>
 
 namespace cuco {
 


### PR DESCRIPTION
This is a small improvement by making all sentinel constructors `constexpr`. It renames `sentinel.hpp` as `sentinel.cuh` since the file contains device code.