### PR TITLE
Cleanup: remove redundant `slot_is_filled` definition

### DIFF
--- a/include/cuco/detail/static_multimap/static_multimap.inl
+++ b/include/cuco/detail/static_multimap/static_multimap.inl
@@ -854,9 +854,9 @@ std::size_t static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::get_si
   cudaStream_t stream) const noexcept
 {
   auto begin  = thrust::make_transform_iterator(raw_slots(), detail::slot_to_tuple<Key, Value>{});
-  auto filled = cuco::detail::slot_is_filled<Key>{empty_key_sentinel_};
+  auto filled = cuco::detail::slot_is_filled<Key>{get_empty_key_sentinel()};
 
-  return thrust::count_if(thrust::cuda::par.on(stream), begin, begin + capacity_, filled);
+  return thrust::count_if(thrust::cuda::par.on(stream), begin, begin + get_capacity(), filled);
 }
 
 template <typename Key,

--- a/include/cuco/detail/static_multimap/static_multimap.inl
+++ b/include/cuco/detail/static_multimap/static_multimap.inl
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <cuco/detail/utils.cuh>
 #include <cuco/detail/utils.hpp>
 
 #include <thrust/count.h>
@@ -21,18 +22,6 @@
 #include <thrust/tuple.h>
 
 #include <iterator>
-
-namespace {
-/**
- * @brief Device functor used to determine if a slot is filled.
- */
-template <typename Key>
-struct slot_is_filled {
-  slot_is_filled(Key s) : empty_key_sentinel{s} {}
-  __device__ __forceinline__ bool operator()(Key const& k) { return k != empty_key_sentinel; }
-  Key empty_key_sentinel;
-};
-}  // anonymous namespace
 
 namespace cuco {
 
@@ -864,9 +853,8 @@ template <typename Key,
 std::size_t static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::get_size(
   cudaStream_t stream) const noexcept
 {
-  auto begin = thrust::make_transform_iterator(
-    raw_slots(), [] __device__(cuco::pair_type<Key, Value> const& pair) { return pair.first; });
-  slot_is_filled<Key> filled(empty_key_sentinel_);
+  auto begin  = thrust::make_transform_iterator(raw_slots(), detail::slot_to_tuple<Key, Value>{});
+  auto filled = cuco::detail::slot_is_filled<Key>{empty_key_sentinel_};
 
   return thrust::count_if(thrust::cuda::par.on(stream), begin, begin + capacity_, filled);
 }


### PR DESCRIPTION
This PR removes the redundant definition of `slot_is_filled` in multimap implementation since the functor has been moved to `detail/util.cuh` in #150 . 

<!--

Thank you for contributing to cuCollections :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
