### PR TITLE
Always download RAPIDS.cmake to ensure dependencies don't overwrite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,10 +15,8 @@
 #=============================================================================
 cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
-if(NOT EXISTS ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
-  file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.08/RAPIDS.cmake
-       ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
-endif()
+file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.08/RAPIDS.cmake
+     ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
 include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
 
 include(rapids-cmake)


### PR DESCRIPTION
When you have dependencies that use RAPIDS.cmake they could overwrite the file and cause a different version to be used when cmake is executed a second time. Instead always download the file to ensure you have the correct version.

Fixes #https://github.com/rapidsai/rapids-cmake/issues/240
