### PR TITLE
Add vscode .devcontainer directory to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__
 *.dylib
 .cache
 .vscode
+.devcontainer
 *.code-workspace
 *.swp
 *.pytest_cache


### PR DESCRIPTION
Just a one-liner to get rid of this pesky dirty working tree when working with [vscode devcontainers](https://code.visualstudio.com/docs/remote/containers).