### PR TITLE
Enable `memcpy_async` execution path

### DIFF
--- a/include/cuco/detail/__config
+++ b/include/cuco/detail/__config
@@ -25,7 +25,7 @@
 #define CUCO_HAS_CUDA_BARRIER
 #endif
 
-#if defined(CUDART_VERSION) && (CUDART_VERSION >= 11100)
+#if defined(CUDART_VERSION) && (CUDART_VERSION >= 11010)
 #define CUCO_HAS_CG_MEMCPY_ASYNC
 #endif
 

--- a/include/cuco/detail/static_multimap/device_view_impl.inl
+++ b/include/cuco/detail/static_multimap/device_view_impl.inl
@@ -502,7 +502,7 @@ class static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_view_
     constexpr bool uses_memcpy_async = thrust::is_contiguous_iterator_v<OutputIt>;
 #else
     constexpr bool uses_memcpy_async = false;
-#endif // end CUCO_HAS_CG_MEMCPY_ASYNC
+#endif  // end CUCO_HAS_CG_MEMCPY_ASYNC
 
     if constexpr (uses_memcpy_async) {
 #if defined(CUCO_HAS_CUDA_BARRIER)

--- a/include/cuco/detail/static_multimap/device_view_impl.inl
+++ b/include/cuco/detail/static_multimap/device_view_impl.inl
@@ -512,14 +512,13 @@ class static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_view_
                                        output_buffer,
                                        sizeof(value_type) * num_outputs);
 #endif  // end CUCO_HAS_CUDA_BARRIER
-      return;
 #endif  // end CUCO_HAS_CG_MEMCPY_ASYNC
     }
-#pragma nv_diag_suppress 128  // warning: unreachable
-    for (auto index = lane_id; index < num_outputs; index += g.size()) {
-      *(output_begin + offset + index) = output_buffer[index];
+    if constexpr (not thrust::is_contiguous_iterator_v<OutputIt>) {
+      for (auto index = lane_id; index < num_outputs; index += g.size()) {
+        *(output_begin + offset + index) = output_buffer[index];
+      }
     }
-#pragma nv_diag_default 128
   }
 
   /**

--- a/include/cuco/detail/static_multimap/device_view_impl.inl
+++ b/include/cuco/detail/static_multimap/device_view_impl.inl
@@ -507,20 +507,19 @@ class static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_view_
         output_buffer,
         cuda::aligned_size_t<alignof(value_type)>(sizeof(value_type) * num_outputs));
 #else
-      cooperative_groups::memcpy_async(
-        g,
-        &thrust::raw_reference_cast(*(output_begin + offset)),
-        output_buffer,
-        sizeof(value_type) * num_outputs);
+      cooperative_groups::memcpy_async(g,
+                                       &thrust::raw_reference_cast(*(output_begin + offset)),
+                                       output_buffer,
+                                       sizeof(value_type) * num_outputs);
 #endif  // end CUCO_HAS_CUDA_BARRIER
       return;
 #endif  // end CUCO_HAS_CG_MEMCPY_ASYNC
     }
-    #pragma nv_diag_suppress 128 // warning: unreachable
+#pragma nv_diag_suppress 128  // warning: unreachable
     for (auto index = lane_id; index < num_outputs; index += g.size()) {
       *(output_begin + offset + index) = output_buffer[index];
     }
-    #pragma nv_diag_default 128
+#pragma nv_diag_default 128
   }
 
   /**

--- a/include/cuco/detail/static_multimap/kernels.cuh
+++ b/include/cuco/detail/static_multimap/kernels.cuh
@@ -23,8 +23,6 @@
 
 #include <cuda/std/atomic>
 
-#include <cooperative_groups/memcpy_async.h>
-
 #include <iterator>
 
 namespace cuco {


### PR DESCRIPTION
The following snippet uses an incorrect `CUDART_VERSION` scheme:
```cpp
#if defined(CUDART_VERSION) && (CUDART_VERSION >= 11100)
#define CUCO_HAS_CG_MEMCPY_ASYNC
#endif
```
`11100` maps to the non-existing CUDA CTK version 11._10_ instead of 11.1.

Reproducer: https://godbolt.org/z/WzfsPcPoE