### PR TITLE
cuco: Support requests to not install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ endif()
 option(BUILD_TESTS "Configure CMake to build tests" ${default_build_option_state})
 option(BUILD_BENCHMARKS "Configure CMake to build (google) benchmarks" ${default_build_option_state})
 option(BUILD_EXAMPLES "Configure CMake to build examples" ${default_build_option_state})
+option(INSTALL_CUCO "Enable CMake install rules for cuco" ${default_build_option_state})
 
 ###################################################################################################
 # - optionally build tests ------------------------------------------------------------------------
@@ -110,11 +111,12 @@ endif(BUILD_EXAMPLES)
 ###################################################################################################
 # - Install targets -------------------------------------------------------------------------------
 
-install(TARGETS cuco EXPORT cuco-exports)
-install(DIRECTORY include/cuco/ DESTINATION include/cuco)
-install(FILES ${CUCO_BINARY_DIR}/include/cuco/version_config.hpp DESTINATION include/cuco)
+if(INSTALL_CUCO)
+    install(TARGETS cuco EXPORT cuco-exports)
+    install(DIRECTORY include/cuco/ DESTINATION include/cuco)
+    install(FILES ${CUCO_BINARY_DIR}/include/cuco/version_config.hpp DESTINATION include/cuco)
 
-set(doc_string
+    set(doc_string
     [=[
 Provide targets for cuCollections.
 
@@ -129,26 +131,27 @@ structures tailored for efficient use with GPUs.
 
 ]=])
 
-# build install targets
-rapids_export(
-    INSTALL cuco
-    EXPORT_SET cuco-exports
-    GLOBAL_TARGETS cuco
-    NAMESPACE cuco::
-    DOCUMENTATION doc_string)
+    # build install targets
+    rapids_export(
+        INSTALL cuco
+        EXPORT_SET cuco-exports
+        GLOBAL_TARGETS cuco
+        NAMESPACE cuco::
+        DOCUMENTATION doc_string)
 
-set(code_string
+    set(code_string
     [=[
 if(NOT TARGET cuco::Thrust)
     thrust_create_target(cuco::Thrust FROM_OPTIONS)
 endif()
 ]=])
 
-# build export targets
-rapids_export(
-    BUILD cuco
-    EXPORT_SET cuco-exports
-    GLOBAL_TARGETS cuco
-    NAMESPACE cuco::
-    DOCUMENTATION doc_string
-    FINAL_CODE_BLOCK code_string)
+    # build export targets
+    rapids_export(
+        BUILD cuco
+        EXPORT_SET cuco-exports
+        GLOBAL_TARGETS cuco
+        NAMESPACE cuco::
+        DOCUMENTATION doc_string
+        FINAL_CODE_BLOCK code_string)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,19 @@ rapids_cuda_init_architectures(CUCO)
 
 project(CUCO VERSION 0.0.1 LANGUAGES CXX CUDA)
 
+###################################################################################################
+# - build options ---------------------------------------------------------------------------------
+
+set(default_build_option_state OFF)
+if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_LIST_DIR}")
+  set(default_build_option_state ON)
+endif()
+
+option(BUILD_TESTS "Configure CMake to build tests" ${default_build_option_state})
+option(BUILD_BENCHMARKS "Configure CMake to build (google) benchmarks" ${default_build_option_state})
+option(BUILD_EXAMPLES "Configure CMake to build examples" ${default_build_option_state})
+option(INSTALL_CUCO "Enable CMake install rules for cuco" ${default_build_option_state})
+
 # Write the version header
 rapids_cmake_write_version_file(include/cuco/version_config.hpp)
 
@@ -73,19 +86,6 @@ target_include_directories(cuco INTERFACE
                 $<INSTALL_INTERFACE:include>)
 target_link_libraries(cuco INTERFACE libcudacxx::libcudacxx CUDA::toolkit $<BUILD_INTERFACE:cuco::Thrust>)
 target_compile_features(cuco INTERFACE cxx_std_17 cuda_std_17)
-
-###################################################################################################
-# - build options ---------------------------------------------------------------------------------
-
-set(default_build_option_state OFF)
-if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_LIST_DIR}")
-  set(default_build_option_state ON)
-endif()
-
-option(BUILD_TESTS "Configure CMake to build tests" ${default_build_option_state})
-option(BUILD_BENCHMARKS "Configure CMake to build (google) benchmarks" ${default_build_option_state})
-option(BUILD_EXAMPLES "Configure CMake to build examples" ${default_build_option_state})
-option(INSTALL_CUCO "Enable CMake install rules for cuco" ${default_build_option_state})
 
 ###################################################################################################
 # - optionally build tests ------------------------------------------------------------------------

--- a/cmake/thirdparty/get_libcudacxx.cmake
+++ b/cmake/thirdparty/get_libcudacxx.cmake
@@ -16,8 +16,12 @@
 function(find_and_configure_libcudacxx)
     include(${rapids-cmake-dir}/cpm/libcudacxx.cmake)
 
-    rapids_cpm_libcudacxx(BUILD_EXPORT_SET cuco-exports
-                          INSTALL_EXPORT_SET cuco-exports)
+    set(exports BUILD_EXPORT_SET cuco-exports)
+    if(INSTALL_CUCO)
+      list(APPEND exports INSTALL_EXPORT_SET cuco-exports)
+    endif()
+
+    rapids_cpm_libcudacxx(${exports})
     set(LIBCUDACXX_INCLUDE_DIR "${libcudacxx_SOURCE_DIR}/include" PARENT_SCOPE)
 endfunction()
 


### PR DESCRIPTION
Allow consuming projects to request cuco to not install itself. This is needed for projects that don't expose
cuco as part of the API.

Note: this also fixes a bug where the consuming project has already brought in libcudacxx as a private dependency( no install ), and cuco errors out as it depends on libcudacxx but it won't be installed.
