### PR TITLE
Update bitwise_compare to check cuco::is_bitwise_comparable

### DIFF
--- a/include/cuco/detail/bitwise_compare.cuh
+++ b/include/cuco/detail/bitwise_compare.cuh
@@ -69,8 +69,10 @@ struct bitwise_compare_impl<8> {
 template <typename T>
 __host__ __device__ constexpr bool bitwise_compare(T const& lhs, T const& rhs)
 {
-  static_assert(cuco::is_bitwise_comparable_v<T>,
-                "Bitwise compared objects must have unique object representations or be explicitly declared as safe for bitwise comparison via specialization of cuco::is_bitwise_comparable_v.");
+  static_assert(
+    cuco::is_bitwise_comparable_v<T>,
+    "Bitwise compared objects must have unique object representations or be explicitly declared as "
+    "safe for bitwise comparison via specialization of cuco::is_bitwise_comparable_v.");
   return detail::bitwise_compare_impl<sizeof(T)>::compare(reinterpret_cast<char const*>(&lhs),
                                                           reinterpret_cast<char const*>(&rhs));
 }

--- a/include/cuco/detail/bitwise_compare.cuh
+++ b/include/cuco/detail/bitwise_compare.cuh
@@ -67,10 +67,10 @@ struct bitwise_compare_impl<8> {
  * @return If the bits in the object representations of lhs and rhs are identical.
  */
 template <typename T>
-__host__ __device__ bool bitwise_compare(T const& lhs, T const& rhs)
+__host__ __device__ constexpr bool bitwise_compare(T const& lhs, T const& rhs)
 {
-  static_assert(std::has_unique_object_representations_v<T>,
-                "Bitwise compared objects must have unique object representation.");
+  static_assert(cuco::is_bitwise_comparable_v<T>,
+                "Bitwise compared objects must have unique object representations or be explicitly declared as safe for bitwise comparison via specialization of cuco::is_bitwise_comparable_v.");
   return detail::bitwise_compare_impl<sizeof(T)>::compare(reinterpret_cast<char const*>(&lhs),
                                                           reinterpret_cast<char const*>(&rhs));
 }


### PR DESCRIPTION
The `bitwise_compare` function should check for the cuco-specific `is_bitwise_comparable_v` trait instead of the `std::has_unique_object_representations`. 

The former derives from the latter, but the latter also allows user-defined specializations. We must use the latter to ensure user-defined specializations enable `bitwise_compare`.
