### PR TITLE
Clean up test code

### DIFF
--- a/tests/static_multimap/multiplicity_test.cu
+++ b/tests/static_multimap/multiplicity_test.cu
@@ -161,18 +161,12 @@ TEMPLATE_TEST_CASE_SIG(
 {
   constexpr std::size_t num_items{4};
 
-  if constexpr (Probe == cuco::test::probe_sequence::linear_probing) {
-    cuco::static_multimap<Key,
-                          Value,
-                          cuda::thread_scope_device,
-                          cuco::cuda_allocator<char>,
-                          cuco::linear_probing<1, cuco::murmurhash3_32<Key>>>
-      map{5, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};
-    test_multiplicity_two(map, num_items);
-  }
-  if constexpr (Probe == cuco::test::probe_sequence::double_hashing) {
-    cuco::static_multimap<Key, Value> map{
-      5, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};
-    test_multiplicity_two(map, num_items);
-  }
+  using probe = std::conditional_t<
+    Probe == cuco::test::probe_sequence::linear_probing,
+    cuco::linear_probing<1, cuco::murmurhash3_32<Key>>,
+    cuco::double_hashing<8, cuco::murmurhash3_32<Key>, cuco::murmurhash3_32<Key>>>;
+
+  cuco::static_multimap<Key, Value, cuda::thread_scope_device, cuco::cuda_allocator<char>, probe>
+    map{5, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};
+  test_multiplicity_two(map, num_items);
 }

--- a/tests/static_multimap/non_match_test.cu
+++ b/tests/static_multimap/non_match_test.cu
@@ -139,18 +139,16 @@ TEMPLATE_TEST_CASE_SIG(
                       return cuco::pair_type<Key, Value>{i / 2, i};
                     });
 
-  if constexpr (Probe == cuco::test::probe_sequence::linear_probing) {
-    cuco::static_multimap<Key,
-                          Value,
-                          cuda::thread_scope_device,
-                          cuco::cuda_allocator<char>,
-                          cuco::linear_probing<1, cuco::murmurhash3_32<Key>>>
-      map{num_keys * 2, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};
-    test_non_matches<Key, Value>(map, d_pairs.begin(), d_keys.begin(), num_keys);
-  }
-  if constexpr (Probe == cuco::test::probe_sequence::double_hashing) {
-    cuco::static_multimap<Key, Value> map{
-      num_keys * 2, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};
-    test_non_matches<Key, Value>(map, d_pairs.begin(), d_keys.begin(), num_keys);
-  }
+  using probe = std::conditional_t<
+    Probe == cuco::test::probe_sequence::linear_probing,
+    cuco::linear_probing<1, cuco::murmurhash3_32<Key>>,
+    cuco::double_hashing<8, cuco::murmurhash3_32<Key>, cuco::murmurhash3_32<Key>>>;
+
+  cuco::static_multimap<Key,
+                        Value,
+                        cuda::thread_scope_device,
+                        cuco::cuda_allocator<char>,
+                        cuco::linear_probing<1, cuco::murmurhash3_32<Key>>>
+    map{num_keys * 2, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};
+  test_non_matches<Key, Value>(map, d_pairs.begin(), d_keys.begin(), num_keys);
 }

--- a/tests/utils.hpp
+++ b/tests/utils.hpp
@@ -24,6 +24,8 @@
 
 #include <cooperative_groups.h>
 
+#include <iterator>
+
 namespace cuco {
 namespace test {
 
@@ -37,7 +39,7 @@ enum class probe_sequence { linear_probing, double_hashing };
 template <typename Iterator, typename Predicate>
 int count_if(Iterator begin, Iterator end, Predicate p, cudaStream_t stream = 0)
 {
-  auto const size      = end - begin;
+  auto const size      = std::distance(begin, end);
   auto const grid_size = (size + block_size - 1) / block_size;
 
   int* count;
@@ -51,7 +53,7 @@ int count_if(Iterator begin, Iterator end, Predicate p, cudaStream_t stream = 0)
   detail::count_if<<<grid_size, block_size, 0, stream>>>(begin, end, count, p);
   CUCO_CUDA_TRY(cudaStreamSynchronize(stream));
 
-  auto res = *count;
+  auto const res = *count;
 
   CUCO_CUDA_TRY(cudaFree(count));
 
@@ -61,7 +63,7 @@ int count_if(Iterator begin, Iterator end, Predicate p, cudaStream_t stream = 0)
 template <typename Iterator, typename Predicate>
 bool all_of(Iterator begin, Iterator end, Predicate p, cudaStream_t stream = 0)
 {
-  auto const size  = end - begin;
+  auto const size  = std::distance(begin, end);
   auto const count = count_if(begin, end, p, stream);
 
   return size == count;
@@ -83,7 +85,7 @@ bool none_of(Iterator begin, Iterator end, Predicate p, cudaStream_t stream = 0)
 template <typename Iterator1, typename Iterator2, typename Predicate>
 bool equal(Iterator1 begin1, Iterator1 end1, Iterator2 begin2, Predicate p, cudaStream_t stream = 0)
 {
-  auto const size      = end1 - begin1;
+  auto const size      = std::distance(begin1, end1);
   auto const grid_size = (size + block_size - 1) / block_size;
 
   int* count;

--- a/tests/utils.hpp
+++ b/tests/utils.hpp
@@ -99,7 +99,7 @@ bool equal(Iterator1 begin1, Iterator1 end1, Iterator2 begin2, Predicate p, cuda
   detail::count_if<<<grid_size, block_size, 0, stream>>>(begin1, end1, begin2, count, p);
   CUCO_CUDA_TRY(cudaStreamSynchronize(stream));
 
-  auto res = *count;
+  auto const res = *count;
 
   CUCO_CUDA_TRY(cudaFree(count));
 


### PR DESCRIPTION
Some minor cleanups of the test code:

- Use `conditional_t` instead of `if constexpr` to minimize redundancy
- Use `std::distance` instead of raw `-` operator to determine the iterator scope
- `const` when possible