### PR TITLE
Inline sentinel namespace + add missing implicit conversion operators

### DIFF
--- a/include/cuco/detail/utils.cuh
+++ b/include/cuco/detail/utils.cuh
@@ -76,5 +76,29 @@ struct slot_is_filled {
   }
 };
 
+/**
+ * @brief A strong type wrapper.
+ *
+ * @tparam T Type of the mapped values
+ */
+template <typename T>
+struct strong_type {
+  /**
+   * @brief Constructs a strong type.
+   *
+   * @param v Value to be wrapped as a strong type
+   */
+  __host__ __device__ explicit constexpr strong_type(T v) : value{v} {}
+
+  /**
+   * @brief Implicit conversion operator to the underlying value.
+   *
+   * @return Underlying value
+   */
+  __host__ __device__ constexpr operator T() const noexcept { return value; }
+
+  T value;  ///< Underlying value
+};
+
 }  // namespace detail
 }  // namespace cuco

--- a/include/cuco/sentinel.cuh
+++ b/include/cuco/sentinel.cuh
@@ -17,7 +17,7 @@
 #pragma once
 
 namespace cuco {
-namespace sentinel {
+inline namespace sentinel {
 /**
  * @brief A strong type wrapper used to denote the empty key sentinel.
  *
@@ -31,6 +31,14 @@ struct empty_key {
    * @param v The empty key sentinel value
    */
   __host__ __device__ explicit constexpr empty_key(T v) : value{v} {}
+
+  /**
+   * @brief Implicit conversion operator to the underlying value.
+   *
+   * @return Sentinel as underlying value type
+   */
+  __host__ __device__ constexpr operator T() const noexcept { return value; }
+
   T value;  ///< Empty key sentinel
 };
 
@@ -47,6 +55,14 @@ struct empty_value {
    * @param v The empty value sentinel value
    */
   __host__ __device__ explicit constexpr empty_value(T v) : value{v} {}
+
+  /**
+   * @brief Implicit conversion operator to the underlying value.
+   *
+   * @return Sentinel as underlying value type
+   */
+  __host__ __device__ constexpr operator T() const noexcept { return value; }
+
   T value;  ///< Empty value sentinel
 };
 
@@ -63,6 +79,14 @@ struct erased_key {
    * @param v The erased key sentinel value
    */
   __host__ __device__ explicit constexpr erased_key(T v) : value{v} {}
+
+  /**
+   * @brief Implicit conversion operator to the underlying value.
+   *
+   * @return Sentinel as underlying value type
+   */
+  __host__ __device__ constexpr operator T() const noexcept { return value; }
+
   T value;  ///< Erased key sentinel
 };
 

--- a/include/cuco/sentinel.cuh
+++ b/include/cuco/sentinel.cuh
@@ -16,30 +16,24 @@
 
 #pragma once
 
+#include <cuco/detail/utils.cuh>
+
 namespace cuco {
 inline namespace sentinel {
+
 /**
  * @brief A strong type wrapper used to denote the empty key sentinel.
  *
  * @tparam T Type of the key values
  */
 template <typename T>
-struct empty_key {
+struct empty_key : public cuco::detail::strong_type<T> {
   /**
    * @brief Constructs an empty key sentinel with the given `v`.
    *
    * @param v The empty key sentinel value
    */
-  __host__ __device__ explicit constexpr empty_key(T v) : value{v} {}
-
-  /**
-   * @brief Implicit conversion operator to the underlying value.
-   *
-   * @return Sentinel as underlying value type
-   */
-  __host__ __device__ constexpr operator T() const noexcept { return value; }
-
-  T value;  ///< Empty key sentinel
+  __host__ __device__ explicit constexpr empty_key(T v) : cuco::detail::strong_type<T>(v) {}
 };
 
 /**
@@ -48,22 +42,13 @@ struct empty_key {
  * @tparam T Type of the mapped values
  */
 template <typename T>
-struct empty_value {
+struct empty_value : public cuco::detail::strong_type<T> {
   /**
    * @brief Constructs an empty value sentinel with the given `v`.
    *
    * @param v The empty value sentinel value
    */
-  __host__ __device__ explicit constexpr empty_value(T v) : value{v} {}
-
-  /**
-   * @brief Implicit conversion operator to the underlying value.
-   *
-   * @return Sentinel as underlying value type
-   */
-  __host__ __device__ constexpr operator T() const noexcept { return value; }
-
-  T value;  ///< Empty value sentinel
+  __host__ __device__ explicit constexpr empty_value(T v) : cuco::detail::strong_type<T>(v) {}
 };
 
 /**
@@ -72,22 +57,13 @@ struct empty_value {
  * @tparam T Type of the key values
  */
 template <typename T>
-struct erased_key {
+struct erased_key : public cuco::detail::strong_type<T> {
   /**
    * @brief Constructs an erased key sentinel with the given `v`.
    *
    * @param v The erased key sentinel value
    */
-  __host__ __device__ explicit constexpr erased_key(T v) : value{v} {}
-
-  /**
-   * @brief Implicit conversion operator to the underlying value.
-   *
-   * @return Sentinel as underlying value type
-   */
-  __host__ __device__ constexpr operator T() const noexcept { return value; }
-
-  T value;  ///< Erased key sentinel
+  __host__ __device__ explicit constexpr erased_key(T v) : cuco::detail::strong_type<T>(v) {}
 };
 
 }  // namespace sentinel


### PR DESCRIPTION
- `namespace sentinel` -> `inline namespace sentinel`
- `cuco::detail::strong_type<T>` utility class
- implicit conversion operator to sentinel's value type: `__host__ __device__ constexpr operator T() const noexcept { return value; }`