### PR TITLE
Fix narrow conversion issues in probing iterator

### DIFF
--- a/include/cuco/detail/probing_scheme_impl.inl
+++ b/include/cuco/detail/probing_scheme_impl.inl
@@ -96,7 +96,8 @@ template <typename ProbeKey, typename Extent>
 __host__ __device__ constexpr auto linear_probing<CGSize, Hash>::operator()(
   ProbeKey const& probe_key, Extent upper_bound) const noexcept
 {
-  return detail::probing_iterator<Extent>{hash_(probe_key) % upper_bound,
+  using size_type = typename Extent::value_type;
+  return detail::probing_iterator<Extent>{static_cast<size_type>(hash_(probe_key) % upper_bound),
                                           1,  // step size is 1
                                           upper_bound};
 }
@@ -108,8 +109,11 @@ __host__ __device__ constexpr auto linear_probing<CGSize, Hash>::operator()(
   ProbeKey const& probe_key,
   Extent upper_bound) const noexcept
 {
+  using size_type = typename Extent::value_type;
   return detail::probing_iterator<Extent>{
-    (hash_(probe_key) + g.thread_rank()) % upper_bound, cg_size, upper_bound};
+    static_cast<size_type>((hash_(probe_key) + g.thread_rank()) % upper_bound),
+    cg_size,
+    upper_bound};
 }
 
 template <int32_t CGSize, typename Hash1, typename Hash2>
@@ -124,9 +128,11 @@ template <typename ProbeKey, typename Extent>
 __host__ __device__ constexpr auto double_hashing<CGSize, Hash1, Hash2>::operator()(
   ProbeKey const& probe_key, Extent upper_bound) const noexcept
 {
+  using size_type = typename Extent::value_type;
   return detail::probing_iterator<Extent>{
-    hash1_(probe_key) % upper_bound,
-    hash2_(probe_key) % (upper_bound - 1) + 1,  // step size in range [1, prime - 1]
+    static_cast<size_type>(hash1_(probe_key) % upper_bound),
+    static_cast<size_type>(hash2_(probe_key) % (upper_bound - 1) +
+                           1),  // step size in range [1, prime - 1]
     upper_bound};
 }
 
@@ -137,9 +143,10 @@ __host__ __device__ constexpr auto double_hashing<CGSize, Hash1, Hash2>::operato
   ProbeKey const& probe_key,
   Extent upper_bound) const noexcept
 {
+  using size_type = typename Extent::value_type;
   return detail::probing_iterator<Extent>{
-    (hash1_(probe_key) + g.thread_rank()) % upper_bound,
-    (hash2_(probe_key) % (upper_bound / cg_size - 1) + 1) * cg_size,
+    static_cast<size_type>((hash1_(probe_key) + g.thread_rank()) % upper_bound),
+    static_cast<size_type>((hash2_(probe_key) % (upper_bound / cg_size - 1) + 1) * cg_size),
     upper_bound};
 }
 }  // namespace experimental

--- a/tests/static_set/unique_sequence_test.cu
+++ b/tests/static_set/unique_sequence_test.cu
@@ -29,8 +29,10 @@
 
 #include <catch2/catch_template_test_macros.hpp>
 
+using size_type = int32_t;
+
 template <typename Set>
-__inline__ void test_unique_sequence(Set& set, std::size_t num_keys)
+__inline__ void test_unique_sequence(Set& set, size_type num_keys)
 {
   using Key = typename Set::key_type;
 
@@ -125,9 +127,9 @@ TEMPLATE_TEST_CASE_SIG(
   (int64_t, cuco::test::probe_sequence::linear_probing, 1),
   (int64_t, cuco::test::probe_sequence::linear_probing, 2))
 {
-  constexpr std::size_t num_keys{400};
-  auto constexpr gold_capacity = CGSize == 1 ? 422  // 211 x 1 x 2
-                                             : 412  // 103 x 2 x 2
+  constexpr size_type num_keys{400};
+  constexpr size_type gold_capacity = CGSize == 1 ? 422  // 211 x 1 x 2
+                                                  : 412  // 103 x 2 x 2
     ;
 
   using probe =
@@ -138,7 +140,7 @@ TEMPLATE_TEST_CASE_SIG(
                                                           cuco::murmurhash3_32<Key>>>;
 
   auto set = cuco::experimental::static_set<Key,
-                                            cuco::experimental::extent<std::size_t>,
+                                            cuco::experimental::extent<size_type>,
                                             cuda::thread_scope_device,
                                             thrust::equal_to<Key>,
                                             probe,


### PR DESCRIPTION
Similar to #306 

This PR fixes narrow conversions inside the probing iterator. Corresponding tests are added to exercise this issue.