### PR TITLE
Get rid of thrust::device_vector::data

### DIFF
--- a/benchmarks/hash_table/static_multimap/optimal_retrieve_bench.cu
+++ b/benchmarks/hash_table/static_multimap/optimal_retrieve_bench.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ std::enable_if_t<(sizeof(Key) == sizeof(Value)), void> nvbench_retrieve(
   thrust::device_vector<cuco::pair_type<Key, Value>> d_results(output_size);
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    map.retrieve_outer(d_keys.begin(), d_keys.end(), d_results.data().get(), launch.get_stream());
+    map.retrieve_outer(d_keys.begin(), d_keys.end(), d_results.begin(), launch.get_stream());
   });
 }
 

--- a/benchmarks/hash_table/static_multimap/query_bench.cu
+++ b/benchmarks/hash_table/static_multimap/query_bench.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ std::enable_if_t<(sizeof(Key) == sizeof(Value)), void> nvbench_static_multimap_q
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     auto count = map.count_outer(d_keys.begin(), d_keys.end(), launch.get_stream());
-    map.retrieve_outer(d_keys.begin(), d_keys.end(), d_results.data().get(), launch.get_stream());
+    map.retrieve_outer(d_keys.begin(), d_keys.end(), d_results.begin(), launch.get_stream());
   });
 }
 

--- a/benchmarks/hash_table/static_multimap/retrieve_bench.cu
+++ b/benchmarks/hash_table/static_multimap/retrieve_bench.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ std::enable_if_t<(sizeof(Key) == sizeof(Value)), void> nvbench_static_multimap_r
   thrust::device_vector<cuco::pair_type<Key, Value>> d_results(output_size);
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    map.retrieve_outer(d_keys.begin(), d_keys.end(), d_results.data().get(), launch.get_stream());
+    map.retrieve_outer(d_keys.begin(), d_keys.end(), d_results.begin(), launch.get_stream());
   });
 }
 

--- a/examples/static_multimap/host_bulk_example.cu
+++ b/examples/static_multimap/host_bulk_example.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,9 +64,8 @@ int main(void)
 
   // Finds all keys {0, 1, 2, ...} and stores associated key/value pairs into `d_results`
   // If a key `keys_to_find[i]` doesn't exist, `d_results[i].second == empty_value_sentinel`
-  auto output_end =
-    map.retrieve_outer(keys_to_find.begin(), keys_to_find.end(), d_results.data().get());
-  auto retrieve_size = output_end - d_results.data().get();
+  auto output_end = map.retrieve_outer(keys_to_find.begin(), keys_to_find.end(), d_results.begin());
+  auto retrieve_size = output_end - d_results.begin();
 
   // The total number of outer matches should be `N + N / 2`
   assert(not(output_size == retrieve_size == N + N / 2));

--- a/tests/static_multimap/non_match_test.cu
+++ b/tests/static_multimap/non_match_test.cu
@@ -43,7 +43,7 @@ __inline__ void test_non_matches(Map& map, PairIt pair_begin, KeyIt key_begin, s
 
     REQUIRE(num == num_keys);
 
-    auto output_begin      = d_results.data().get();
+    auto output_begin      = d_results.begin();
     auto output_end        = map.retrieve(key_begin, key_begin + num_keys, output_begin);
     std::size_t const size = thrust::distance(output_begin, output_end);
 
@@ -75,7 +75,7 @@ __inline__ void test_non_matches(Map& map, PairIt pair_begin, KeyIt key_begin, s
 
     REQUIRE(num == (num_keys + num_keys / 2));
 
-    auto output_begin      = d_results.data().get();
+    auto output_begin      = d_results.begin();
     auto output_end        = map.retrieve_outer(key_begin, key_begin + num_keys, output_begin);
     std::size_t const size = thrust::distance(output_begin, output_end);
 


### PR DESCRIPTION
Closes #188 

This PR gets rid of the use of `thrust::device_vector::data().get()` in cuco tests, examples and benchmarks to make sure algorithms can work properly with thrust proxy references.

<!--

Thank you for contributing to cuCollections :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
