### PR TITLE
Extend macros for error checking and int128 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This will take care of downloading `cuCollections` from GitHub and making the he
 <a name="link-footnote">1</a>: `cuCollections` is header-only and therefore there is no binary component to "link" against. The linking terminology comes from CMake's `target_link_libraries` which is still used even for header-only library targets.
 
 ## Requirements
-- `nvcc 11.6+`
+- `nvcc 11.5+`
 - C++17
 - Volta+
     - Pascal is partially supported. Any data structures that require blocking algorithms are not supported. See [libcu++](https://nvidia.github.io/libcudacxx/setup/requirements.html#device-architectures) documentation for more details.

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 <th><b><a href="">Doxygen Documentation (TODO)</a></b></th>
 </tr></table>
 
-`cuCollections` (`cuco`) is an open-source, header-only library of GPU-accelerated, concurrent data structures. 
+`cuCollections` (`cuco`) is an open-source, header-only library of GPU-accelerated, concurrent data structures.
 
-Similar to how [Thrust](https://github.com/thrust/thrust) and [CUB](https://github.com/thrust/cub) provide STL-like, GPU accelerated algorithms and primitives, `cuCollections` provides STL-like concurrent data structures. `cuCollections` is not a one-to-one, drop-in replacement for STL data structures like `std::unordered_map`. Instead, it provides functionally similar data structures tailored for efficient use with GPUs. 
+Similar to how [Thrust](https://github.com/thrust/thrust) and [CUB](https://github.com/thrust/cub) provide STL-like, GPU accelerated algorithms and primitives, `cuCollections` provides STL-like concurrent data structures. `cuCollections` is not a one-to-one, drop-in replacement for STL data structures like `std::unordered_map`. Instead, it provides functionally similar data structures tailored for efficient use with GPUs.
 
 ## Development Status
 
-`cuCollections` is still under heavy development. Users should expect breaking changes and refactoring to be common. 
+`cuCollections` is still under heavy development. Users should expect breaking changes and refactoring to be common.
 
 ## Getting cuCollections
 
@@ -21,7 +21,7 @@ Similar to how [Thrust](https://github.com/thrust/thrust) and [CUB](https://gith
 
 `cuCollections` is designed to make it easy to include within another CMake project.
  The `CMakeLists.txt` exports a `cuco` target that can be linked<sup>[1](#link-footnote)</sup>
- into a target to setup include directories, dependencies, and compile flags necessary to use `cuCollections` in your project. 
+ into a target to setup include directories, dependencies, and compile flags necessary to use `cuCollections` in your project.
 
 
 We recommend using [CMake Package Manager (CPM)](https://github.com/TheLartians/CPM.cmake) to fetch `cuCollections` into your project.
@@ -47,12 +47,12 @@ target_link_libraries(my_library cuco)
 
 This will take care of downloading `cuCollections` from GitHub and making the headers available in a location that can be found by CMake. Linking against the `cuco` target will provide everything needed for `cuco` to be used by the `my_library` target.
 
-<a name="link-footnote">1</a>: `cuCollections` is header-only and therefore there is no binary component to "link" against. The linking terminology comes from CMake's `target_link_libraries` which is still used even for header-only library targets. 
+<a name="link-footnote">1</a>: `cuCollections` is header-only and therefore there is no binary component to "link" against. The linking terminology comes from CMake's `target_link_libraries` which is still used even for header-only library targets.
 
 ## Requirements
-- `nvcc 11+`
+- `nvcc 11.6+`
 - C++17
-- Volta+ 
+- Volta+
     - Pascal is partially supported. Any data structures that require blocking algorithms are not supported. See [libcu++](https://nvidia.github.io/libcudacxx/setup/requirements.html#device-architectures) documentation for more details.
 
 ## Dependencies
@@ -67,7 +67,7 @@ No action is required from the user to satisfy these dependencies. `cuCollection
 
 ## Building cuCollections
 
-Since `cuCollections` is header-only, there is nothing to build to use it. 
+Since `cuCollections` is header-only, there is nothing to build to use it.
 
 To build the tests, benchmarks, and examples:
 
@@ -75,7 +75,7 @@ To build the tests, benchmarks, and examples:
 cd $CUCO_ROOT
 mkdir -p build
 cd build
-cmake .. 
+cmake ..
 make
 ```
 Binaries will be built into:
@@ -179,7 +179,7 @@ class example_class {
 
 ## Data Structures
 
-We plan to add many GPU-accelerated, concurrent data structures to `cuCollections`. As of now, the two flagships are variants of hash tables. 
+We plan to add many GPU-accelerated, concurrent data structures to `cuCollections`. As of now, the two flagships are variants of hash tables.
 
 ### `static_set`
 

--- a/include/cuco/detail/__config
+++ b/include/cuco/detail/__config
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,23 @@
  * limitations under the License.
  */
 
- #pragma once
+#pragma once
 
- #include <nv/target>
+#include <nv/target>
+
+#if !defined(__CUDACC_VER_MAJOR__) || !defined(__CUDACC_VER_MINOR__)
+#error "NVCC version not found"
+#elif __CUDACC_VER_MAJOR__ < 11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ < 6)
+#error "NVCC version 11.6 or later is required"
+#endif
+
+#if !defined(__CUDACC_RELAXED_CONSTEXPR__)
+#error "Support for relaxed constexpr is required"
+#endif
+
+#if !defined(__CUDACC_EXTENDED_LAMBDA__)
+#error "Support for extended device lambdas is required"
+#endif
 
 // WAR for libcudacxx/296
 #define CUCO_CUDA_MINIMUM_ARCH _NV_FIRST_ARG(__CUDA_ARCH_LIST__)
@@ -31,4 +45,8 @@
 
 #if (CUCO_CUDA_MINIMUM_ARCH >= 700)
 #define CUCO_HAS_INDEPENDENT_THREADS
+#endif
+
+#if defined(__SIZEOF_INT128__) && (CUDART_VERSION) && (CUDART_VERSION >= 11060)
+#define CUCO_HAS_INT128
 #endif

--- a/include/cuco/detail/__config
+++ b/include/cuco/detail/__config
@@ -21,7 +21,7 @@
 #if !defined(__CUDACC_VER_MAJOR__) || !defined(__CUDACC_VER_MINOR__)
 #error "NVCC version not found"
 #elif __CUDACC_VER_MAJOR__ < 11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ < 5)
-#error "NVCC version 11.6 or later is required"
+#error "NVCC version 11.5 or later is required"
 #endif
 
 #if !defined(__CUDACC_RELAXED_CONSTEXPR__)
@@ -47,6 +47,6 @@
 #define CUCO_HAS_INDEPENDENT_THREADS
 #endif
 
-#if defined(__SIZEOF_INT128__) && (CUDART_VERSION) && (CUDART_VERSION >= 11060)
+#if defined(__SIZEOF_INT128__)
 #define CUCO_HAS_INT128
 #endif

--- a/include/cuco/detail/__config
+++ b/include/cuco/detail/__config
@@ -20,7 +20,7 @@
 
 #if !defined(__CUDACC_VER_MAJOR__) || !defined(__CUDACC_VER_MINOR__)
 #error "NVCC version not found"
-#elif __CUDACC_VER_MAJOR__ < 11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ < 6)
+#elif __CUDACC_VER_MAJOR__ < 11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ < 5)
 #error "NVCC version 11.6 or later is required"
 #endif
 


### PR DESCRIPTION
This PR defines some more error-checking macros in the `detail/__config` header and introduces a macro to check for `int128` support (which is required for the new `cuco::extent` implementation). Since `int128` support has been [introduced in CTK 11.6](https://docs.nvidia.com/cuda/archive/11.6.0/cuda-toolkit-release-notes/index.html#cuda-general-new-features) (preview in 11.5), I also bumped the minimum required nvcc version to 11.5.