### PR TITLE
Fix problem with implicit conversion of lhs operands in fast_int operators

### DIFF
--- a/include/cuco/utility/fast_int.cuh
+++ b/include/cuco/utility/fast_int.cuh
@@ -132,17 +132,19 @@ struct fast_int {
   value_type magic_;  ///< Magic number for fast division
   value_type shift_;  ///< Shift for fast division
 
-  friend __host__ __device__ constexpr value_type operator/(value_type lhs,
-                                                            fast_int const& rhs) noexcept
+  template <typename Lhs>
+  friend __host__ __device__ constexpr value_type operator/(Lhs lhs, fast_int const& rhs) noexcept
   {
+    static_assert(cuda::std::is_same_v<Lhs, value_type>,
+                  "Left-hand side operand must be of type value_type.");
     if (rhs.value_ == 1) { return lhs; }                // edge case for value_ == 1
     if (rhs.magic_ == 0) { return lhs >> rhs.shift_; }  // edge case for value_ == pow2
     auto const mul = (lhs == cuda::std::numeric_limits<T>::max()) ? lhs : lhs + 1;
     return rhs.mulhi(rhs.magic_, mul) >> rhs.shift_;
   }
 
-  friend __host__ __device__ constexpr value_type operator%(value_type lhs,
-                                                            fast_int const& rhs) noexcept
+  template <typename Lhs>
+  friend __host__ __device__ constexpr value_type operator%(Lhs lhs, fast_int const& rhs) noexcept
   {
     return lhs - (lhs / rhs) * rhs.value_;
   }


### PR DESCRIPTION
The optimized operator/ and operator% in `fast_int` require the left-hand side operands to be of the same type as the underlying `value_type` of the `fast_int`. In order to meet this constraint, the compiler converts the lhs to the `value_type` implicitly, which results in unexpected behavior when mixing signed and unsigned input types (see reproducer https://godbolt.org/z/j8z4a9rGK). 

This PR enforces the lhs operand to be of `value_type` and throws a compile-time error otherwise.