### PR TITLE
Fix static_map::find benchmark output type

### DIFF
--- a/benchmarks/hash_table/static_map/find_bench.cu
+++ b/benchmarks/hash_table/static_map/find_bench.cu
@@ -58,7 +58,7 @@ std::enable_if_t<(sizeof(Key) == sizeof(Value)), void> static_map_find(
 
   gen.dropout(keys.begin(), keys.end(), matching_rate);
 
-  thrust::device_vector<bool> result(num_keys);
+  thrust::device_vector<Value> result(num_keys);
 
   state.add_element_count(num_keys);
 


### PR DESCRIPTION
This PR fixes a minor bug by using the proper output type in `static_map::find` benchmark.