### PR TITLE
Introduce cuco::cuda_stream_ref

### DIFF
--- a/benchmarks/hash_table/static_set/contains_bench.cu
+++ b/benchmarks/hash_table/static_set/contains_bench.cu
@@ -54,7 +54,7 @@ void static_set_contains(nvbench::state& state, nvbench::type_list<Key, Dist>)
   state.add_element_count(num_keys);
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    set.contains(keys.begin(), keys.end(), result.begin(), launch.get_stream());
+    set.contains(keys.begin(), keys.end(), result.begin(), {launch.get_stream()});
   });
 }
 

--- a/benchmarks/hash_table/static_set/insert_bench.cu
+++ b/benchmarks/hash_table/static_set/insert_bench.cu
@@ -48,10 +48,10 @@ void static_set_insert(nvbench::state& state, nvbench::type_list<Key, Dist>)
   state.exec(nvbench::exec_tag::sync | nvbench::exec_tag::timer,
              [&](nvbench::launch& launch, auto& timer) {
                cuco::experimental::static_set<Key> set{
-                 size, cuco::empty_key<Key>{-1}, {}, {}, {}, launch.get_stream()};
+                 size, cuco::empty_key<Key>{-1}, {}, {}, {}, {launch.get_stream()}};
 
                timer.start();
-               set.insert(keys.begin(), keys.end(), launch.get_stream());
+               set.insert(keys.begin(), keys.end(), {launch.get_stream()});
                timer.stop();
              });
 }

--- a/benchmarks/hash_table/static_set/retrieve_all_bench.cu
+++ b/benchmarks/hash_table/static_set/retrieve_all_bench.cu
@@ -50,7 +50,7 @@ void static_set_retrieve_all(nvbench::state& state, nvbench::type_list<Key, Dist
 
   state.add_element_count(num_keys);
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    auto end = set.retrieve_all(result.begin(), launch.get_stream());
+    auto end = set.retrieve_all(result.begin(), {launch.get_stream()});
   });
 }
 

--- a/benchmarks/hash_table/static_set/size_bench.cu
+++ b/benchmarks/hash_table/static_set/size_bench.cu
@@ -50,7 +50,7 @@ void static_set_size(nvbench::state& state, nvbench::type_list<Key, Dist>)
   set.insert(keys.begin(), keys.end());
 
   state.exec(nvbench::exec_tag::sync,
-             [&](nvbench::launch& launch) { auto const size = set.size(launch.get_stream()); });
+             [&](nvbench::launch& launch) { auto const size = set.size({launch.get_stream()}); });
 }
 
 NVBENCH_BENCH_TYPES(static_set_size,

--- a/include/cuco/cuda_stream_ref.hpp
+++ b/include/cuco/cuda_stream_ref.hpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cuda_runtime_api.h>
+
+#include <cstddef>
+
+namespace cuco {
+namespace experimental {
+
+/**
+ * @brief Strongly-typed non-owning wrapper for CUDA streams with default constructor.
+ *
+ * This wrapper is simply a "view": it does not own the lifetime of the stream it wraps.
+ */
+class cuda_stream_ref {
+ public:
+  constexpr cuda_stream_ref()                       = default;  ///< Default constructor
+  constexpr cuda_stream_ref(cuda_stream_ref const&) = default;  ///< Copy constructor
+  constexpr cuda_stream_ref(cuda_stream_ref&&)      = default;  ///< Move constructor
+
+  /**
+   * @brief Copy-assignment operator.
+   *
+   * @return Copy of this stream reference.
+   */
+  constexpr cuda_stream_ref& operator=(cuda_stream_ref const&) = default;
+
+  /**
+   * @brief Move-assignment operator.
+   *
+   * @return New location of this stream reference.
+   */
+  constexpr cuda_stream_ref& operator=(cuda_stream_ref&&) = default;  ///< Move-assignment operator
+
+  ~cuda_stream_ref() = default;
+
+  constexpr cuda_stream_ref(int)            = delete;  //< Prevent cast from literal 0
+  constexpr cuda_stream_ref(std::nullptr_t) = delete;  //< Prevent cast from nullptr
+
+  /**
+   * @brief Implicit conversion from `cudaStream_t`.
+   *
+   * @param stream The CUDA stream to reference.
+   */
+  constexpr cuda_stream_ref(cudaStream_t stream) noexcept : stream_{stream} {}
+
+  /**
+   * @brief Get the wrapped stream.
+   *
+   * @return The wrapped stream.
+   */
+  [[nodiscard]] constexpr cudaStream_t value() const noexcept { return stream_; }
+
+  /**
+   * @brief Implicit conversion to `cudaStream_t`.
+   *
+   * @return The underlying `cudaStream_t`.
+   */
+  constexpr operator cudaStream_t() const noexcept { return value(); }
+
+  /**
+   * @brief Return true if the wrapped stream is the CUDA per-thread default stream.
+   *
+   * @return True if the wrapped stream is the per-thread default stream; else false.
+   */
+  [[nodiscard]] inline bool is_per_thread_default() const noexcept;
+
+  /**
+   * @brief Return true if the wrapped stream is explicitly the CUDA legacy default stream.
+   *
+   * @return True if the wrapped stream is the default stream; else false.
+   */
+  [[nodiscard]] inline bool is_default() const noexcept;
+
+  /**
+   * @brief Synchronize the viewed CUDA stream.
+   *
+   * Calls `cudaStreamSynchronize()`.
+   *
+   * @throw cuco::cuda_error if stream synchronization fails
+   */
+  void synchronize() const;
+
+ private:
+  cudaStream_t stream_{};
+};
+
+/**
+ * @brief Static `cuda_stream_ref` of the default stream (stream 0), for convenience
+ */
+static constexpr cuda_stream_ref cuda_stream_default{};
+
+/**
+ * @brief Static `cuda_stream_ref` of cudaStreamLegacy, for convenience
+ */
+static const cuda_stream_ref cuda_stream_legacy{cudaStreamLegacy};
+
+/**
+ * @brief Static `cuda_stream_ref` of cudaStreamPerThread, for convenience
+ */
+static const cuda_stream_ref cuda_stream_per_thread{cudaStreamPerThread};
+
+// /**
+//  * @brief Equality comparison operator for streams
+//  *
+//  * @param lhs The first stream view to compare
+//  * @param rhs The second stream view to compare
+//  * @return true if equal, false if unequal
+//  */
+// inline bool operator==(cuda_stream_ref lhs, cuda_stream_ref rhs)
+// {
+//   return lhs.value() == rhs.value();
+// }
+
+// /**
+//  * @brief Inequality comparison operator for streams
+//  *
+//  * @param lhs The first stream view to compare
+//  * @param rhs The second stream view to compare
+//  * @return true if unequal, false if equal
+//  */
+// inline bool operator!=(cuda_stream_ref lhs, cuda_stream_ref rhs) { return not(lhs == rhs); }
+
+}  // namespace experimental
+}  // namespace cuco
+
+#include <cuco/detail/cuda_stream_ref.inl>

--- a/include/cuco/detail/cuda_stream_ref.inl
+++ b/include/cuco/detail/cuda_stream_ref.inl
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cuco/cuda_stream_ref.hpp>
+#include <cuco/detail/error.hpp>
+
+#include <cuda_runtime_api.h>
+
+namespace cuco {
+namespace experimental {
+
+[[nodiscard]] inline bool cuda_stream_ref::is_per_thread_default() const noexcept
+{
+#ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
+  return value() == cuda_stream_per_thread || value() == nullptr;
+#else
+  return value() == cuda_stream_per_thread;
+#endif
+}
+
+[[nodiscard]] inline bool cuda_stream_ref::is_default() const noexcept
+{
+#ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
+  return value() == cuda_stream_legacy;
+#else
+  return value() == cuda_stream_legacy || value() == nullptr;
+#endif
+}
+
+inline void cuda_stream_ref::synchronize() const
+{
+  CUCO_CUDA_TRY(cudaStreamSynchronize(this->stream_));
+}
+
+}  // namespace experimental
+}  // namespace cuco

--- a/include/cuco/detail/static_set/static_set.inl
+++ b/include/cuco/detail/static_set/static_set.inl
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <cuco/cuda_stream_ref.hpp>
 #include <cuco/detail/error.hpp>
 #include <cuco/detail/prime.hpp>
 #include <cuco/detail/static_set/functors.cuh>
@@ -50,7 +51,7 @@ constexpr static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Sto
   KeyEqual pred,
   ProbingScheme const& probing_scheme,
   Allocator const& alloc,
-  cudaStream_t stream)
+  cuda_stream_ref stream)
   : empty_key_sentinel_{empty_key_sentinel},
     predicate_{pred},
     probing_scheme_{probing_scheme},
@@ -70,7 +71,7 @@ template <class Key,
 template <typename InputIt>
 static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::size_type
 static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::insert(
-  InputIt first, InputIt last, cudaStream_t stream)
+  InputIt first, InputIt last, cuda_stream_ref stream)
 {
   auto const num_keys = cuco::detail::distance(first, last);
   if (num_keys == 0) { return 0; }
@@ -99,7 +100,7 @@ template <class Key,
           class Storage>
 template <typename InputIt>
 void static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::insert_async(
-  InputIt first, InputIt last, cudaStream_t stream)
+  InputIt first, InputIt last, cuda_stream_ref stream)
 {
   auto const num_keys = cuco::detail::distance(first, last);
   if (num_keys == 0) { return; }
@@ -124,7 +125,7 @@ template <class Key,
 template <typename InputIt, typename StencilIt, typename Predicate>
 static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::size_type
 static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::insert_if(
-  InputIt first, InputIt last, StencilIt stencil, Predicate pred, cudaStream_t stream)
+  InputIt first, InputIt last, StencilIt stencil, Predicate pred, cuda_stream_ref stream)
 {
   auto const num_keys = cuco::detail::distance(first, last);
   if (num_keys == 0) { return 0; }
@@ -152,7 +153,7 @@ template <class Key,
           class Storage>
 template <typename InputIt, typename StencilIt, typename Predicate>
 void static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::insert_if_async(
-  InputIt first, InputIt last, StencilIt stencil, Predicate pred, cudaStream_t stream)
+  InputIt first, InputIt last, StencilIt stencil, Predicate pred, cuda_stream_ref stream)
 {
   auto const num_keys = cuco::detail::distance(first, last);
   if (num_keys == 0) { return; }
@@ -175,10 +176,10 @@ template <class Key,
           class Storage>
 template <typename InputIt, typename OutputIt>
 void static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::contains(
-  InputIt first, InputIt last, OutputIt output_begin, cudaStream_t stream) const
+  InputIt first, InputIt last, OutputIt output_begin, cuda_stream_ref stream) const
 {
   contains_async(first, last, output_begin, stream);
-  CUCO_CUDA_TRY(cudaStreamSynchronize(stream));
+  stream.synchronize();
 }
 
 template <class Key,
@@ -190,7 +191,7 @@ template <class Key,
           class Storage>
 template <typename InputIt, typename OutputIt>
 void static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::contains_async(
-  InputIt first, InputIt last, OutputIt output_begin, cudaStream_t stream) const
+  InputIt first, InputIt last, OutputIt output_begin, cuda_stream_ref stream) const
 {
   auto const num_keys = cuco::detail::distance(first, last);
   if (num_keys == 0) { return; }
@@ -219,7 +220,7 @@ template <class Key,
           class Storage>
 template <typename OutputIt>
 OutputIt static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::retrieve_all(
-  OutputIt output_begin, cudaStream_t stream) const
+  OutputIt output_begin, cuda_stream_ref stream) const
 {
   auto begin  = thrust::make_transform_iterator(thrust::counting_iterator<size_type>(0),
                                                detail::get_slot<storage_ref_type>(storage_.ref()));
@@ -248,7 +249,7 @@ OutputIt static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Stor
   size_type h_num_out;
   CUCO_CUDA_TRY(
     cudaMemcpyAsync(&h_num_out, d_num_out, sizeof(size_type), cudaMemcpyDeviceToHost, stream));
-  CUCO_CUDA_TRY(cudaStreamSynchronize(stream));
+  stream.synchronize();
   std::allocator_traits<temp_allocator_type>::deallocate(
     temp_allocator, reinterpret_cast<char*>(d_num_out), sizeof(size_type));
   temp_allocator.deallocate(d_temp_storage, temp_storage_bytes);
@@ -265,7 +266,7 @@ template <class Key,
           class Storage>
 static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::size_type
 static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::size(
-  cudaStream_t stream) const
+  cuda_stream_ref stream) const
 {
   auto counter = detail::counter_storage<size_type, thread_scope, allocator_type>{allocator_};
   counter.reset(stream);

--- a/include/cuco/detail/storage/aow_storage.cuh
+++ b/include/cuco/detail/storage/aow_storage.cuh
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cuco/cuda_stream_ref.hpp>
 #include <cuco/detail/storage/kernels.cuh>
 #include <cuco/detail/storage/storage_base.cuh>
 #include <cuco/detail/tuning.cuh>
@@ -226,7 +227,7 @@ class aow_storage : public aow_storage_base<WindowSize, T, Extent> {
    * @param key Key to which all keys in `slots` are initialized
    * @param stream Stream used for executing the kernel
    */
-  void initialize(value_type key, cudaStream_t stream) noexcept
+  void initialize(value_type key, cuda_stream_ref stream) noexcept
   {
     auto constexpr stride = 4;
     auto const grid_size  = (this->num_windows() + stride * detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /

--- a/include/cuco/detail/storage/counter_storage.cuh
+++ b/include/cuco/detail/storage/counter_storage.cuh
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cuco/cuda_stream_ref.hpp>
 #include <cuco/detail/error.hpp>
 #include <cuco/detail/storage/storage_base.cuh>
 #include <cuco/extent.cuh>
@@ -64,7 +65,7 @@ class counter_storage : public storage_base<cuco::experimental::extent<SizeType,
    *
    * @param stream CUDA stream used to reset
    */
-  void reset(cudaStream_t stream)
+  void reset(cuda_stream_ref stream)
   {
     static_assert(sizeof(size_type) == sizeof(value_type));
     CUCO_CUDA_TRY(cudaMemsetAsync(this->data(), 0, sizeof(value_type), stream));
@@ -92,12 +93,12 @@ class counter_storage : public storage_base<cuco::experimental::extent<SizeType,
    * @param stream CUDA stream used to copy device value to the host
    * @return Value of the atomic counter
    */
-  [[nodiscard]] constexpr size_type load_to_host(cudaStream_t stream) const
+  [[nodiscard]] constexpr size_type load_to_host(cuda_stream_ref stream) const
   {
     size_type h_count;
     CUCO_CUDA_TRY(
       cudaMemcpyAsync(&h_count, this->data(), sizeof(size_type), cudaMemcpyDeviceToHost, stream));
-    CUCO_CUDA_TRY(cudaStreamSynchronize(stream));
+    stream.synchronize();
     return h_count;
   }
 

--- a/include/cuco/static_set.cuh
+++ b/include/cuco/static_set.cuh
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cuco/cuda_stream_ref.hpp>
 #include <cuco/detail/__config>
 #include <cuco/detail/prime.hpp>
 #include <cuco/extent.cuh>
@@ -165,7 +166,7 @@ class static_set {
                        KeyEqual pred                       = {},
                        ProbingScheme const& probing_scheme = {},
                        Allocator const& alloc              = {},
-                       cudaStream_t stream                 = nullptr);
+                       cuda_stream_ref stream              = {});
 
   /**
    * @brief Inserts all keys in the range `[first, last)` and returns the number of successful
@@ -185,7 +186,7 @@ class static_set {
    * @return Number of successfully inserted keys
    */
   template <typename InputIt>
-  size_type insert(InputIt first, InputIt last, cudaStream_t stream = nullptr);
+  size_type insert(InputIt first, InputIt last, cuda_stream_ref stream = {});
 
   /**
    * @brief Asynchonously inserts all keys in the range `[first, last)`.
@@ -199,7 +200,7 @@ class static_set {
    * @param stream CUDA stream used for insert
    */
   template <typename InputIt>
-  void insert_async(InputIt first, InputIt last, cudaStream_t stream = nullptr);
+  void insert_async(InputIt first, InputIt last, cuda_stream_ref stream = {});
 
   /**
    * @brief Inserts keys in the range `[first, last)` if `pred` of the corresponding stencil returns
@@ -227,7 +228,7 @@ class static_set {
    */
   template <typename InputIt, typename StencilIt, typename Predicate>
   size_type insert_if(
-    InputIt first, InputIt last, StencilIt stencil, Predicate pred, cudaStream_t stream = nullptr);
+    InputIt first, InputIt last, StencilIt stencil, Predicate pred, cuda_stream_ref stream = {});
 
   /**
    * @brief Asynchonously inserts keys in the range `[first, last)` if `pred` of the corresponding
@@ -251,7 +252,7 @@ class static_set {
    */
   template <typename InputIt, typename StencilIt, typename Predicate>
   void insert_if_async(
-    InputIt first, InputIt last, StencilIt stencil, Predicate pred, cudaStream_t stream = nullptr);
+    InputIt first, InputIt last, StencilIt stencil, Predicate pred, cuda_stream_ref stream = {});
 
   /**
    * @brief Indicates whether the keys in the range `[first, last)` are contained in the set.
@@ -271,7 +272,7 @@ class static_set {
   void contains(InputIt first,
                 InputIt last,
                 OutputIt output_begin,
-                cudaStream_t stream = nullptr) const;
+                cuda_stream_ref stream = {}) const;
 
   /**
    * @brief Asynchonously indicates whether the keys in the range `[first, last)` are contained in
@@ -289,7 +290,7 @@ class static_set {
   void contains_async(InputIt first,
                       InputIt last,
                       OutputIt output_begin,
-                      cudaStream_t stream = nullptr) const;
+                      cuda_stream_ref stream = {}) const;
 
   /**
    * @brief Retrieves all keys contained in the set.
@@ -309,7 +310,7 @@ class static_set {
    * @return Iterator indicating the end of the output
    */
   template <typename OutputIt>
-  [[nodiscard]] OutputIt retrieve_all(OutputIt output_begin, cudaStream_t stream = nullptr) const;
+  [[nodiscard]] OutputIt retrieve_all(OutputIt output_begin, cuda_stream_ref stream = {}) const;
 
   /**
    * @brief Gets the number of elements in the container.
@@ -319,7 +320,7 @@ class static_set {
    * @param stream CUDA stream used to get the number of inserted elements
    * @return The number of elements in the container
    */
-  [[nodiscard]] size_type size(cudaStream_t stream = nullptr) const;
+  [[nodiscard]] size_type size(cuda_stream_ref stream = {}) const;
 
   /**
    * @brief Gets the maximum number of elements the hash map can hold.


### PR DESCRIPTION
This PR introduces a non-owning wrapper for `cudaStream_t` coined `cuco::cuda_stream_ref` and primarily borrows from [RMM's implementation](https://github.com/rapidsai/rmm/blob/528b283cacdc312ef99052644a0bb33e07338836/include/rmm/cuda_stream_view.hpp).