### PR TITLE
Faster modulo computation for runtime extents

### DIFF
--- a/include/cuco/detail/probing_scheme_impl.inl
+++ b/include/cuco/detail/probing_scheme_impl.inl
@@ -124,8 +124,9 @@ template <typename ProbeKey, typename Extent>
 __host__ __device__ constexpr auto double_hashing<CGSize, Hash1, Hash2>::operator()(
   ProbeKey const& probe_key, Extent upper_bound) const noexcept
 {
+  // TODO make step size an odd number in case extent_kind::POW2
   static_assert(Extent::kind != extent_kind::PLAIN,
-                "Double hashing cannot be used with extent_kind::PLAIN");
+                "Double hashing cannot be used with extent_kind::PLAIN or extent_kind::POW2");
 
   return detail::probing_iterator<Extent>{
     upper_bound.mod(hash1_(probe_key)),
@@ -141,8 +142,9 @@ __host__ __device__ constexpr auto double_hashing<CGSize, Hash1, Hash2>::operato
   ProbeKey const& probe_key,
   Extent upper_bound) const noexcept
 {
+  // TODO make step size an odd number in case extent_kind::POW2
   static_assert(Extent::kind != extent_kind::PLAIN,
-                "Double hashing cannot be used with extent_kind::PLAIN");
+                "Double hashing cannot be used with extent_kind::PLAIN or extent_kind::POW2");
 
   return detail::probing_iterator<Extent>{
     upper_bound.mod(hash1_(probe_key) + g.thread_rank()),

--- a/include/cuco/extent.cuh
+++ b/include/cuco/extent.cuh
@@ -43,6 +43,8 @@ struct extent {
 
   using value_type = SizeType;  ///< Extent value type
 
+  static constexpr extent_kind kind = Kind;  ///< Extent kind
+
   constexpr extent() = default;
 
   /// Constructs from `SizeType`
@@ -89,6 +91,8 @@ struct extent<SizeType, dynamic_extent, Kind> {
   static_assert(std::is_integral_v<SizeType>, "SizeType must be an integer type");
 
   using value_type = SizeType;  ///< Extent value type
+
+  static constexpr extent_kind kind = Kind;  ///< Extent kind
 
   /**
    * @brief Constructs extent from a given `size`.


### PR DESCRIPTION
This PR introduces a new tparam for the `extent` class, namely `extent_kind`, which can be used to specify if the extent should be a prime number, a power-of-two, or just a plain number.
Constraining the valid extent values to one of these classes enables us to dispatch optimized modulo operators if the extent's value is only known at runtime (for compile-time extents, the compiler already can and will figure out a faster implementation than what's given by the builtin `operator%`).

TODOs
- [ ] add tests for `POW2`, `PLAIN`, and `PRIME`
- [ ] add benchmarks
- [ ] enable `POW2` extents for double hashing (make the step size an odd number, so it is always co-prime to the capacity)
- [ ] ~~enable fast modulo computation for prime extents by computing a set of magic numbers (pre-computed or on-the-fly)~~ Moved to a new PR

Closes #284 