### PR TITLE
Add container-specific detail namespace to resolve naming conflicts

### DIFF
--- a/include/cuco/detail/static_map/functors.cuh
+++ b/include/cuco/detail/static_map/functors.cuh
@@ -19,6 +19,7 @@
 
 namespace cuco {
 namespace experimental {
+namespace static_map_ns {
 namespace detail {
 
 /**
@@ -53,5 +54,6 @@ struct slot_is_filled {
 };
 
 }  // namespace detail
+}  // namespace static_map_ns
 }  // namespace experimental
 }  // namespace cuco

--- a/include/cuco/detail/static_map/kernels.cuh
+++ b/include/cuco/detail/static_map/kernels.cuh
@@ -26,6 +26,7 @@
 
 namespace cuco {
 namespace experimental {
+namespace static_map_ns {
 namespace detail {
 
 /**
@@ -89,5 +90,6 @@ __global__ void find(InputIt first, cuco::detail::index_type n, OutputIt output_
 }
 
 }  // namespace detail
+}  // namespace static_map_ns
 }  // namespace experimental
 }  // namespace cuco

--- a/include/cuco/detail/static_map/static_map.inl
+++ b/include/cuco/detail/static_map/static_map.inl
@@ -224,7 +224,7 @@ void static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Stora
     (cg_size * num_keys + detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
     (detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE);
 
-  detail::find<cg_size, detail::CUCO_DEFAULT_BLOCK_SIZE>
+  static_map_ns::detail::find<cg_size, detail::CUCO_DEFAULT_BLOCK_SIZE>
     <<<grid_size, detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
       first, num_keys, output_begin, ref(op::find));
 }
@@ -242,7 +242,7 @@ OutputIt
 static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::retrieve_all(
   OutputIt output_begin, cuda_stream_ref stream) const
 {
-  auto const is_filled = detail::slot_is_filled(this->empty_key_sentinel());
+  auto const is_filled = static_map_ns::detail::slot_is_filled(this->empty_key_sentinel());
   return impl_->retrieve_all(output_begin, is_filled, stream);
 }
 
@@ -258,7 +258,7 @@ static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::
 static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::size(
   cuda_stream_ref stream) const noexcept
 {
-  auto const is_filled = detail::slot_is_filled(this->empty_key_sentinel());
+  auto const is_filled = static_map_ns::detail::slot_is_filled(this->empty_key_sentinel());
   return impl_->size(is_filled, stream);
 }
 

--- a/include/cuco/detail/static_set/functors.cuh
+++ b/include/cuco/detail/static_set/functors.cuh
@@ -19,6 +19,7 @@
 
 namespace cuco {
 namespace experimental {
+namespace static_set_ns {
 namespace detail {
 
 /**
@@ -53,5 +54,6 @@ struct slot_is_filled {
 };
 
 }  // namespace detail
+}  // namespace static_set_ns
 }  // namespace experimental
 }  // namespace cuco

--- a/include/cuco/detail/static_set/kernels.cuh
+++ b/include/cuco/detail/static_set/kernels.cuh
@@ -26,6 +26,7 @@
 
 namespace cuco {
 namespace experimental {
+namespace static_set_ns {
 namespace detail {
 
 /**
@@ -87,5 +88,6 @@ __global__ void find(InputIt first, cuco::detail::index_type n, OutputIt output_
 }
 
 }  // namespace detail
+}  // namespace static_set_ns
 }  // namespace experimental
 }  // namespace cuco

--- a/include/cuco/detail/static_set/static_set.inl
+++ b/include/cuco/detail/static_set/static_set.inl
@@ -205,7 +205,7 @@ void static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>
     (cg_size * num_keys + detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
     (detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE);
 
-  detail::find<cg_size, detail::CUCO_DEFAULT_BLOCK_SIZE>
+  static_set_ns::detail::find<cg_size, detail::CUCO_DEFAULT_BLOCK_SIZE>
     <<<grid_size, detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
       first, num_keys, output_begin, ref(op::find));
 }
@@ -221,7 +221,7 @@ template <typename OutputIt>
 OutputIt static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::retrieve_all(
   OutputIt output_begin, cuda_stream_ref stream) const
 {
-  auto const is_filled = detail::slot_is_filled(this->empty_key_sentinel());
+  auto const is_filled = static_set_ns::detail::slot_is_filled(this->empty_key_sentinel());
   return impl_->retrieve_all(output_begin, is_filled, stream);
 }
 
@@ -236,7 +236,7 @@ static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::siz
 static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::size(
   cuda_stream_ref stream) const noexcept
 {
-  auto const is_filled = detail::slot_is_filled(this->empty_key_sentinel());
+  auto const is_filled = static_set_ns::detail::slot_is_filled(this->empty_key_sentinel());
   return impl_->size(is_filled, stream);
 }
 


### PR DESCRIPTION
This PRs adds container-specific namespace, e.g. `static_map_ns` and `static_set_ns`, to resolve naming conflicts like:
```bash
/home/seunghwak/Program/anaconda/envs/cugraph-2308/include/cuco/detail/static_set/functors.cuh(30): error: class template "cuco::experimental::detail::slot_is_filled" has already been defined

/home/seunghwak/Program/anaconda/envs/cugraph-2308/include/cuco/detail/static_set/kernels.cuh(51): error: function template "cuco::experimental::detail::find" has already been defined
```