### PR TITLE
Update `static_map` size computation

### DIFF
--- a/include/cuco/detail/common_kernels.cuh
+++ b/include/cuco/detail/common_kernels.cuh
@@ -50,7 +50,8 @@ __global__ void size(View view, AtomicT* count)
 
   while (idx < n) {
     auto const key = (slots + idx)->first.load(cuda::std::memory_order_relaxed);
-    thread_count += not cuco::detail::bitwise_compare(key, view.get_empty_key_sentinel());
+    thread_count += not(cuco::detail::bitwise_compare(key, view.get_empty_key_sentinel()) or
+                        cuco::detail::bitwise_compare(key, view.get_erased_key_sentinel()));
     idx += loop_stride;
   }
 

--- a/include/cuco/detail/common_kernels.cuh
+++ b/include/cuco/detail/common_kernels.cuh
@@ -46,10 +46,10 @@ __global__ void size(View view, AtomicT* count)
   size_type thread_count = 0;
   auto const n           = view.get_capacity();
 
-  auto* slots = reinterpret_cast<typename View::value_type*>(view.get_slots());
+  auto* slots = view.get_slots();
 
   while (idx < n) {
-    auto const key = (*(slots + idx)).first;
+    auto const key = (slots + idx)->first.load(cuda::std::memory_order_relaxed);
     thread_count += not cuco::detail::bitwise_compare(key, view.get_empty_key_sentinel());
     idx += loop_stride;
   }

--- a/include/cuco/detail/common_kernels.cuh
+++ b/include/cuco/detail/common_kernels.cuh
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cuco/detail/bitwise_compare.cuh>
+#include <cuco/detail/utils.hpp>
+
+#include <cub/block/block_reduce.cuh>
+
+#include <cuda/atomic>
+
+namespace cuco {
+namespace detail {
+
+/**
+ * @brief Calculates the number of filled slots for the given view.
+ *
+ * @tparam BlockSize Number of threads in each block
+ * @tparam View Type of non-owning view allowing access to map storage
+ * @tparam AtomicT Atomic counter type
+ *
+ * @param view Non-owning device view used to access to map storage
+ * @param count Number of filled slots
+ */
+template <int32_t BlockSize, typename View, typename AtomicT>
+__global__ void size(View view, AtomicT* count)
+{
+  using size_type = std::size_t;
+
+  cuco::detail::index_type const loop_stride = gridDim.x * BlockSize;
+  cuco::detail::index_type idx               = BlockSize * blockIdx.x + threadIdx.x;
+
+  size_type thread_count = 0;
+  auto const n           = view.get_capacity();
+
+  auto* slots = reinterpret_cast<typename View::value_type*>(view.get_slots());
+
+  while (idx < n) {
+    auto const key = (*(slots + idx)).first;
+    thread_count += not cuco::detail::bitwise_compare(key, view.get_empty_key_sentinel());
+    idx += loop_stride;
+  }
+
+  using BlockReduce = cub::BlockReduce<size_type, BlockSize>;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+  size_type const block_count = BlockReduce(temp_storage).Sum(thread_count);
+  if (threadIdx.x == 0) { count->fetch_add(block_count, cuda::std::memory_order_relaxed); }
+}
+
+}  // namespace detail
+}  // namespace cuco

--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -287,20 +287,21 @@ void static_map<Key, Value, Scope, Allocator>::contains(InputIt first,
 template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
 std::size_t static_map<Key, Value, Scope, Allocator>::get_size(cudaStream_t stream) const noexcept
 {
-  using namespace experimental::detail;
-
-  auto view    = get_device_view();
-  auto counter = counter_storage<std::size_t, Scope, Allocator>{slot_allocator_};
+  auto view = get_device_view();
+  auto counter =
+    experimental::detail::counter_storage<std::size_t, Scope, Allocator>{slot_allocator_};
   counter.reset(stream);
 
   auto const grid_size =
-    (this->get_capacity() + CUCO_DEFAULT_STRIDE * CUCO_DEFAULT_BLOCK_SIZE - 1) /
-    (CUCO_DEFAULT_STRIDE * CUCO_DEFAULT_BLOCK_SIZE);
+    (this->get_capacity() +
+     experimental::detail::CUCO_DEFAULT_STRIDE * experimental::detail::CUCO_DEFAULT_BLOCK_SIZE -
+     1) /
+    (experimental::detail::CUCO_DEFAULT_STRIDE * experimental::detail::CUCO_DEFAULT_BLOCK_SIZE);
 
   // TODO: custom kernel to be replaced by cub::DeviceReduce::Sum when cub version is bumped to
   // v2.1.0
-  detail::size<CUCO_DEFAULT_BLOCK_SIZE>
-    <<<grid_size, CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(view, counter.data());
+  detail::size<experimental::detail::CUCO_DEFAULT_BLOCK_SIZE>
+    <<<grid_size, experimental::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(view, counter.data());
 
   return counter.load_to_host(stream);
 }

--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -306,6 +306,12 @@ std::size_t static_map<Key, Value, Scope, Allocator>::get_size(cudaStream_t stre
 }
 
 template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
+float static_map<Key, Value, Scope, Allocator>::get_load_factor(cudaStream_t stream) const noexcept
+{
+  return static_cast<float>(this->get_size(stream)) / capacity_;
+}
+
+template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
 template <typename KeyEqual>
 __device__ static_map<Key, Value, Scope, Allocator>::device_mutable_view::insert_result
 static_map<Key, Value, Scope, Allocator>::device_mutable_view::packed_cas(

--- a/include/cuco/detail/static_multimap/device_view_impl.inl
+++ b/include/cuco/detail/static_multimap/device_view_impl.inl
@@ -63,7 +63,8 @@ class static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_view_
                                             Value empty_value_sentinel) noexcept
     : probe_sequence_{slots, capacity},
       empty_key_sentinel_{empty_key_sentinel},
-      empty_value_sentinel_{empty_value_sentinel}
+      empty_value_sentinel_{empty_value_sentinel},
+      erased_key_sentinel_{empty_key_sentinel}
   {
   }
 
@@ -173,6 +174,13 @@ class static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_view_
   }
 
   /**
+   * @brief Gets the sentinel value used to represent an erased key slot.
+   *
+   * @return The sentinel value used to represent an erased key slot
+   */
+  __host__ __device__ Key get_erased_key_sentinel() const noexcept { return erased_key_sentinel_; }
+
+  /**
    * @brief Gets slots array.
    *
    * @return Slots array
@@ -206,6 +214,7 @@ class static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_view_
   probe_sequence_type probe_sequence_;  ///< Probe sequence used to probe the hash map
   Key empty_key_sentinel_{};            ///< Key value that represents an empty slot
   Value empty_value_sentinel_{};        ///< Initial Value of empty slot
+  Key erased_key_sentinel_{};           ///< Key value that represents an erased slot
 };                                      // class device_view_impl_base
 
 template <typename Key,

--- a/include/cuco/detail/static_multimap/device_view_impl.inl
+++ b/include/cuco/detail/static_multimap/device_view_impl.inl
@@ -174,9 +174,9 @@ class static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_view_
   }
 
   /**
-   * @brief Gets the sentinel value used to represent an erased key slot.
+   * @brief Gets the sentinel value used to represent an erased slot.
    *
-   * @return The sentinel value used to represent an erased key slot
+   * @return The sentinel value used to represent an erased slot
    */
   __host__ __device__ Key get_erased_key_sentinel() const noexcept { return erased_key_sentinel_; }
 

--- a/include/cuco/detail/static_multimap/static_multimap.inl
+++ b/include/cuco/detail/static_multimap/static_multimap.inl
@@ -909,20 +909,21 @@ template <typename Key,
 std::size_t static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::get_size(
   cudaStream_t stream) const noexcept
 {
-  using namespace experimental::detail;
-
-  auto view    = get_device_view();
-  auto counter = counter_storage<std::size_t, Scope, Allocator>{slot_allocator_};
+  auto view = get_device_view();
+  auto counter =
+    experimental::detail::counter_storage<std::size_t, Scope, Allocator>{slot_allocator_};
   counter.reset(stream);
 
   auto const grid_size =
-    (this->get_capacity() + CUCO_DEFAULT_STRIDE * CUCO_DEFAULT_BLOCK_SIZE - 1) /
-    (CUCO_DEFAULT_STRIDE * CUCO_DEFAULT_BLOCK_SIZE);
+    (this->get_capacity() +
+     experimental::detail::CUCO_DEFAULT_STRIDE * experimental::detail::CUCO_DEFAULT_BLOCK_SIZE -
+     1) /
+    (experimental::detail::CUCO_DEFAULT_STRIDE * experimental::detail::CUCO_DEFAULT_BLOCK_SIZE);
 
   // TODO: custom kernel to be replaced by cub::DeviceReduce::Sum when cub version is bumped to
   // v2.1.0
-  detail::size<CUCO_DEFAULT_BLOCK_SIZE>
-    <<<grid_size, CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(view, counter.data());
+  detail::size<experimental::detail::CUCO_DEFAULT_BLOCK_SIZE>
+    <<<grid_size, experimental::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(view, counter.data());
 
   return counter.load_to_host(stream);
 }

--- a/include/cuco/detail/static_multimap/static_multimap.inl
+++ b/include/cuco/detail/static_multimap/static_multimap.inl
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#include <cuco/detail/common_kernels.cuh>
+#include <cuco/detail/storage/counter_storage.cuh>
+#include <cuco/detail/tuning.cuh>
 #include <cuco/detail/utils.cuh>
 #include <cuco/detail/utils.hpp>
 
@@ -906,10 +909,25 @@ template <typename Key,
 std::size_t static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::get_size(
   cudaStream_t stream) const noexcept
 {
-  auto begin  = thrust::make_transform_iterator(raw_slots(), detail::slot_to_tuple<Key, Value>{});
-  auto filled = cuco::detail::slot_is_filled<Key>{get_empty_key_sentinel()};
+  static_assert(sizeof(pair_atomic_type) == sizeof(value_type));
+  auto view = get_device_view();
 
-  return thrust::count_if(thrust::cuda::par.on(stream), begin, begin + get_capacity(), filled);
+  auto counter =
+    experimental::detail::counter_storage<std::size_t, Scope, Allocator>{slot_allocator_};
+  counter.reset(stream);
+
+  auto const grid_size =
+    (this->get_capacity() +
+     experimental::detail::CUCO_DEFAULT_STRIDE * experimental::detail::CUCO_DEFAULT_BLOCK_SIZE -
+     1) /
+    (experimental::detail::CUCO_DEFAULT_STRIDE * experimental::detail::CUCO_DEFAULT_BLOCK_SIZE);
+
+  // TODO: custom kernel to be replaced by cub::DeviceReduce::Sum when cub version is bumped to
+  // v2.1.0
+  detail::size<experimental::detail::CUCO_DEFAULT_BLOCK_SIZE>
+    <<<grid_size, experimental::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(view, counter.data());
+
+  return counter.load_to_host(stream);
 }
 
 template <typename Key,

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -1363,14 +1363,14 @@ class static_map {
    *
    * @return The number of elements in the map
    */
-  std::size_t get_size(cudaStream_t stream = 0) const noexcept;
+  [[nodiscard]] std::size_t get_size(cudaStream_t stream = 0) const noexcept;
 
   /**
    * @brief Gets the load factor of the hash map.
    *
    * @return The load factor of the hash map
    */
-  float get_load_factor() const noexcept
+  float get_load_factor(cudaStream_t stream = 0) const noexcept
   {
     return static_cast<float>(this->get_size()) / capacity_;
   }

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -1368,12 +1368,11 @@ class static_map {
   /**
    * @brief Gets the load factor of the hash map.
    *
+   * @param stream Stream used for load factor computation
+   *
    * @return The load factor of the hash map
    */
-  float get_load_factor(cudaStream_t stream = 0) const noexcept
-  {
-    return static_cast<float>(this->get_size()) / capacity_;
-  }
+  [[nodiscard]] float get_load_factor(cudaStream_t stream = 0) const noexcept;
 
   /**
    * @brief Gets the sentinel value used to represent an empty key slot.

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -242,20 +242,23 @@ class static_map {
    * convertible to the map's `value_type`
    * @tparam Hash Unary callable type
    * @tparam KeyEqual Binary callable type
+   *
    * @param first Beginning of the sequence of key/value pairs
    * @param last End of the sequence of key/value pairs
    * @param hash The unary function to apply to hash each key
    * @param key_equal The binary function to compare two keys for equality
    * @param stream Stream used for executing the kernels
+   *
+   * @return Number of successful insertions
    */
   template <typename InputIt,
             typename Hash     = cuco::murmurhash3_32<key_type>,
             typename KeyEqual = thrust::equal_to<key_type>>
-  void insert(InputIt first,
-              InputIt last,
-              Hash hash           = Hash{},
-              KeyEqual key_equal  = KeyEqual{},
-              cudaStream_t stream = 0);
+  std::size_t insert(InputIt first,
+                     InputIt last,
+                     Hash hash           = Hash{},
+                     KeyEqual key_equal  = KeyEqual{},
+                     cudaStream_t stream = 0);
 
   /**
    * @brief Inserts key/value pairs in the range `[first, last)` if `pred`
@@ -271,6 +274,7 @@ class static_map {
    * argument type is convertible from <tt>std::iterator_traits<StencilIt>::value_type</tt>
    * @tparam Hash Unary callable type
    * @tparam KeyEqual Binary callable type
+   *
    * @param first Beginning of the sequence of key/value pairs
    * @param last End of the sequence of key/value pairs
    * @param stencil Beginning of the stencil sequence
@@ -279,19 +283,21 @@ class static_map {
    * @param hash The unary function to hash each key
    * @param key_equal The binary function to compare two keys for equality
    * @param stream CUDA stream used for insert
+   *
+   * @return Number of successful insertions
    */
   template <typename InputIt,
             typename StencilIt,
             typename Predicate,
             typename Hash     = cuco::murmurhash3_32<key_type>,
             typename KeyEqual = thrust::equal_to<key_type>>
-  void insert_if(InputIt first,
-                 InputIt last,
-                 StencilIt stencil,
-                 Predicate pred,
-                 Hash hash           = Hash{},
-                 KeyEqual key_equal  = KeyEqual{},
-                 cudaStream_t stream = 0);
+  std::size_t insert_if(InputIt first,
+                        InputIt last,
+                        StencilIt stencil,
+                        Predicate pred,
+                        Hash hash           = Hash{},
+                        KeyEqual key_equal  = KeyEqual{},
+                        cudaStream_t stream = 0);
 
   /**
    * @brief Erases keys in the range `[first, last)`.
@@ -307,27 +313,30 @@ class static_map {
    *
    * This function synchronizes `stream`.
    *
+   * @throw std::runtime_error if a unique erased key sentinel value was not
+   * provided at construction
+   *
    * @tparam InputIt Device accessible input iterator whose `value_type` is
    * convertible to the map's `value_type`
    * @tparam Hash Unary callable type
    * @tparam KeyEqual Binary callable type
+   *
    * @param first Beginning of the sequence of keys
    * @param last End of the sequence of keys
    * @param hash The unary function to apply to hash each key
    * @param key_equal The binary function to compare two keys for equality
    * @param stream Stream used for executing the kernels
    *
-   * @throw std::runtime_error if a unique erased key sentinel value was not
-   * provided at construction
+   * @return Number of successful erasures
    */
   template <typename InputIt,
             typename Hash     = cuco::murmurhash3_32<key_type>,
             typename KeyEqual = thrust::equal_to<key_type>>
-  void erase(InputIt first,
-             InputIt last,
-             Hash hash           = Hash{},
-             KeyEqual key_equal  = KeyEqual{},
-             cudaStream_t stream = 0);
+  std::size_t erase(InputIt first,
+                    InputIt last,
+                    Hash hash           = Hash{},
+                    KeyEqual key_equal  = KeyEqual{},
+                    cudaStream_t stream = 0);
 
   /**
    * @brief Finds the values corresponding to all keys in the range `[first, last)`.
@@ -1350,16 +1359,21 @@ class static_map {
   /**
    * @brief Gets the number of elements in the hash map.
    *
+   * @param stream Stream used for size computation
+   *
    * @return The number of elements in the map
    */
-  std::size_t get_size() const noexcept { return size_; }
+  std::size_t get_size(cudaStream_t stream = 0) const noexcept;
 
   /**
    * @brief Gets the load factor of the hash map.
    *
    * @return The load factor of the hash map
    */
-  float get_load_factor() const noexcept { return static_cast<float>(size_) / capacity_; }
+  float get_load_factor() const noexcept
+  {
+    return static_cast<float>(this->get_size()) / capacity_;
+  }
 
   /**
    * @brief Gets the sentinel value used to represent an empty key slot.

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -664,6 +664,16 @@ class static_multimap {
       return impl_.get_empty_value_sentinel();
     }
 
+    /**
+     * @brief Gets the sentinel value used to represent an empty key slot.
+     *
+     * @return The sentinel value used to represent an empty key slot
+     */
+    __host__ __device__ __forceinline__ Key get_erased_key_sentinel() const noexcept
+    {
+      return impl_.get_erased_key_sentinel();
+    }
+
    protected:
     ViewImpl impl_;
   };  // class device_view_base
@@ -1343,9 +1353,11 @@ class static_multimap {
   }
 
  private:
-  std::size_t capacity_{};                      ///< Total number of slots
-  Key empty_key_sentinel_{};                    ///< Key value that represents an empty slot
-  Value empty_value_sentinel_{};                ///< Initial value of empty slot
+  std::size_t capacity_{};        ///< Total number of slots
+  Key empty_key_sentinel_{};      ///< Key value that represents an empty slot
+  Value empty_value_sentinel_{};  ///< Initial value of empty slot
+  // TODO multimap erase
+  Key erased_key_sentinel_{};                   ///< Key value that represents an erased slot
   slot_allocator_type slot_allocator_{};        ///< Allocator used to allocate slots
   counter_allocator_type counter_allocator_{};  ///< Allocator used to allocate counters
   counter_deleter delete_counter_;              ///< Custom counter deleter

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -1286,7 +1286,8 @@ class static_multimap {
   /**
    * @brief Gets the number of elements in the hash map.
    *
-   * @param stream CUDA stream used to get the number of inserted elements
+   * @param stream CUDA stream used for size computation
+   *
    * @return The number of elements in the map
    */
   std::size_t get_size(cudaStream_t stream = 0) const noexcept;

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -1300,7 +1300,7 @@ class static_multimap {
    *
    * @return The number of elements in the map
    */
-  std::size_t get_size(cudaStream_t stream = 0) const noexcept;
+  [[nodiscard]] std::size_t get_size(cudaStream_t stream = 0) const noexcept;
 
   /**
    * @brief Gets the load factor of the hash map.
@@ -1308,7 +1308,7 @@ class static_multimap {
    * @param stream CUDA stream used to get the load factor
    * @return The load factor of the hash map
    */
-  float get_load_factor(cudaStream_t stream = 0) const noexcept;
+  [[nodiscard]] float get_load_factor(cudaStream_t stream = 0) const noexcept;
 
   /**
    * @brief Gets the sentinel value used to represent an empty key slot.

--- a/tests/static_map/erase_test.cu
+++ b/tests/static_map/erase_test.cu
@@ -53,8 +53,9 @@ TEMPLATE_TEST_CASE_SIG("erase key", "", ((typename T), T), (int32_t), (int64_t))
 
     REQUIRE(map.get_size() == num_keys);
 
-    map.erase(d_keys.begin(), d_keys.end());
+    auto const size = map.erase(d_keys.begin(), d_keys.end());
 
+    REQUIRE(size == num_keys);
     REQUIRE(map.get_size() == 0);
 
     map.contains(d_keys.begin(), d_keys.end(), d_keys_exist.begin());


### PR DESCRIPTION
Closes #300 

Several changes involved in this PR:

- Using a custom kernel to compute the number of filled slots in map and multimap
- Fixing a bug where erased slots are not counted as empty slots
- Allowing size computation for more than 2^31 elements and to be replaced by cub reduce sum once cub-v2.1.0 is available
- Changing the `static_map` public APIs like `insert`, `insert_if` and `erase` to return the number of successful insertions/erasures
- Adding `erased_key_sentinel` into multimap

Note: `get_size` is **expensive**, use the return value of bulk insert/erase when possible.