### PR TITLE
Make XXHash the default hash function

### DIFF
--- a/include/cuco/dynamic_map.cuh
+++ b/include/cuco/dynamic_map.cuh
@@ -208,7 +208,7 @@ class dynamic_map {
    * @param stream Stream used for executing the kernels
    */
   template <typename InputIt,
-            typename Hash     = cuco::murmurhash3_32<key_type>,
+            typename Hash     = cuco::default_hash_function<key_type>,
             typename KeyEqual = thrust::equal_to<key_type>>
   void insert(InputIt first,
               InputIt last,
@@ -247,7 +247,7 @@ class dynamic_map {
    * provided at construction
    */
   template <typename InputIt,
-            typename Hash     = cuco::murmurhash3_32<key_type>,
+            typename Hash     = cuco::default_hash_function<key_type>,
             typename KeyEqual = thrust::equal_to<key_type>>
   void erase(InputIt first,
              InputIt last,
@@ -277,7 +277,7 @@ class dynamic_map {
    */
   template <typename InputIt,
             typename OutputIt,
-            typename Hash     = cuco::murmurhash3_32<key_type>,
+            typename Hash     = cuco::default_hash_function<key_type>,
             typename KeyEqual = thrust::equal_to<key_type>>
   void find(InputIt first,
             InputIt last,
@@ -307,7 +307,7 @@ class dynamic_map {
    */
   template <typename InputIt,
             typename OutputIt,
-            typename Hash     = cuco::murmurhash3_32<key_type>,
+            typename Hash     = cuco::default_hash_function<key_type>,
             typename KeyEqual = thrust::equal_to<key_type>>
   void contains(InputIt first,
                 InputIt last,

--- a/include/cuco/hash_functions.cuh
+++ b/include/cuco/hash_functions.cuh
@@ -44,7 +44,7 @@ template <typename Key>
 using murmurhash3_fmix_64 = detail::MurmurHash3_fmix64<Key>;
 
 /**
- * @brief A `murmurhash3_32` hash function to hash the given argument on host and device.
+ * @brief A 32-bit `MurmurHash3` hash function to hash the given argument on host and device.
  *
  * @tparam Key The type of the values to hash
  */
@@ -52,7 +52,7 @@ template <typename Key>
 using murmurhash3_32 = detail::MurmurHash3_32<Key>;
 
 /**
- * @brief A `XXH32` hash function to hash the given argument on host and device.
+ * @brief A 32-bit `XXH32` hash function to hash the given argument on host and device.
  *
  * @tparam Key The type of the values to hash
  */
@@ -60,11 +60,19 @@ template <typename Key>
 using xxhash_32 = detail::XXHash_32<Key>;
 
 /**
- * @brief A `XXH64` hash function to hash the given argument on host and device.
+ * @brief A 64-bit `XXH64` hash function to hash the given argument on host and device.
  *
  * @tparam Key The type of the values to hash
  */
 template <typename Key>
 using xxhash_64 = detail::XXHash_64<Key>;
+
+/**
+ * @brief Default hash function.
+ *
+ * @tparam Key The type of the values to hash
+ */
+template <typename Key>
+using default_hash_function = xxhash_32<Key>;
 
 }  // namespace cuco

--- a/include/cuco/probe_sequences.cuh
+++ b/include/cuco/probe_sequences.cuh
@@ -60,7 +60,7 @@ class linear_probing : public detail::probe_sequence_base<CGSize> {
  * @tparam Hash1 Unary callable type
  * @tparam Hash2 Unary callable type
  */
-template <uint32_t CGSize, typename Hash1, typename Hash2>
+template <uint32_t CGSize, typename Hash1, typename Hash2 = Hash1>
 class double_hashing : public detail::probe_sequence_base<CGSize> {
  public:
   using probe_sequence_base_type =

--- a/include/cuco/probing_scheme.cuh
+++ b/include/cuco/probing_scheme.cuh
@@ -96,7 +96,7 @@ class linear_probing : private detail::probing_scheme_base<CGSize> {
  * @tparam Hash1 Unary callable type
  * @tparam Hash2 Unary callable type
  */
-template <int32_t CGSize, typename Hash1, typename Hash2>
+template <int32_t CGSize, typename Hash1, typename Hash2 = Hash1>
 class double_hashing : private detail::probing_scheme_base<CGSize> {
  public:
   using probing_scheme_base_type =

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -89,11 +89,11 @@ template <class Key,
           class Extent             = cuco::experimental::extent<std::size_t>,
           cuda::thread_scope Scope = cuda::thread_scope_device,
           class KeyEqual           = thrust::equal_to<Key>,
-          class ProbingScheme      = cuco::experimental::double_hashing<4,  // CG size
-                                                                   cuco::murmurhash3_32<Key>,
-                                                                   cuco::murmurhash3_32<Key>>,
-          class Allocator          = cuco::cuda_allocator<cuco::pair<Key, T>>,
-          class Storage            = cuco::experimental::aow_storage<1>>
+          class ProbingScheme =
+            cuco::experimental::double_hashing<4,  // CG size
+                                               cuco::default_hash_function<Key>>,
+          class Allocator = cuco::cuda_allocator<cuco::pair<Key, T>>,
+          class Storage   = cuco::experimental::aow_storage<1>>
 class static_map {
   static_assert(sizeof(Key) <= 4, "Container does not support key types larger than 4 bytes.");
 

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -249,7 +249,7 @@ class static_map {
    * @param stream Stream used for executing the kernels
    */
   template <typename InputIt,
-            typename Hash     = cuco::murmurhash3_32<key_type>,
+            typename Hash     = cuco::default_hash_function<key_type>,
             typename KeyEqual = thrust::equal_to<key_type>>
   void insert(InputIt first,
               InputIt last,
@@ -283,7 +283,7 @@ class static_map {
   template <typename InputIt,
             typename StencilIt,
             typename Predicate,
-            typename Hash     = cuco::murmurhash3_32<key_type>,
+            typename Hash     = cuco::default_hash_function<key_type>,
             typename KeyEqual = thrust::equal_to<key_type>>
   void insert_if(InputIt first,
                  InputIt last,
@@ -321,7 +321,7 @@ class static_map {
    * provided at construction
    */
   template <typename InputIt,
-            typename Hash     = cuco::murmurhash3_32<key_type>,
+            typename Hash     = cuco::default_hash_function<key_type>,
             typename KeyEqual = thrust::equal_to<key_type>>
   void erase(InputIt first,
              InputIt last,
@@ -350,7 +350,7 @@ class static_map {
    */
   template <typename InputIt,
             typename OutputIt,
-            typename Hash     = cuco::murmurhash3_32<key_type>,
+            typename Hash     = cuco::default_hash_function<key_type>,
             typename KeyEqual = thrust::equal_to<key_type>>
   void find(InputIt first,
             InputIt last,
@@ -405,7 +405,7 @@ class static_map {
    */
   template <typename InputIt,
             typename OutputIt,
-            typename Hash     = cuco::murmurhash3_32<key_type>,
+            typename Hash     = cuco::default_hash_function<key_type>,
             typename KeyEqual = thrust::equal_to<key_type>>
   void contains(InputIt first,
                 InputIt last,
@@ -927,7 +927,7 @@ class static_map {
      * equality
      * @return `true` if the insert was successful, `false` otherwise.
      */
-    template <typename Hash     = cuco::murmurhash3_32<key_type>,
+    template <typename Hash     = cuco::default_hash_function<key_type>,
               typename KeyEqual = thrust::equal_to<key_type>>
     __device__ bool insert(value_type const& insert_pair,
                            Hash hash          = Hash{},
@@ -958,7 +958,7 @@ class static_map {
      * @return a pair consisting of an iterator to the element and a bool,
      * either `true` if the insert was successful, `false` otherwise.
      */
-    template <typename Hash     = cuco::murmurhash3_32<key_type>,
+    template <typename Hash     = cuco::default_hash_function<key_type>,
               typename KeyEqual = thrust::equal_to<key_type>>
     __device__ thrust::pair<iterator, bool> insert_and_find(
       value_type const& insert_pair, Hash hash = Hash{}, KeyEqual key_equal = KeyEqual{}) noexcept;
@@ -983,7 +983,7 @@ class static_map {
      * @return `true` if the insert was successful, `false` otherwise.
      */
     template <typename CG,
-              typename Hash     = cuco::murmurhash3_32<key_type>,
+              typename Hash     = cuco::default_hash_function<key_type>,
               typename KeyEqual = thrust::equal_to<key_type>>
     __device__ bool insert(CG const& g,
                            value_type const& insert_pair,
@@ -1004,7 +1004,7 @@ class static_map {
      * equality
      * @return `true` if the erasure was successful, `false` otherwise.
      */
-    template <typename Hash     = cuco::murmurhash3_32<key_type>,
+    template <typename Hash     = cuco::default_hash_function<key_type>,
               typename KeyEqual = thrust::equal_to<key_type>>
     __device__ bool erase(key_type const& k,
                           Hash hash          = Hash{},
@@ -1027,7 +1027,7 @@ class static_map {
      * @return `true` if the erasure was successful, `false` otherwise.
      */
     template <typename CG,
-              typename Hash     = cuco::murmurhash3_32<key_type>,
+              typename Hash     = cuco::default_hash_function<key_type>,
               typename KeyEqual = thrust::equal_to<key_type>>
     __device__ bool erase(CG const& g,
                           key_type const& k,
@@ -1194,7 +1194,7 @@ class static_map {
      * @return An iterator to the position at which the key/value pair
      * containing `k` was inserted
      */
-    template <typename Hash     = cuco::murmurhash3_32<key_type>,
+    template <typename Hash     = cuco::default_hash_function<key_type>,
               typename KeyEqual = thrust::equal_to<key_type>>
     __device__ iterator find(Key const& k,
                              Hash hash          = Hash{},
@@ -1214,7 +1214,7 @@ class static_map {
      * @return An iterator to the position at which the key/value pair
      * containing `k` was inserted
      */
-    template <typename Hash     = cuco::murmurhash3_32<key_type>,
+    template <typename Hash     = cuco::default_hash_function<key_type>,
               typename KeyEqual = thrust::equal_to<key_type>>
     __device__ const_iterator find(Key const& k,
                                    Hash hash          = Hash{},
@@ -1241,7 +1241,7 @@ class static_map {
      * containing `k` was inserted
      */
     template <typename CG,
-              typename Hash     = cuco::murmurhash3_32<key_type>,
+              typename Hash     = cuco::default_hash_function<key_type>,
               typename KeyEqual = thrust::equal_to<key_type>>
     __device__ iterator
     find(CG g, Key const& k, Hash hash = Hash{}, KeyEqual key_equal = KeyEqual{}) noexcept;
@@ -1267,7 +1267,7 @@ class static_map {
      * containing `k` was inserted
      */
     template <typename CG,
-              typename Hash     = cuco::murmurhash3_32<key_type>,
+              typename Hash     = cuco::default_hash_function<key_type>,
               typename KeyEqual = thrust::equal_to<key_type>>
     __device__ const_iterator
     find(CG g, Key const& k, Hash hash = Hash{}, KeyEqual key_equal = KeyEqual{}) const noexcept;
@@ -1296,7 +1296,7 @@ class static_map {
      * containing `k` was inserted
      */
     template <typename ProbeKey,
-              typename Hash     = cuco::murmurhash3_32<key_type>,
+              typename Hash     = cuco::default_hash_function<key_type>,
               typename KeyEqual = thrust::equal_to<key_type>>
     __device__ bool contains(ProbeKey const& k,
                              Hash hash          = Hash{},
@@ -1331,7 +1331,7 @@ class static_map {
      */
     template <typename CG,
               typename ProbeKey,
-              typename Hash     = cuco::murmurhash3_32<key_type>,
+              typename Hash     = cuco::default_hash_function<key_type>,
               typename KeyEqual = thrust::equal_to<key_type>>
     __device__ std::enable_if_t<std::is_invocable_v<KeyEqual, ProbeKey, Key>, bool> contains(
       CG const& g,

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -130,7 +130,7 @@ template <typename Key,
           typename Value,
           cuda::thread_scope Scope = cuda::thread_scope_device,
           typename Allocator       = cuco::cuda_allocator<char>,
-          class ProbeSequence      = cuco::double_hashing<8, cuco::murmurhash3_32<Key>>>
+          class ProbeSequence      = cuco::double_hashing<8, cuco::default_hash_function<Key>>>
 class static_multimap {
   static_assert(
     cuco::is_bitwise_comparable_v<Key>,

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -130,8 +130,7 @@ template <typename Key,
           typename Value,
           cuda::thread_scope Scope = cuda::thread_scope_device,
           typename Allocator       = cuco::cuda_allocator<char>,
-          class ProbeSequence =
-            cuco::double_hashing<8, cuco::murmurhash3_32<Key>, cuco::murmurhash3_32<Key>>>
+          class ProbeSequence      = cuco::double_hashing<8, cuco::murmurhash3_32<Key>>>
 class static_multimap {
   static_assert(
     cuco::is_bitwise_comparable_v<Key>,

--- a/include/cuco/static_set.cuh
+++ b/include/cuco/static_set.cuh
@@ -86,7 +86,6 @@ template <class Key,
           cuda::thread_scope Scope = cuda::thread_scope_device,
           class KeyEqual           = thrust::equal_to<Key>,
           class ProbingScheme      = experimental::double_hashing<4,  // CG size
-                                                             cuco::murmurhash3_32<Key>,
                                                              cuco::murmurhash3_32<Key>>,
           class Allocator          = cuco::cuda_allocator<std::byte>,
           class Storage            = cuco::experimental::aow_storage<1>>

--- a/include/cuco/static_set.cuh
+++ b/include/cuco/static_set.cuh
@@ -86,7 +86,7 @@ template <class Key,
           cuda::thread_scope Scope = cuda::thread_scope_device,
           class KeyEqual           = thrust::equal_to<Key>,
           class ProbingScheme      = experimental::double_hashing<4,  // CG size
-                                                             cuco::murmurhash3_32<Key>>,
+                                                             cuco::default_hash_function<Key>>,
           class Allocator          = cuco::cuda_allocator<std::byte>,
           class Storage            = cuco::experimental::aow_storage<1>>
 class static_set {

--- a/tests/static_map/key_sentinel_test.cu
+++ b/tests/static_map/key_sentinel_test.cu
@@ -62,15 +62,17 @@ TEMPLATE_TEST_CASE_SIG(
       pairs_begin,
       pairs_begin + num_keys,
       [m_view] __device__(cuco::pair_type<Key, Value> const& pair) mutable {
-        return m_view.insert(pair, cuco::murmurhash3_32<Key>{}, custom_equals<Key>{});
+        return m_view.insert(pair, cuco::default_hash_function<Key>{}, custom_equals<Key>{});
       }));
   }
 
   SECTION(
     "Tests of CG insert: The custom `key_equal` can never be used to compare against sentinel")
   {
-    map.insert(
-      pairs_begin, pairs_begin + num_keys, cuco::murmurhash3_32<Key>{}, custom_equals<Key>{});
+    map.insert(pairs_begin,
+               pairs_begin + num_keys,
+               cuco::default_hash_function<Key>{},
+               custom_equals<Key>{});
     // All keys inserted via custom `key_equal` should be found
     REQUIRE(cuco::test::all_of(pairs_begin,
                                pairs_begin + num_keys,

--- a/tests/static_map/stream_test.cu
+++ b/tests/static_map/stream_test.cu
@@ -57,7 +57,7 @@ TEMPLATE_TEST_CASE_SIG("Unique sequence of keys on given stream",
     thrust::make_counting_iterator<int>(0),
     [] __device__(auto i) { return cuco::pair_type<Key, Value>(i, i); });
 
-  auto hash_fn  = cuco::murmurhash3_32<Key>{};
+  auto hash_fn  = cuco::default_hash_function<Key>{};
   auto equal_fn = thrust::equal_to<Value>{};
 
   // bulk function test cases

--- a/tests/static_multimap/custom_pair_retrieve_test.cu
+++ b/tests/static_multimap/custom_pair_retrieve_test.cu
@@ -197,8 +197,8 @@ TEMPLATE_TEST_CASE_SIG(
   constexpr std::size_t num_pairs{200};
 
   using probe = std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
-                                   cuco::linear_probing<1, cuco::murmurhash3_32<Key>>,
-                                   cuco::double_hashing<8, cuco::murmurhash3_32<Key>>>;
+                                   cuco::linear_probing<1, cuco::default_hash_function<Key>>,
+                                   cuco::double_hashing<8, cuco::default_hash_function<Key>>>;
 
   cuco::static_multimap<Key, Value, cuda::thread_scope_device, cuco::cuda_allocator<char>, probe>
     map{num_pairs * 2, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};

--- a/tests/static_multimap/custom_pair_retrieve_test.cu
+++ b/tests/static_multimap/custom_pair_retrieve_test.cu
@@ -196,10 +196,9 @@ TEMPLATE_TEST_CASE_SIG(
 {
   constexpr std::size_t num_pairs{200};
 
-  using probe = std::conditional_t<
-    Probe == cuco::test::probe_sequence::linear_probing,
-    cuco::linear_probing<1, cuco::murmurhash3_32<Key>>,
-    cuco::double_hashing<8, cuco::murmurhash3_32<Key>, cuco::murmurhash3_32<Key>>>;
+  using probe = std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
+                                   cuco::linear_probing<1, cuco::murmurhash3_32<Key>>,
+                                   cuco::double_hashing<8, cuco::murmurhash3_32<Key>>>;
 
   cuco::static_multimap<Key, Value, cuda::thread_scope_device, cuco::cuda_allocator<char>, probe>
     map{num_pairs * 2, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};

--- a/tests/static_multimap/insert_if_test.cu
+++ b/tests/static_multimap/insert_if_test.cu
@@ -67,10 +67,9 @@ TEMPLATE_TEST_CASE_SIG(
                       return cuco::pair_type<Key, Value>{i, i};
                     });
 
-  using probe = std::conditional_t<
-    Probe == cuco::test::probe_sequence::linear_probing,
-    cuco::linear_probing<1, cuco::murmurhash3_32<Key>>,
-    cuco::double_hashing<8, cuco::murmurhash3_32<Key>, cuco::murmurhash3_32<Key>>>;
+  using probe = std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
+                                   cuco::linear_probing<1, cuco::murmurhash3_32<Key>>,
+                                   cuco::double_hashing<8, cuco::murmurhash3_32<Key>>>;
 
   cuco::static_multimap<Key, Value, cuda::thread_scope_device, cuco::cuda_allocator<char>, probe>
     map{num_keys * 2, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};

--- a/tests/static_multimap/insert_if_test.cu
+++ b/tests/static_multimap/insert_if_test.cu
@@ -68,8 +68,8 @@ TEMPLATE_TEST_CASE_SIG(
                     });
 
   using probe = std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
-                                   cuco::linear_probing<1, cuco::murmurhash3_32<Key>>,
-                                   cuco::double_hashing<8, cuco::murmurhash3_32<Key>>>;
+                                   cuco::linear_probing<1, cuco::default_hash_function<Key>>,
+                                   cuco::double_hashing<8, cuco::default_hash_function<Key>>>;
 
   cuco::static_multimap<Key, Value, cuda::thread_scope_device, cuco::cuda_allocator<char>, probe>
     map{num_keys * 2, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};

--- a/tests/static_multimap/multiplicity_test.cu
+++ b/tests/static_multimap/multiplicity_test.cu
@@ -162,8 +162,8 @@ TEMPLATE_TEST_CASE_SIG(
   constexpr std::size_t num_items{4};
 
   using probe = std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
-                                   cuco::linear_probing<1, cuco::murmurhash3_32<Key>>,
-                                   cuco::double_hashing<8, cuco::murmurhash3_32<Key>>>;
+                                   cuco::linear_probing<1, cuco::default_hash_function<Key>>,
+                                   cuco::double_hashing<8, cuco::default_hash_function<Key>>>;
 
   cuco::static_multimap<Key, Value, cuda::thread_scope_device, cuco::cuda_allocator<char>, probe>
     map{5, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};

--- a/tests/static_multimap/multiplicity_test.cu
+++ b/tests/static_multimap/multiplicity_test.cu
@@ -161,10 +161,9 @@ TEMPLATE_TEST_CASE_SIG(
 {
   constexpr std::size_t num_items{4};
 
-  using probe = std::conditional_t<
-    Probe == cuco::test::probe_sequence::linear_probing,
-    cuco::linear_probing<1, cuco::murmurhash3_32<Key>>,
-    cuco::double_hashing<8, cuco::murmurhash3_32<Key>, cuco::murmurhash3_32<Key>>>;
+  using probe = std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
+                                   cuco::linear_probing<1, cuco::murmurhash3_32<Key>>,
+                                   cuco::double_hashing<8, cuco::murmurhash3_32<Key>>>;
 
   cuco::static_multimap<Key, Value, cuda::thread_scope_device, cuco::cuda_allocator<char>, probe>
     map{5, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};

--- a/tests/static_multimap/non_match_test.cu
+++ b/tests/static_multimap/non_match_test.cu
@@ -139,10 +139,9 @@ TEMPLATE_TEST_CASE_SIG(
                       return cuco::pair_type<Key, Value>{i / 2, i};
                     });
 
-  using probe = std::conditional_t<
-    Probe == cuco::test::probe_sequence::linear_probing,
-    cuco::linear_probing<1, cuco::murmurhash3_32<Key>>,
-    cuco::double_hashing<8, cuco::murmurhash3_32<Key>, cuco::murmurhash3_32<Key>>>;
+  using probe = std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
+                                   cuco::linear_probing<1, cuco::murmurhash3_32<Key>>,
+                                   cuco::double_hashing<8, cuco::murmurhash3_32<Key>>>;
 
   cuco::static_multimap<Key,
                         Value,

--- a/tests/static_multimap/non_match_test.cu
+++ b/tests/static_multimap/non_match_test.cu
@@ -140,14 +140,14 @@ TEMPLATE_TEST_CASE_SIG(
                     });
 
   using probe = std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
-                                   cuco::linear_probing<1, cuco::murmurhash3_32<Key>>,
-                                   cuco::double_hashing<8, cuco::murmurhash3_32<Key>>>;
+                                   cuco::linear_probing<1, cuco::default_hash_function<Key>>,
+                                   cuco::double_hashing<8, cuco::default_hash_function<Key>>>;
 
   cuco::static_multimap<Key,
                         Value,
                         cuda::thread_scope_device,
                         cuco::cuda_allocator<char>,
-                        cuco::linear_probing<1, cuco::murmurhash3_32<Key>>>
+                        cuco::linear_probing<1, cuco::default_hash_function<Key>>>
     map{num_keys * 2, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};
   test_non_matches<Key, Value>(map, d_pairs.begin(), d_keys.begin(), num_keys);
 }

--- a/tests/static_multimap/pair_function_test.cu
+++ b/tests/static_multimap/pair_function_test.cu
@@ -132,10 +132,9 @@ TEMPLATE_TEST_CASE_SIG(
                       return cuco::pair_type<Key, Value>{i / 2, i};
                     });
 
-  using probe = std::conditional_t<
-    Probe == cuco::test::probe_sequence::linear_probing,
-    cuco::linear_probing<1, cuco::murmurhash3_32<Key>>,
-    cuco::double_hashing<8, cuco::murmurhash3_32<Key>, cuco::murmurhash3_32<Key>>>;
+  using probe = std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
+                                   cuco::linear_probing<1, cuco::murmurhash3_32<Key>>,
+                                   cuco::double_hashing<8, cuco::murmurhash3_32<Key>>>;
 
   cuco::static_multimap<Key, Value, cuda::thread_scope_device, cuco::cuda_allocator<char>, probe>
     map{num_pairs * 2, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};

--- a/tests/static_multimap/pair_function_test.cu
+++ b/tests/static_multimap/pair_function_test.cu
@@ -133,8 +133,8 @@ TEMPLATE_TEST_CASE_SIG(
                     });
 
   using probe = std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
-                                   cuco::linear_probing<1, cuco::murmurhash3_32<Key>>,
-                                   cuco::double_hashing<8, cuco::murmurhash3_32<Key>>>;
+                                   cuco::linear_probing<1, cuco::default_hash_function<Key>>,
+                                   cuco::double_hashing<8, cuco::default_hash_function<Key>>>;
 
   cuco::static_multimap<Key, Value, cuda::thread_scope_device, cuco::cuda_allocator<char>, probe>
     map{num_pairs * 2, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};

--- a/tests/static_set/capacity_test.cu
+++ b/tests/static_set/capacity_test.cu
@@ -21,9 +21,8 @@
 TEST_CASE("Static set capacity", "")
 {
   constexpr std::size_t num_keys{400};
-  using Key = int32_t;
-  using ProbeT =
-    cuco::experimental::double_hashing<1, cuco::murmurhash3_32<Key>, cuco::murmurhash3_32<Key>>;
+  using Key        = int32_t;
+  using ProbeT     = cuco::experimental::double_hashing<1, cuco::murmurhash3_32<Key>>;
   using Equal      = thrust::equal_to<Key>;
   using AllocatorT = cuco::cuda_allocator<std::byte>;
   using StorageT   = cuco::experimental::aow_storage<2>;
@@ -35,11 +34,7 @@ TEST_CASE("Static set capacity", "")
     using extent_type = cuco::experimental::extent<std::size_t, num_keys>;
     cuco::experimental::
       static_set<Key, extent_type, cuda::thread_scope_device, Equal, ProbeT, AllocatorT, StorageT>
-        set{extent_type{},
-            cuco::empty_key<Key>{-1},
-            {},
-            ProbeT{cuco::murmurhash3_32<Key>{}, cuco::murmurhash3_32<Key>{}},
-            {}};
+        set{extent_type{}, cuco::empty_key<Key>{-1}};
     auto const capacity = set.capacity();
     STATIC_REQUIRE(capacity == gold_capacity);
 
@@ -55,11 +50,7 @@ TEST_CASE("Static set capacity", "")
     using extent_type = cuco::experimental::extent<std::size_t>;
     cuco::experimental::
       static_set<Key, extent_type, cuda::thread_scope_device, Equal, ProbeT, AllocatorT, StorageT>
-        set{num_keys,
-            cuco::empty_key<Key>{-1},
-            {},
-            ProbeT{cuco::murmurhash3_32<Key>{}, cuco::murmurhash3_32<Key>{}},
-            {}};
+        set{num_keys, cuco::empty_key<Key>{-1}};
     auto const capacity = set.capacity();
     REQUIRE(capacity == gold_capacity);
 
@@ -76,7 +67,7 @@ TEST_CASE("Static set capacity", "")
     using probe       = cuco::experimental::linear_probing<2, cuco::murmurhash3_32<Key>>;
     auto set          = cuco::experimental::
       static_set<Key, extent_type, cuda::thread_scope_device, Equal, probe, AllocatorT, StorageT>{
-        extent_type{}, cuco::empty_key<Key>{-1}, {}, probe{cuco::murmurhash3_32<Key>{}}, {}};
+        extent_type{}, cuco::empty_key<Key>{-1}};
 
     REQUIRE(set.capacity() == gold_capacity);
 
@@ -99,8 +90,7 @@ TEST_CASE("Static set capacity", "")
                                               Equal,
                                               probe,
                                               AllocatorT,
-                                              StorageT>{
-      num_keys, cuco::empty_key<Key>{-1}, {}, probe{cuco::murmurhash3_32<Key>{}}, {}};
+                                              StorageT>{num_keys, cuco::empty_key<Key>{-1}};
 
     auto const capacity = set.capacity();
     REQUIRE(capacity == gold_capacity);

--- a/tests/static_set/capacity_test.cu
+++ b/tests/static_set/capacity_test.cu
@@ -22,7 +22,7 @@ TEST_CASE("Static set capacity", "")
 {
   constexpr std::size_t num_keys{400};
   using Key        = int32_t;
-  using ProbeT     = cuco::experimental::double_hashing<1, cuco::murmurhash3_32<Key>>;
+  using ProbeT     = cuco::experimental::double_hashing<1, cuco::default_hash_function<Key>>;
   using Equal      = thrust::equal_to<Key>;
   using AllocatorT = cuco::cuda_allocator<std::byte>;
   using StorageT   = cuco::experimental::aow_storage<2>;
@@ -64,7 +64,7 @@ TEST_CASE("Static set capacity", "")
     auto constexpr gold_capacity = 412;  // 103 x 2 x 2
 
     using extent_type = cuco::experimental::extent<std::size_t, num_keys>;
-    using probe       = cuco::experimental::linear_probing<2, cuco::murmurhash3_32<Key>>;
+    using probe       = cuco::experimental::linear_probing<2, cuco::default_hash_function<Key>>;
     auto set          = cuco::experimental::
       static_set<Key, extent_type, cuda::thread_scope_device, Equal, probe, AllocatorT, StorageT>{
         extent_type{}, cuco::empty_key<Key>{-1}};
@@ -83,7 +83,7 @@ TEST_CASE("Static set capacity", "")
   {
     auto constexpr gold_capacity = 412;  // 103 x 2 x 2
 
-    using probe = cuco::experimental::linear_probing<2, cuco::murmurhash3_32<Key>>;
+    using probe = cuco::experimental::linear_probing<2, cuco::default_hash_function<Key>>;
     auto set    = cuco::experimental::static_set<Key,
                                               cuco::experimental::extent<std::size_t>,
                                               cuda::thread_scope_device,

--- a/tests/static_set/insert_and_find_test.cu
+++ b/tests/static_set/insert_and_find_test.cu
@@ -93,10 +93,10 @@ TEMPLATE_TEST_CASE_SIG(
 {
   constexpr std::size_t num_keys{400};
 
-  using probe =
-    std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
-                       cuco::experimental::linear_probing<CGSize, cuco::murmurhash3_32<Key>>,
-                       cuco::experimental::double_hashing<CGSize, cuco::murmurhash3_32<Key>>>;
+  using probe = std::conditional_t<
+    Probe == cuco::test::probe_sequence::linear_probing,
+    cuco::experimental::linear_probing<CGSize, cuco::default_hash_function<Key>>,
+    cuco::experimental::double_hashing<CGSize, cuco::default_hash_function<Key>>>;
 
   auto set = cuco::experimental::static_set<Key,
                                             cuco::experimental::extent<std::size_t>,

--- a/tests/static_set/insert_and_find_test.cu
+++ b/tests/static_set/insert_and_find_test.cu
@@ -96,9 +96,7 @@ TEMPLATE_TEST_CASE_SIG(
   using probe =
     std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
                        cuco::experimental::linear_probing<CGSize, cuco::murmurhash3_32<Key>>,
-                       cuco::experimental::double_hashing<CGSize,
-                                                          cuco::murmurhash3_32<Key>,
-                                                          cuco::murmurhash3_32<Key>>>;
+                       cuco::experimental::double_hashing<CGSize, cuco::murmurhash3_32<Key>>>;
 
   auto set = cuco::experimental::static_set<Key,
                                             cuco::experimental::extent<std::size_t>,

--- a/tests/static_set/large_input_test.cu
+++ b/tests/static_set/large_input_test.cu
@@ -67,16 +67,12 @@ TEMPLATE_TEST_CASE_SIG(
   constexpr std::size_t num_keys{1'200'000'000};
 
   using extent_type = cuco::experimental::extent<std::size_t>;
-  using probe       = cuco::experimental::
-    double_hashing<CGSize, cuco::murmurhash3_32<Key>, cuco::murmurhash3_32<Key>>;
+  using probe       = cuco::experimental::double_hashing<CGSize, cuco::murmurhash3_32<Key>>;
 
   try {
     auto set = cuco::experimental::
       static_set<Key, extent_type, cuda::thread_scope_device, thrust::equal_to<Key>, probe>{
-        num_keys * 2,
-        cuco::empty_key<Key>{-1},
-        thrust::equal_to<Key>{},
-        probe{cuco::murmurhash3_32<Key>{}, cuco::murmurhash3_32<Key>{}}};
+        num_keys * 2, cuco::empty_key<Key>{-1}};
 
     thrust::device_vector<bool> d_contained(num_keys);
     test_unique_sequence(set, d_contained.data().get(), num_keys);

--- a/tests/static_set/large_input_test.cu
+++ b/tests/static_set/large_input_test.cu
@@ -67,7 +67,7 @@ TEMPLATE_TEST_CASE_SIG(
   constexpr std::size_t num_keys{1'200'000'000};
 
   using extent_type = cuco::experimental::extent<std::size_t>;
-  using probe       = cuco::experimental::double_hashing<CGSize, cuco::murmurhash3_32<Key>>;
+  using probe       = cuco::experimental::double_hashing<CGSize, cuco::default_hash_function<Key>>;
 
   try {
     auto set = cuco::experimental::

--- a/tests/static_set/retrieve_all_test.cu
+++ b/tests/static_set/retrieve_all_test.cu
@@ -78,9 +78,7 @@ TEMPLATE_TEST_CASE_SIG(
   using probe =
     std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
                        cuco::experimental::linear_probing<CGSize, cuco::murmurhash3_32<Key>>,
-                       cuco::experimental::double_hashing<CGSize,
-                                                          cuco::murmurhash3_32<Key>,
-                                                          cuco::murmurhash3_32<Key>>>;
+                       cuco::experimental::double_hashing<CGSize, cuco::murmurhash3_32<Key>>>;
 
   auto set = cuco::experimental::static_set<Key,
                                             cuco::experimental::extent<std::size_t>,

--- a/tests/static_set/retrieve_all_test.cu
+++ b/tests/static_set/retrieve_all_test.cu
@@ -75,10 +75,10 @@ TEMPLATE_TEST_CASE_SIG(
                                              : 422  // 211 x 2 x 1
     ;
 
-  using probe =
-    std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
-                       cuco::experimental::linear_probing<CGSize, cuco::murmurhash3_32<Key>>,
-                       cuco::experimental::double_hashing<CGSize, cuco::murmurhash3_32<Key>>>;
+  using probe = std::conditional_t<
+    Probe == cuco::test::probe_sequence::linear_probing,
+    cuco::experimental::linear_probing<CGSize, cuco::default_hash_function<Key>>,
+    cuco::experimental::double_hashing<CGSize, cuco::default_hash_function<Key>>>;
 
   auto set = cuco::experimental::static_set<Key,
                                             cuco::experimental::extent<std::size_t>,

--- a/tests/static_set/unique_sequence_test.cu
+++ b/tests/static_set/unique_sequence_test.cu
@@ -135,9 +135,7 @@ TEMPLATE_TEST_CASE_SIG(
   using probe =
     std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
                        cuco::experimental::linear_probing<CGSize, cuco::murmurhash3_32<Key>>,
-                       cuco::experimental::double_hashing<CGSize,
-                                                          cuco::murmurhash3_32<Key>,
-                                                          cuco::murmurhash3_32<Key>>>;
+                       cuco::experimental::double_hashing<CGSize, cuco::murmurhash3_32<Key>>>;
 
   auto set = cuco::experimental::static_set<Key,
                                             cuco::experimental::extent<size_type>,

--- a/tests/static_set/unique_sequence_test.cu
+++ b/tests/static_set/unique_sequence_test.cu
@@ -132,10 +132,10 @@ TEMPLATE_TEST_CASE_SIG(
                                                   : 412  // 103 x 2 x 2
     ;
 
-  using probe =
-    std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
-                       cuco::experimental::linear_probing<CGSize, cuco::murmurhash3_32<Key>>,
-                       cuco::experimental::double_hashing<CGSize, cuco::murmurhash3_32<Key>>>;
+  using probe = std::conditional_t<
+    Probe == cuco::test::probe_sequence::linear_probing,
+    cuco::experimental::linear_probing<CGSize, cuco::default_hash_function<Key>>,
+    cuco::experimental::double_hashing<CGSize, cuco::default_hash_function<Key>>>;
 
   auto set = cuco::experimental::static_set<Key,
                                             cuco::experimental::extent<size_type>,


### PR DESCRIPTION
This PR introduces `xxhash_32` as the new default hash function for cuco's data structures.

Additional changes:

- Add `cuco::default_hash_function` alias for convenience.
- Default Double Hashing's second hash function: `typename Hash2 = Hash1` for convenience.