### PR TITLE
Correct issues when `INSTALL_CUCO` is set to OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,12 +111,9 @@ endif(BUILD_EXAMPLES)
 ###################################################################################################
 # - Install targets -------------------------------------------------------------------------------
 
-if(INSTALL_CUCO)
-    install(TARGETS cuco EXPORT cuco-exports)
-    install(DIRECTORY include/cuco/ DESTINATION include/cuco)
-    install(FILES ${CUCO_BINARY_DIR}/include/cuco/version_config.hpp DESTINATION include/cuco)
+install(TARGETS cuco EXPORT cuco-exports)
 
-    set(doc_string
+set(doc_string
     [=[
 Provide targets for cuCollections.
 
@@ -131,27 +128,30 @@ structures tailored for efficient use with GPUs.
 
 ]=])
 
-    # build install targets
+set(code_string
+[=[
+if(NOT TARGET cuco::Thrust)
+thrust_create_target(cuco::Thrust FROM_OPTIONS)
+endif()
+]=])
+
+# build directory cuco-config generation
+rapids_export(
+    BUILD cuco
+    EXPORT_SET cuco-exports
+    GLOBAL_TARGETS cuco
+    NAMESPACE cuco::
+    DOCUMENTATION doc_string
+    FINAL_CODE_BLOCK code_string)
+
+if(INSTALL_CUCO)
+    install(DIRECTORY include/cuco/ DESTINATION include/cuco)
+    install(FILES ${CUCO_BINARY_DIR}/include/cuco/version_config.hpp DESTINATION include/cuco)
+    # install directory cuco-config generation
     rapids_export(
         INSTALL cuco
         EXPORT_SET cuco-exports
         GLOBAL_TARGETS cuco
         NAMESPACE cuco::
         DOCUMENTATION doc_string)
-
-    set(code_string
-    [=[
-if(NOT TARGET cuco::Thrust)
-    thrust_create_target(cuco::Thrust FROM_OPTIONS)
-endif()
-]=])
-
-    # build export targets
-    rapids_export(
-        BUILD cuco
-        EXPORT_SET cuco-exports
-        GLOBAL_TARGETS cuco
-        NAMESPACE cuco::
-        DOCUMENTATION doc_string
-        FINAL_CODE_BLOCK code_string)
 endif()

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -25,6 +25,7 @@ CPMAddPackage(
     # Additionally, attempting to set the CMAKE_CXX_VERSION here doesn't propogate to the feature test build
     # Therefore, we just disable the feature test and assume platforms we care about have a regex impl available
     "RUN_HAVE_STD_REGEX 0" #
+    "BENCHMARK_ENABLE_INSTALL OFF"
 )
 
 CPMAddPackage(
@@ -32,6 +33,7 @@ CPMAddPackage(
   GITHUB_REPOSITORY NVIDIA/nvbench
   GIT_TAG main
   GIT_SHALLOW TRUE
+  EXCLUDE_FROM_ALL YES
 )
 
 ###################################################################################################


### PR DESCRIPTION
While https://github.com/NVIDIA/cuCollections/pull/216 allows cuco to have install rules disabled it missed a couple of bits which are corrected with this PR:

- nvbench and google bench still installed files
- when `INSTALL_CUCO` is OFF we still need to generate a cuco-config in the build directory 
