### PR TITLE
Move macros to `detail/__config` header … once again

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -37,10 +37,3 @@ ConfigureExample(STATIC_MAP_HOST_BULK_EXAMPLE "${CMAKE_CURRENT_SOURCE_DIR}/stati
 ConfigureExample(STATIC_MAP_DEVICE_SIDE_EXAMPLE "${CMAKE_CURRENT_SOURCE_DIR}/static_map/device_view_example.cu")
 ConfigureExample(STATIC_MAP_CUSTOM_TYPE_EXAMPLE "${CMAKE_CURRENT_SOURCE_DIR}/static_map/custom_type_example.cu")
 ConfigureExample(STATIC_MULTIMAP_HOST_BULK_EXAMPLE "${CMAKE_CURRENT_SOURCE_DIR}/static_multimap/host_bulk_example.cu")
-
-foreach(arch IN LISTS CMAKE_CUDA_ARCHITECTURES)
-    if("${arch}" MATCHES "^6")
-      target_compile_definitions(STATIC_MAP_CUSTOM_TYPE_EXAMPLE PRIVATE CUCO_NO_INDEPENDENT_THREADS)
-      break()
-    endif()
-endforeach()

--- a/examples/static_map/custom_type_example.cu
+++ b/examples/static_map/custom_type_example.cu
@@ -23,7 +23,7 @@
 #include <thrust/transform.h>
 
 // User-defined key type
-#ifdef CUCO_NO_INDEPENDENT_THREADS
+#if !defined(CUCO_HAS_INDEPENDENT_THREADS)
 struct custom_key_type {
   int32_t a;
   int32_t b;

--- a/include/cuco/detail/__config
+++ b/include/cuco/detail/__config
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ #pragma once
+
+ #include <nv/target>
+
+// WAR for libcudacxx/296
+#define CUCO_CUDA_MINIMUM_ARCH _NV_FIRST_ARG(__CUDA_ARCH_LIST__)
+
+#if defined(CUDART_VERSION) && (CUDART_VERSION >= 11000) && (CUCO_CUDA_MINIMUM_ARCH >= 700)
+#define CUCO_HAS_CUDA_BARRIER
+#endif
+
+#if defined(CUDART_VERSION) && (CUDART_VERSION >= 11100)
+#define CUCO_HAS_CG_MEMCPY_ASYNC
+#endif
+
+#if (CUCO_CUDA_MINIMUM_ARCH >= 700)
+#define CUCO_HAS_INDEPENDENT_THREADS
+#endif

--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#include <cuco/detail/__config>
 #include <cuco/detail/bitwise_compare.cuh>
 #include <cuco/detail/error.hpp>
 #include <cuco/detail/utils.cuh>
@@ -403,7 +402,7 @@ __device__ bool static_map<Key, Value, Scope, Allocator>::device_mutable_view::i
         }
 
         if constexpr (not cuco::detail::is_packable<value_type>()) {
-#if !defined(CUCO_HAS_INDEPENDENT_THREADS)
+#if (_CUDA_ARCH__ < 700)
           return cas_dependent_write(current_slot, insert_pair, key_equal, existing_key);
 #else
           return back_to_back_cas(current_slot, insert_pair, key_equal, existing_key);
@@ -460,7 +459,7 @@ __device__ bool static_map<Key, Value, Scope, Allocator>::device_mutable_view::i
         }
         // Otherwise, two back-to-back CAS operations
         else {
-#if !defined(CUCO_HAS_INDEPENDENT_THREADS)
+#if (__CUDA_ARCH__ < 700)
           status = cas_dependent_write(current_slot, insert_pair, key_equal, existing_key);
 #else
           status = back_to_back_cas(current_slot, insert_pair, key_equal, existing_key);

--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <cuco/detail/__config>
 #include <cuco/detail/bitwise_compare.cuh>
 #include <cuco/detail/error.hpp>
 #include <cuco/detail/utils.cuh>
@@ -402,7 +403,7 @@ __device__ bool static_map<Key, Value, Scope, Allocator>::device_mutable_view::i
         }
 
         if constexpr (not cuco::detail::is_packable<value_type>()) {
-#if __CUDA_ARCH__ < 700
+#if !defined(CUCO_HAS_INDEPENDENT_THREADS)
           return cas_dependent_write(current_slot, insert_pair, key_equal, existing_key);
 #else
           return back_to_back_cas(current_slot, insert_pair, key_equal, existing_key);
@@ -459,7 +460,7 @@ __device__ bool static_map<Key, Value, Scope, Allocator>::device_mutable_view::i
         }
         // Otherwise, two back-to-back CAS operations
         else {
-#if __CUDA_ARCH__ < 700
+#if !defined(CUCO_HAS_INDEPENDENT_THREADS)
           status = cas_dependent_write(current_slot, insert_pair, key_equal, existing_key);
 #else
           status = back_to_back_cas(current_slot, insert_pair, key_equal, existing_key);

--- a/include/cuco/detail/static_multimap/device_view_impl.inl
+++ b/include/cuco/detail/static_multimap/device_view_impl.inl
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <cuco/detail/__config>
 #include <cuco/detail/bitwise_compare.cuh>
 #include <cuco/detail/static_multimap/kernels.cuh>
 #include <cuco/detail/utils.cuh>
@@ -420,7 +421,7 @@ class static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_mutab
         uint32_t src_lane = __ffs(window_contains_empty) - 1;
 
         if (g.thread_rank() == src_lane) {
-#if __CUDA_ARCH__ < 700
+#if !defined(CUCO_HAS_INDEPENDENT_THREADS)
           status = cas_dependent_write(current_slot, insert_pair);
 #else
           status = back_to_back_cas(current_slot, insert_pair);

--- a/include/cuco/detail/static_multimap/device_view_impl.inl
+++ b/include/cuco/detail/static_multimap/device_view_impl.inl
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#include <cuco/detail/__config>
 #include <cuco/detail/bitwise_compare.cuh>
 #include <cuco/detail/static_multimap/kernels.cuh>
 #include <cuco/detail/utils.cuh>
@@ -421,7 +420,7 @@ class static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_mutab
         uint32_t src_lane = __ffs(window_contains_empty) - 1;
 
         if (g.thread_rank() == src_lane) {
-#if !defined(CUCO_HAS_INDEPENDENT_THREADS)
+#if (__CUDA_ARCH__ < 700)
           status = cas_dependent_write(current_slot, insert_pair);
 #else
           status = back_to_back_cas(current_slot, insert_pair);

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cuco/allocator.hpp>
+#include <cuco/detail/__config>
 #include <cuco/detail/error.hpp>
 #include <cuco/detail/hash_functions.cuh>
 #include <cuco/detail/pair.cuh>
@@ -27,10 +28,6 @@
 #include <thrust/functional.h>
 
 #include <cuda/std/atomic>
-#if defined(CUDART_VERSION) && (CUDART_VERSION >= 11000) && defined(__CUDA_ARCH__) && \
-  (__CUDA_ARCH__ >= 700)
-#define CUCO_HAS_CUDA_BARRIER
-#endif
 
 #if defined(CUCO_HAS_CUDA_BARRIER)
 #include <cuda/barrier>
@@ -156,7 +153,7 @@ class static_map {
   using counter_allocator_type = typename std::allocator_traits<Allocator>::rebind_alloc<
     atomic_ctr_type>;  ///< Type of the allocator to (de)allocate atomic counters
 
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 700)
+#if !defined(CUCO_HAS_INDEPENDENT_THREADS)
   static_assert(atomic_key_type::is_always_lock_free,
                 "A key type larger than 8B is supported for only sm_70 and up.");
   static_assert(atomic_mapped_type::is_always_lock_free,

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cuco/allocator.hpp>
+#include <cuco/detail/__config>
 #include <cuco/detail/error.hpp>
 #include <cuco/detail/prime.hpp>
 #include <cuco/probe_sequences.cuh>
@@ -26,15 +27,6 @@
 #include <thrust/functional.h>
 
 #include <cuda/std/atomic>
-#if defined(CUDART_VERSION) && (CUDART_VERSION >= 11000) && defined(__CUDA_ARCH__) && \
-  (__CUDA_ARCH__ >= 700)
-#define CUCO_HAS_CUDA_BARRIER
-#endif
-
-// cg::memcpy_aysnc is supported for CUDA 11.1 and up
-#if defined(CUDART_VERSION) && (CUDART_VERSION >= 11100)
-#define CUCO_HAS_CG_MEMCPY_ASYNC
-#endif
 
 #if defined(CUCO_HAS_CUDA_BARRIER)
 #include <cuda/barrier>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,13 +64,6 @@ ConfigureTest(STATIC_MAP_TEST
     static_map/stream_test.cu
     static_map/unique_sequence_test.cu)
 
-foreach(arch IN LISTS CMAKE_CUDA_ARCHITECTURES)
-    if("${arch}" MATCHES "^6")
-      target_compile_definitions(STATIC_MAP_TEST PRIVATE CUCO_NO_INDEPENDENT_THREADS)
-      break()
-    endif()
-endforeach()
-
 ###################################################################################################
 # - dynamic_map tests -----------------------------------------------------------------------------
 ConfigureTest(DYNAMIC_MAP_TEST

--- a/tests/static_map/custom_type_test.cu
+++ b/tests/static_map/custom_type_test.cu
@@ -100,7 +100,8 @@ struct custom_key_equals {
 TEMPLATE_TEST_CASE_SIG("User defined key and value type",
                        "",
                        ((typename Key, typename Value), Key, Value),
-#ifndef CUCO_NO_INDEPENDENT_THREADS  // Key type larger than 8B only supported for sm_70 and up
+#if defined(CUCO_HAS_INDEPENDENT_THREADS)  // Key type larger than 8B only supported for sm_70 and
+                                           // up
                        (key_pair_type<int64_t>, value_pair_type<int32_t>),
                        (key_pair_type<int64_t>, value_pair_type<int64_t>),
                        (large_key_type<int32_t>, value_pair_type<int32_t>),

--- a/tests/static_map/heterogeneous_lookup_test.cu
+++ b/tests/static_map/heterogeneous_lookup_test.cu
@@ -81,7 +81,8 @@ struct custom_key_equal {
 
 TEMPLATE_TEST_CASE("Heterogeneous lookup",
                    "",
-#ifndef CUCO_NO_INDEPENDENT_THREADS  // Key type larger than 8B only supported for sm_70 and up
+#if defined(CUCO_HAS_INDEPENDENT_THREADS)  // Key type larger than 8B only supported for sm_70 and
+                                           // up
                    int64_t,
 #endif
                    int32_t)

--- a/tests/static_multimap/heterogeneous_lookup_test.cu
+++ b/tests/static_multimap/heterogeneous_lookup_test.cu
@@ -81,7 +81,8 @@ struct custom_key_equal {
 
 TEMPLATE_TEST_CASE("Heterogeneous lookup",
                    "",
-#ifndef CUCO_NO_INDEPENDENT_THREADS  // Key type larger than 8B only supported for sm_70 and up
+#if defined(CUCO_HAS_INDEPENDENT_THREADS)  // Key type larger than 8B only supported for sm_70 and
+                                           // up
                    int64_t,
 #endif
                    int32_t)


### PR DESCRIPTION
Fix for the reverted PR #192.
Closes #198.

The initial problem was, that we used the `__CUDA_ARCH__` macro in a conditional in host code which is UB.
I have now switched to the `__CUDA_MINIMUM_ARCH__` macro which expands to the same value for every compilation pass.
The current implementation is a workaround until NVIDIA/libcudacxx#296 has been solved.