### PR TITLE
Make size type a template parameter to get rid of narrow conversions

### DIFF
--- a/include/cuco/detail/storage/aow_storage.cuh
+++ b/include/cuco/detail/storage/aow_storage.cuh
@@ -272,7 +272,8 @@ class aow_storage : public aow_storage_base<WindowSize, T, Extent> {
     typename std::allocator_traits<Allocator>::rebind_alloc<window_type>;  ///< Type of the
                                                                            ///< allocator to
                                                                            ///< (de)allocate windows
-  using window_deleter_type = custom_deleter<allocator_type>;  ///< Type of window deleter
+  using window_deleter_type =
+    custom_deleter<size_type, allocator_type>;  ///< Type of window deleter
   using ref_type = aow_storage_ref<window_size, value_type, extent_type>;  ///< Storage ref type
 
   /**

--- a/include/cuco/detail/storage/counter_storage.cuh
+++ b/include/cuco/detail/storage/counter_storage.cuh
@@ -44,7 +44,8 @@ class counter_storage : public storage_base<cuco::experimental::extent<SizeType,
   using value_type     = cuda::atomic<size_type, Scope>;  ///< Type of the counter
   using allocator_type = typename std::allocator_traits<Allocator>::rebind_alloc<
     value_type>;  ///< Type of the allocator to (de)allocate counter
-  using counter_deleter_type = custom_deleter<allocator_type>;  ///< Type of counter deleter
+  using counter_deleter_type =
+    custom_deleter<size_type, allocator_type>;  ///< Type of counter deleter
 
   /**
    * @brief Constructor of counter storage.

--- a/include/cuco/detail/storage/storage_base.cuh
+++ b/include/cuco/detail/storage/storage_base.cuh
@@ -24,9 +24,10 @@ namespace detail {
 /**
  * @brief Custom deleter for unique pointer.
  *
+ * @tparam SizeType Type of device storage size
  * @tparam Allocator Type of allocator used for device storage
  */
-template <typename Allocator>
+template <typename SizeType, typename Allocator>
 struct custom_deleter {
   using pointer = typename Allocator::value_type*;  ///< Value pointer type
 
@@ -36,7 +37,7 @@ struct custom_deleter {
    * @param size Number of values to deallocate
    * @param allocator Allocator used for deallocating device storage
    */
-  explicit constexpr custom_deleter(std::size_t size, Allocator& allocator)
+  explicit constexpr custom_deleter(SizeType size, Allocator& allocator)
     : size_{size}, allocator_{allocator}
   {
   }
@@ -48,7 +49,7 @@ struct custom_deleter {
    */
   void operator()(pointer ptr) { allocator_.deallocate(ptr, size_); }
 
-  std::size_t size_;      ///< Number of values to delete
+  SizeType size_;         ///< Number of values to delete
   Allocator& allocator_;  ///< Allocator used deallocating values
 };
 


### PR DESCRIPTION
This PR fixes a narrow conversion bug unveiled by cudf CI.