### PR TITLE
Update the default parameters for `static_set`

### DIFF
--- a/include/cuco/detail/static_set/kernels.cuh
+++ b/include/cuco/detail/static_set/kernels.cuh
@@ -43,7 +43,7 @@ namespace detail {
  * @param first Beginning of the sequence of input elements
  * @param n Number of input elements
  * @param num_successes Number of successful inserted elements
- * @param ref Non-owing set device ref used to access the slot storage
+ * @param ref Non-owning set device ref used to access the slot storage
  */
 template <int32_t BlockSize, typename InputIterator, typename AtomicT, typename Ref>
 __global__ void insert(InputIterator first,
@@ -85,7 +85,7 @@ __global__ void insert(InputIterator first,
  *
  * @param first Beginning of the sequence of input elements
  * @param n Number of input elements
- * @param ref Non-owing set device ref used to access the slot storage
+ * @param ref Non-owning set device ref used to access the slot storage
  */
 template <int32_t BlockSize, typename InputIterator, typename Ref>
 __global__ void insert_async(InputIterator first, cuco::detail::index_type n, Ref ref)
@@ -117,7 +117,7 @@ __global__ void insert_async(InputIterator first, cuco::detail::index_type n, Re
  * @param first Beginning of the sequence of input elements
  * @param n Number of input elements
  * @param num_successes Number of successful inserted elements
- * @param ref Non-owing set device ref used to access the slot storage
+ * @param ref Non-owning set device ref used to access the slot storage
  */
 template <int32_t CGSize, int32_t BlockSize, typename InputIterator, typename AtomicT, typename Ref>
 __global__ void insert(InputIterator first,
@@ -163,7 +163,7 @@ __global__ void insert(InputIterator first,
  *
  * @param first Beginning of the sequence of input elements
  * @param n Number of input elements
- * @param ref Non-owing set device ref used to access the slot storage
+ * @param ref Non-owning set device ref used to access the slot storage
  */
 template <int32_t CGSize, int32_t BlockSize, typename InputIterator, typename Ref>
 __global__ void insert_async(InputIterator first, cuco::detail::index_type n, Ref ref)
@@ -196,7 +196,7 @@ __global__ void insert_async(InputIterator first, cuco::detail::index_type n, Re
  * @param first Beginning of the sequence of keys
  * @param n Number of keys
  * @param output_begin Beginning of the sequence of booleans for the presence of each key
- * @param ref Non-owing set device ref used to access the slot storage
+ * @param ref Non-owning set device ref used to access the slot storage
  */
 template <int32_t BlockSize, typename InputIt, typename OutputIt, typename Ref>
 __global__ void contains(InputIt first, cuco::detail::index_type n, OutputIt output_begin, Ref ref)
@@ -245,7 +245,7 @@ __global__ void contains(InputIt first, cuco::detail::index_type n, OutputIt out
  * @param first Beginning of the sequence of keys
  * @param n Number of keys
  * @param output_begin Beginning of the sequence of booleans for the presence of each key
- * @param ref Non-owing set device ref used to access the slot storage
+ * @param ref Non-owning set device ref used to access the slot storage
  */
 template <int32_t CGSize, int32_t BlockSize, typename InputIt, typename OutputIt, typename Ref>
 __global__ void contains(InputIt first, cuco::detail::index_type n, OutputIt output_begin, Ref ref)
@@ -280,6 +280,45 @@ __global__ void contains(InputIt first, cuco::detail::index_type n, OutputIt out
     if (idx < n and tile.thread_rank() == 0) { *(output_begin + idx) = output_buffer[tile_idx]; }
     idx += loop_stride;
   }
+}
+
+/**
+ * @brief Calculates the number of filled slots for the given window storage.
+ *
+ * @tparam BlockSize Number of threads in each block
+ * @tparam StorageRef Type of non-owning ref allowing access to storage
+ * @tparam AtomicT Atomic counter type
+ *
+ * @param storage Non-owning device ref used to access the slot storage
+ * @param empty_sentinel Sentinel indicating empty slots
+ * @param count Number of filled slots
+ */
+template <int32_t BlockSize, typename StorageRef, typename AtomicT>
+__global__ void size(StorageRef storage,
+                     typename StorageRef::value_type empty_sentinel,
+                     AtomicT* count)
+{
+  using size_type = typename StorageRef::size_type;
+
+  cuco::detail::index_type const loop_stride = gridDim.x * BlockSize;
+  cuco::detail::index_type idx               = BlockSize * blockIdx.x + threadIdx.x;
+
+  size_type thread_count = 0;
+  auto const n           = storage.num_windows();
+
+  while (idx < n) {
+    auto const window = storage[idx];
+#pragma unroll
+    for (auto const& it : window) {
+      thread_count += static_cast<size_type>(not cuco::detail::bitwise_compare(it, empty_sentinel));
+    }
+    idx += loop_stride;
+  }
+
+  using BlockReduce = cub::BlockReduce<size_type, BlockSize>;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+  size_type const block_count = BlockReduce(temp_storage).Sum(thread_count);
+  if (threadIdx.x == 0) { count->fetch_add(block_count, cuda::std::memory_order_relaxed); }
 }
 
 }  // namespace detail

--- a/include/cuco/detail/static_set/static_set.inl
+++ b/include/cuco/detail/static_set/static_set.inl
@@ -172,34 +172,20 @@ static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::siz
 static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::size(
   cudaStream_t stream) const
 {
-  auto const begin = thrust::make_transform_iterator(
-    storage_.data(),
-    cuco::detail::elements_per_window<typename storage_type::value_type>{empty_key_sentinel_});
+  auto counter = detail::counter_storage<size_type, thread_scope, allocator_type>{allocator_};
+  counter.reset(stream);
 
-  std::size_t temp_storage_bytes = 0;
-  using temp_allocator_type = typename std::allocator_traits<allocator_type>::rebind_alloc<char>;
-  auto temp_allocator       = temp_allocator_type{allocator_};
-  auto d_size               = reinterpret_cast<size_type*>(
-    std::allocator_traits<temp_allocator_type>::allocate(temp_allocator, sizeof(size_type)));
-  cub::DeviceReduce::Sum(
-    nullptr, temp_storage_bytes, begin, d_size, storage_.num_windows(), stream);
+  auto const grid_size = (cg_size * storage_.num_windows() +
+                          detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
+                         (detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE);
 
-  auto d_temp_storage =
-    std::allocator_traits<temp_allocator_type>::allocate(temp_allocator, temp_storage_bytes);
+  // TODO: custom kernel to be replaced by cub::DeviceReduce::Sum when cub version is bumped to
+  // v2.1.0
+  detail::size<detail::CUCO_DEFAULT_BLOCK_SIZE>
+    <<<grid_size, detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+      storage_.ref(), this->empty_key_sentinel(), counter.data());
 
-  cub::DeviceReduce::Sum(
-    d_temp_storage, temp_storage_bytes, begin, d_size, storage_.num_windows(), stream);
-
-  size_type h_size;
-  CUCO_CUDA_TRY(
-    cudaMemcpyAsync(&h_size, d_size, sizeof(size_type), cudaMemcpyDeviceToHost, stream));
-  CUCO_CUDA_TRY(cudaStreamSynchronize(stream));
-  std::allocator_traits<temp_allocator_type>::deallocate(
-    temp_allocator, reinterpret_cast<char*>(d_size), sizeof(size_type));
-  std::allocator_traits<temp_allocator_type>::deallocate(
-    temp_allocator, d_temp_storage, temp_storage_bytes);
-
-  return h_size;
+  return counter.load_to_host(stream);
 }
 
 template <class Key,

--- a/include/cuco/detail/static_set/static_set.inl
+++ b/include/cuco/detail/static_set/static_set.inl
@@ -175,9 +175,9 @@ static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::siz
   auto counter = detail::counter_storage<size_type, thread_scope, allocator_type>{allocator_};
   counter.reset(stream);
 
-  auto const grid_size = (cg_size * storage_.num_windows() +
-                          detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
-                         (detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE);
+  auto const grid_size =
+    (storage_.num_windows() + detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
+    (detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE);
 
   // TODO: custom kernel to be replaced by cub::DeviceReduce::Sum when cub version is bumped to
   // v2.1.0

--- a/include/cuco/static_set.cuh
+++ b/include/cuco/static_set.cuh
@@ -84,11 +84,11 @@ template <class Key,
           class Extent             = cuco::experimental::extent<std::size_t>,
           cuda::thread_scope Scope = cuda::thread_scope_device,
           class KeyEqual           = thrust::equal_to<Key>,
-          class ProbingScheme      = experimental::double_hashing<1,  // CG size
+          class ProbingScheme      = experimental::double_hashing<4,  // CG size
                                                              cuco::murmurhash3_32<Key>,
                                                              cuco::murmurhash3_32<Key>>,
           class Allocator          = cuco::cuda_allocator<std::byte>,
-          class Storage            = cuco::experimental::aow_storage<2>>
+          class Storage            = cuco::experimental::aow_storage<1>>
 class static_set {
   static_assert(sizeof(Key) <= 8, "Container does not support key types larger than 8 bytes.");
 

--- a/tests/static_set/unique_sequence_test.cu
+++ b/tests/static_set/unique_sequence_test.cu
@@ -77,16 +77,19 @@ TEMPLATE_TEST_CASE_SIG(
                                              : 412  // 103 x 2 x 2
     ;
 
-  using extent_type = cuco::experimental::extent<std::size_t>;
+  using extent_type    = cuco::experimental::extent<std::size_t>;
+  using allocator_type = cuco::cuda_allocator<std::byte>;
+  using storage_type   = cuco::experimental::aow_storage<2>;
 
   if constexpr (Probe == cuco::test::probe_sequence::linear_probing) {
     using probe = cuco::experimental::linear_probing<CGSize, cuco::murmurhash3_32<Key>>;
-    auto set    = cuco::experimental::
-      static_set<Key, extent_type, cuda::thread_scope_device, thrust::equal_to<Key>, probe>{
-        num_keys,
-        cuco::empty_key<Key>{-1},
-        thrust::equal_to<Key>{},
-        probe{cuco::murmurhash3_32<Key>{}}};
+    auto set    = cuco::experimental::static_set<Key,
+                                              extent_type,
+                                              cuda::thread_scope_device,
+                                              thrust::equal_to<Key>,
+                                              probe,
+                                              allocator_type,
+                                              storage_type>{num_keys, cuco::empty_key<Key>{-1}};
 
     REQUIRE(set.capacity() == gold_capacity);
 
@@ -96,12 +99,13 @@ TEMPLATE_TEST_CASE_SIG(
   if constexpr (Probe == cuco::test::probe_sequence::double_hashing) {
     using probe = cuco::experimental::
       double_hashing<CGSize, cuco::murmurhash3_32<Key>, cuco::murmurhash3_32<Key>>;
-    auto set = cuco::experimental::
-      static_set<Key, extent_type, cuda::thread_scope_device, thrust::equal_to<Key>, probe>{
-        num_keys,
-        cuco::empty_key<Key>{-1},
-        thrust::equal_to<Key>{},
-        probe{cuco::murmurhash3_32<Key>{}, cuco::murmurhash3_32<Key>{}}};
+    auto set = cuco::experimental::static_set<Key,
+                                              extent_type,
+                                              cuda::thread_scope_device,
+                                              thrust::equal_to<Key>,
+                                              probe,
+                                              allocator_type,
+                                              storage_type>{num_keys, cuco::empty_key<Key>{-1}};
 
     REQUIRE(set.capacity() == gold_capacity);
 


### PR DESCRIPTION
This PR sets the default CG size to 4 and the default window size to 1 for better runtime performance.

It also falls back the `size()` implementation to use a custom kernel instead of `cub::DeviceReduce::Sum` since the latter doesn't support operations for more than 2^31 elements for now.