### PR TITLE
Add set `insert_and_find` device ref APIs

### DIFF
--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -22,6 +22,7 @@
 #include <cuco/sentinel.cuh>
 
 #include <thrust/distance.h>
+#include <thrust/pair.h>
 
 #include <cooperative_groups.h>
 #include <cuda/std/atomic>
@@ -184,6 +185,20 @@ class operator_impl<op::insert_tag,
       }
     }
   }
+
+  /**
+   * @brief Inserts the given element into the set.
+   *
+   * @note This API returns a pair consisting of an iterator to the inserted element (or to the
+   * element that prevented the insertion) and a `bool` denoting whether the insertion took place or
+   * not.
+   *
+   * @param value The element to insert
+   *
+   * @return a pair consisting of an iterator to the element and a bool indicating whether the
+   * insertion is successful or not.
+   */
+  __device__ thrust::pair<iterator, bool> insert_and_find(value_type const& value) noexcept;
 
  private:
   // TODO: this should be a common enum for all data structures

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -83,6 +83,61 @@ static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::e
   return empty_key_sentinel_;
 }
 
+template <typename Key,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
+__device__
+  static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::insert_result
+  static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::attempt_insert(
+    value_type* slot, value_type const& value)
+{
+  // temporary workaround due to performance regression
+  // https://github.com/NVIDIA/libcudacxx/issues/366
+  value_type const old = [&]() {
+    value_type expected = this->empty_key_sentinel();
+    value_type val      = value;
+    if constexpr (sizeof(value_type) == sizeof(uint32_t)) {
+      auto* expected_ptr = reinterpret_cast<unsigned int*>(&expected);
+      auto* value_ptr    = reinterpret_cast<unsigned int*>(&val);
+      if constexpr (Scope == cuda::thread_scope_system) {
+        return atomicCAS_system(reinterpret_cast<unsigned int*>(slot), *expected_ptr, *value_ptr);
+      } else if constexpr (Scope == cuda::thread_scope_device) {
+        return atomicCAS(reinterpret_cast<unsigned int*>(slot), *expected_ptr, *value_ptr);
+      } else if constexpr (Scope == cuda::thread_scope_block) {
+        return atomicCAS_block(reinterpret_cast<unsigned int*>(slot), *expected_ptr, *value_ptr);
+      } else {
+        static_assert(cuco::dependent_false<decltype(Scope)>, "Unsupported thread scope");
+      }
+    }
+    if constexpr (sizeof(value_type) == sizeof(uint64_t)) {
+      auto* expected_ptr = reinterpret_cast<unsigned long long int*>(&expected);
+      auto* value_ptr    = reinterpret_cast<unsigned long long int*>(&val);
+      if constexpr (Scope == cuda::thread_scope_system) {
+        return atomicCAS_system(
+          reinterpret_cast<unsigned long long int*>(slot), *expected_ptr, *value_ptr);
+      } else if constexpr (Scope == cuda::thread_scope_device) {
+        return atomicCAS(
+          reinterpret_cast<unsigned long long int*>(slot), *expected_ptr, *value_ptr);
+      } else if constexpr (Scope == cuda::thread_scope_block) {
+        return atomicCAS_block(
+          reinterpret_cast<unsigned long long int*>(slot), *expected_ptr, *value_ptr);
+      } else {
+        static_assert(cuco::dependent_false<decltype(Scope)>, "Unsupported thread scope");
+      }
+    }
+  }();
+  if (*slot == old) {
+    // Shouldn't use `predicate_` operator directly since it includes a redundant bitwise compare
+    return predicate_.equal_to(old, value) == detail::equal_result::EQUAL ? insert_result::DUPLICATE
+                                                                          : insert_result::CONTINUE;
+  } else {
+    return insert_result::SUCCESS;
+  }
+}
+
 namespace detail {
 
 template <typename Key,

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -99,7 +99,7 @@ __device__
   value_type const old = [&]() {
     value_type expected = this->empty_key_sentinel();
     value_type val      = value;
-    if constexpr (sizeof(value_type) == sizeof(uint32_t)) {
+    if constexpr (sizeof(value_type) == sizeof(unsigned int)) {
       auto* expected_ptr = reinterpret_cast<unsigned int*>(&expected);
       auto* value_ptr    = reinterpret_cast<unsigned int*>(&val);
       if constexpr (Scope == cuda::thread_scope_system) {
@@ -112,7 +112,7 @@ __device__
         static_assert(cuco::dependent_false<decltype(Scope)>, "Unsupported thread scope");
       }
     }
-    if constexpr (sizeof(value_type) == sizeof(uint64_t)) {
+    if constexpr (sizeof(value_type) == sizeof(unsigned long long int)) {
       auto* expected_ptr = reinterpret_cast<unsigned long long int*>(&expected);
       auto* value_ptr    = reinterpret_cast<unsigned long long int*>(&val);
       if constexpr (Scope == cuda::thread_scope_system) {

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -290,8 +290,8 @@ class operator_impl<op::insert_and_find_tag,
       auto const window_slots = ref_.storage_ref_[*probing_iter];
 
       for (auto i = 0; i < window_size; ++i) {
-        auto const eq_res      = ref_.predicate_(window_slots[i], value);
-        auto const* window_ptr = (ref_.storage_ref_.data() + *probing_iter)->data();
+        auto const eq_res = ref_.predicate_(window_slots[i], value);
+        auto* window_ptr  = (ref_.storage_ref_.data() + *probing_iter)->data();
 
         // If the key is already in the container, return false
         if (eq_res == detail::equal_result::EQUAL) { return {iterator{&window_ptr[i]}, false}; }
@@ -347,8 +347,7 @@ class operator_impl<op::insert_and_find_tag,
         return cuco::pair<detail::equal_result, int32_t>{detail::equal_result::UNEQUAL, -1};
       }();
 
-      auto const* slot_ptr =
-        (ref_.storage_ref_.data() + *probing_iter)->data() + intra_window_index;
+      auto* slot_ptr = (ref_.storage_ref_.data() + *probing_iter)->data() + intra_window_index;
 
       // If the key is already in the container, return false
       auto const group_finds_equal = group.ballot(state == detail::equal_result::EQUAL);

--- a/include/cuco/operator.hpp
+++ b/include/cuco/operator.hpp
@@ -28,6 +28,12 @@ struct insert_tag {
 } inline constexpr insert;
 
 /**
+ * @brief `insert_and_find` operator tag
+ */
+struct insert_and_find_tag {
+} inline constexpr insert_and_find;
+
+/**
  * @brief `contains` operator tag
  */
 struct contains_tag {

--- a/include/cuco/static_set_ref.cuh
+++ b/include/cuco/static_set_ref.cuh
@@ -80,11 +80,12 @@ class static_set_ref
   using extent_type         = typename storage_ref_type::extent_type;  ///< Extent type
   using size_type           = typename storage_ref_type::size_type;    ///< Probing scheme size type
   using key_equal           = KeyEqual;  ///< Type of key equality binary callable
+  using iterator            = typename storage_ref_type::iterator;   ///< Slot iterator type
+  using const_iterator = typename storage_ref_type::const_iterator;  ///< Const slot iterator type
 
   static constexpr auto cg_size = probing_scheme_type::cg_size;  ///< Cooperative group size
   static constexpr auto window_size =
-    storage_ref_type::window_size;             ///< Number of elements handled per window
-  static constexpr auto thread_scope = Scope;  ///< Thread scope
+    storage_ref_type::window_size;  ///< Number of elements handled per window
 
   /**
    * @brief Constructs static_set_ref.
@@ -115,6 +116,67 @@ class static_set_ref
   [[nodiscard]] __host__ __device__ constexpr key_type empty_key_sentinel() const noexcept;
 
  private:
+  // TODO: this should be a common enum for all data structures
+  enum class insert_result : int32_t { CONTINUE = 0, SUCCESS = 1, DUPLICATE = 2 };
+
+  /**
+   * @brief Attempts to insert an element into a slot.
+   *
+   * @note Dispatches the correct implementation depending on the container
+   * type and presence of other operator mixins.
+   *
+   * @param slot Pointer to the slot in memory
+   * @param value Element to insert
+   *
+   * @return Result of this operation, i.e., success/continue/duplicate
+   */
+  [[nodiscard]] __device__ insert_result attempt_insert(value_type* slot, value_type const& value)
+  {
+    // temporary workaround due to performance regression
+    // https://github.com/NVIDIA/libcudacxx/issues/366
+    value_type const old = [&]() {
+      value_type expected = this->empty_key_sentinel();
+      value_type val      = value;
+      if constexpr (sizeof(value_type) == sizeof(uint32_t)) {
+        auto* expected_ptr = reinterpret_cast<unsigned int*>(&expected);
+        auto* value_ptr    = reinterpret_cast<unsigned int*>(&val);
+        if constexpr (Scope == cuda::thread_scope_system) {
+          return atomicCAS_system(reinterpret_cast<unsigned int*>(slot), *expected_ptr, *value_ptr);
+        } else if constexpr (Scope == cuda::thread_scope_device) {
+          return atomicCAS(reinterpret_cast<unsigned int*>(slot), *expected_ptr, *value_ptr);
+        } else if constexpr (Scope == cuda::thread_scope_block) {
+          return atomicCAS_block(reinterpret_cast<unsigned int*>(slot), *expected_ptr, *value_ptr);
+        } else {
+          static_assert(cuco::dependent_false<decltype(Scope)>, "Unsupported thread scope");
+        }
+      }
+      if constexpr (sizeof(value_type) == sizeof(uint64_t)) {
+        auto* expected_ptr = reinterpret_cast<unsigned long long int*>(&expected);
+        auto* value_ptr    = reinterpret_cast<unsigned long long int*>(&val);
+        if constexpr (Scope == cuda::thread_scope_system) {
+          return atomicCAS_system(
+            reinterpret_cast<unsigned long long int*>(slot), *expected_ptr, *value_ptr);
+        } else if constexpr (Scope == cuda::thread_scope_device) {
+          return atomicCAS(
+            reinterpret_cast<unsigned long long int*>(slot), *expected_ptr, *value_ptr);
+        } else if constexpr (Scope == cuda::thread_scope_block) {
+          return atomicCAS_block(
+            reinterpret_cast<unsigned long long int*>(slot), *expected_ptr, *value_ptr);
+        } else {
+          static_assert(cuco::dependent_false<decltype(Scope)>, "Unsupported thread scope");
+        }
+      }
+    }();
+    if (*slot == old) {
+      // Shouldn't use `predicate_` operator directly since it includes a redundant bitwise compare
+      return predicate_.equal_to(old, value) == detail::equal_result::EQUAL
+               ? insert_result::DUPLICATE
+               : insert_result::CONTINUE;
+    } else {
+      return insert_result::SUCCESS;
+    }
+  }
+
   cuco::empty_key<key_type> empty_key_sentinel_;            ///< Empty key sentinel
   detail::equal_wrapper<value_type, key_equal> predicate_;  ///< Key equality binary callable
   probing_scheme_type probing_scheme_;                      ///< Probing scheme

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ ConfigureTest(UTILITY_TEST
 ConfigureTest(STATIC_SET_TEST
     static_set/capacity_test.cu
     static_set/heterogeneous_lookup_test.cu
+    static_set/insert_and_find_test.cu
     static_set/large_input_test.cu
     static_set/retrieve_all_test.cu
     static_set/size_test.cu

--- a/tests/static_set/retrieve_all_test.cu
+++ b/tests/static_set/retrieve_all_test.cu
@@ -20,12 +20,10 @@
 
 #include <thrust/device_vector.h>
 #include <thrust/distance.h>
-#include <thrust/execution_policy.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
-#include <thrust/transform.h>
 
 #include <catch2/catch_template_test_macros.hpp>
 
@@ -35,27 +33,25 @@ __inline__ void test_unique_sequence(Set& set, std::size_t num_keys)
   using Key = typename Set::key_type;
 
   thrust::device_vector<Key> d_keys(num_keys);
-
-  thrust::sequence(thrust::device, d_keys.begin(), d_keys.end());
-
-  auto key_begin = d_keys.begin();
+  thrust::sequence(d_keys.begin(), d_keys.end());
+  auto keys_begin = d_keys.begin();
 
   SECTION("Non-inserted keys should not be contained.")
   {
     REQUIRE(set.size() == 0);
 
-    auto key_end = set.retrieve_all(key_begin);
-    REQUIRE(std::distance(key_begin, key_end) == 0);
+    auto keys_end = set.retrieve_all(keys_begin);
+    REQUIRE(std::distance(keys_begin, keys_end) == 0);
   }
 
-  set.insert(key_begin, key_begin + num_keys);
+  set.insert(keys_begin, keys_begin + num_keys);
   REQUIRE(set.size() == num_keys);
 
   SECTION("All inserted key/value pairs should be contained.")
   {
     thrust::device_vector<Key> d_res(num_keys);
     auto d_res_end = set.retrieve_all(d_res.begin());
-    thrust::sort(thrust::device, d_res.begin(), d_res_end);
+    thrust::sort(d_res.begin(), d_res_end);
     REQUIRE(cuco::test::equal(
       d_res.begin(), d_res_end, thrust::counting_iterator<Key>(0), thrust::equal_to<Key>{}));
   }
@@ -79,38 +75,23 @@ TEMPLATE_TEST_CASE_SIG(
                                              : 422  // 211 x 2 x 1
     ;
 
-  using extent_type    = cuco::experimental::extent<std::size_t>;
-  using allocator_type = cuco::cuda_allocator<std::byte>;
-  using storage_type   = cuco::experimental::aow_storage<1>;
+  using probe =
+    std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
+                       cuco::experimental::linear_probing<CGSize, cuco::murmurhash3_32<Key>>,
+                       cuco::experimental::double_hashing<CGSize,
+                                                          cuco::murmurhash3_32<Key>,
+                                                          cuco::murmurhash3_32<Key>>>;
 
-  if constexpr (Probe == cuco::test::probe_sequence::linear_probing) {
-    using probe = cuco::experimental::linear_probing<CGSize, cuco::murmurhash3_32<Key>>;
-    auto set    = cuco::experimental::static_set<Key,
-                                              extent_type,
-                                              cuda::thread_scope_device,
-                                              thrust::equal_to<Key>,
-                                              probe,
-                                              allocator_type,
-                                              storage_type>{num_keys, cuco::empty_key<Key>{-1}};
+  auto set = cuco::experimental::static_set<Key,
+                                            cuco::experimental::extent<std::size_t>,
+                                            cuda::thread_scope_device,
+                                            thrust::equal_to<Key>,
+                                            probe,
+                                            cuco::cuda_allocator<std::byte>,
+                                            cuco::experimental::aow_storage<1>>{
+    num_keys, cuco::empty_key<Key>{-1}};
 
-    REQUIRE(set.capacity() == gold_capacity);
+  REQUIRE(set.capacity() == gold_capacity);
 
-    test_unique_sequence(set, num_keys);
-  }
-
-  if constexpr (Probe == cuco::test::probe_sequence::double_hashing) {
-    using probe = cuco::experimental::
-      double_hashing<CGSize, cuco::murmurhash3_32<Key>, cuco::murmurhash3_32<Key>>;
-    auto set = cuco::experimental::static_set<Key,
-                                              extent_type,
-                                              cuda::thread_scope_device,
-                                              thrust::equal_to<Key>,
-                                              probe,
-                                              allocator_type,
-                                              storage_type>{num_keys, cuco::empty_key<Key>{-1}};
-
-    REQUIRE(set.capacity() == gold_capacity);
-
-    test_unique_sequence(set, num_keys);
-  }
+  test_unique_sequence(set, num_keys);
 }

--- a/tests/static_set/unique_sequence_test.cu
+++ b/tests/static_set/unique_sequence_test.cu
@@ -20,7 +20,6 @@
 
 #include <thrust/device_vector.h>
 #include <thrust/distance.h>
-#include <thrust/execution_policy.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/counting_iterator.h>

--- a/tests/static_set/unique_sequence_test.cu
+++ b/tests/static_set/unique_sequence_test.cu
@@ -130,38 +130,23 @@ TEMPLATE_TEST_CASE_SIG(
                                              : 412  // 103 x 2 x 2
     ;
 
-  using extent_type    = cuco::experimental::extent<std::size_t>;
-  using allocator_type = cuco::cuda_allocator<std::byte>;
-  using storage_type   = cuco::experimental::aow_storage<2>;
+  using probe =
+    std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
+                       cuco::experimental::linear_probing<CGSize, cuco::murmurhash3_32<Key>>,
+                       cuco::experimental::double_hashing<CGSize,
+                                                          cuco::murmurhash3_32<Key>,
+                                                          cuco::murmurhash3_32<Key>>>;
 
-  if constexpr (Probe == cuco::test::probe_sequence::linear_probing) {
-    using probe = cuco::experimental::linear_probing<CGSize, cuco::murmurhash3_32<Key>>;
-    auto set    = cuco::experimental::static_set<Key,
-                                              extent_type,
-                                              cuda::thread_scope_device,
-                                              thrust::equal_to<Key>,
-                                              probe,
-                                              allocator_type,
-                                              storage_type>{num_keys, cuco::empty_key<Key>{-1}};
+  auto set = cuco::experimental::static_set<Key,
+                                            cuco::experimental::extent<std::size_t>,
+                                            cuda::thread_scope_device,
+                                            thrust::equal_to<Key>,
+                                            probe,
+                                            cuco::cuda_allocator<std::byte>,
+                                            cuco::experimental::aow_storage<2>>{
+    num_keys, cuco::empty_key<Key>{-1}};
 
-    REQUIRE(set.capacity() == gold_capacity);
+  REQUIRE(set.capacity() == gold_capacity);
 
-    test_unique_sequence(set, num_keys);
-  }
-
-  if constexpr (Probe == cuco::test::probe_sequence::double_hashing) {
-    using probe = cuco::experimental::
-      double_hashing<CGSize, cuco::murmurhash3_32<Key>, cuco::murmurhash3_32<Key>>;
-    auto set = cuco::experimental::static_set<Key,
-                                              extent_type,
-                                              cuda::thread_scope_device,
-                                              thrust::equal_to<Key>,
-                                              probe,
-                                              allocator_type,
-                                              storage_type>{num_keys, cuco::empty_key<Key>{-1}};
-
-    REQUIRE(set.capacity() == gold_capacity);
-
-    test_unique_sequence(set, num_keys);
-  }
+  test_unique_sequence(set, num_keys);
 }


### PR DESCRIPTION
This PR adds device side `insert_and_find` APIs for `static_set`. It also includes small cleanups of the current refactoring code.