### PR TITLE
Use rapids-cmake 22.10 best practice for RAPIDS.cmake location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,11 @@
 #=============================================================================
 cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
-file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.08/RAPIDS.cmake
-     ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
-include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/CUCO_RAPIDS.cmake)
+    file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.08/RAPIDS.cmake
+         ${CMAKE_CURRENT_BINARY_DIR}/CUCO_RAPIDS.cmake)
+endif()
+include(${CMAKE_CURRENT_BINARY_DIR}/CUCO_RAPIDS.cmake)
 
 include(rapids-cmake)
 include(rapids-cpm)


### PR DESCRIPTION
Removes possibility of another projects RAPIDS.cmake being used, and removes need to always download a version.

