### PR TITLE
Modify `experimental::static_map::retrieve_all` API

### DIFF
--- a/include/cuco/detail/open_addressing_impl.cuh
+++ b/include/cuco/detail/open_addressing_impl.cuh
@@ -386,10 +386,12 @@ class open_addressing_impl {
    * @note Behavior is undefined if the range beginning at `output_begin` is smaller than the return
    * value of `size()`.
    *
+   * @tparam InputIt Device accessible container slot iterator
    * @tparam OutputIt Device accessible random access output iterator whose `value_type` is
-   * convertible from the container's `key_type`
+   * convertible from the container's `value_type`
    * @tparam Predicate Type of predicate indicating if the given slot is filled
    *
+   * @param begin Beginning of the container slot iterator
    * @param output_begin Beginning output iterator for keys
    * @param is_filled Predicate indicating if the given slot is filled
    * @param stream CUDA stream used for this operation

--- a/include/cuco/detail/open_addressing_impl.cuh
+++ b/include/cuco/detail/open_addressing_impl.cuh
@@ -396,15 +396,12 @@ class open_addressing_impl {
    *
    * @return Iterator indicating the end of the output
    */
-  template <typename OutputIt, typename Predicate>
-  [[nodiscard]] OutputIt retrieve_all(OutputIt output_begin,
+  template <typename InputIt, typename OutputIt, typename Predicate>
+  [[nodiscard]] OutputIt retrieve_all(InputIt begin,
+                                      OutputIt output_begin,
                                       Predicate const& is_filled,
                                       cuda_stream_ref stream) const
   {
-    auto begin =
-      thrust::make_transform_iterator(thrust::counting_iterator<size_type>(0),
-                                      detail::get_slot<storage_ref_type>(this->storage_ref()));
-
     std::size_t temp_storage_bytes = 0;
     using temp_allocator_type = typename std::allocator_traits<allocator_type>::rebind_alloc<char>;
     auto temp_allocator       = temp_allocator_type{this->allocator()};

--- a/include/cuco/detail/static_map/functors.cuh
+++ b/include/cuco/detail/static_map/functors.cuh
@@ -17,16 +17,51 @@
 
 #include <cuco/detail/bitwise_compare.cuh>
 
+#include <thrust/tuple.h>
+
 namespace cuco {
 namespace experimental {
+namespace static_map_ns {
 namespace detail {
+
+/**
+ * @brief Device functor returning the content of the slot indexed by `idx`.
+ *
+ * @tparam StorageRef Storage ref type
+ */
+template <typename StorageRef>
+struct get_slot {
+  StorageRef storage_;  ///< Storage ref
+
+  /**
+   * @brief Constructs `get_slot` functor with the given storage ref.
+   *
+   * @param s Input storage ref
+   */
+  explicit constexpr get_slot(StorageRef s) noexcept : storage_{s} {}
+
+  /**
+   * @brief Accesses the slot content with the given index.
+   *
+   * @param idx The slot index
+   * @return The slot content
+   */
+  __device__ constexpr auto operator()(typename StorageRef::size_type idx) const noexcept
+  {
+    auto const window_idx      = idx / StorageRef::window_size;
+    auto const intra_idx       = idx % StorageRef::window_size;
+    auto const [first, second] = storage_[window_idx][intra_idx];
+    return thrust::make_tuple(first, second);
+  }
+};
 
 /**
  * @brief Device functor returning whether the input slot indexed by `idx` is filled.
  *
- * @tparam T The slot content type
+ * @tparam T The slot key type
+ * @tparam U The slot value type
  */
-template <typename T>
+template <typename T, typename U>
 struct slot_is_filled {
   T empty_sentinel_;  ///< The value of the empty key sentinel
 
@@ -43,15 +78,29 @@ struct slot_is_filled {
    * @tparam U Slot content type
    *
    * @param slot The slot
+   *
    * @return `true` if slot is filled
    */
-  template <typename U>
-  __device__ constexpr bool operator()(U const& slot) const noexcept
+  template <typename Slot>
+  __device__ constexpr bool operator()(Slot const& slot) const noexcept
+  {
+    return not cuco::detail::bitwise_compare(empty_sentinel_, thrust::get<0>(slot));
+  }
+
+  /**
+   * @brief Indicates if the target slot `slot` is filled.
+   *
+   * @param slot The slot
+   *
+   * @return `true` if slot is filled
+   */
+  __device__ constexpr bool operator()(cuco::pair<T, U> const& slot) const noexcept
   {
     return not cuco::detail::bitwise_compare(empty_sentinel_, slot.first);
   }
 };
 
 }  // namespace detail
+}  // namespace static_map_ns
 }  // namespace experimental
 }  // namespace cuco

--- a/include/cuco/detail/static_map/static_map.inl
+++ b/include/cuco/detail/static_map/static_map.inl
@@ -244,7 +244,7 @@ static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::
 {
   // XXX: thrust counting iterator doesn't work if size_type is larger than 32-bit
   auto const begin = thrust::make_transform_iterator(
-    thrust::counting_iterator<size_type>(0),
+    thrust::counting_iterator<size_type>{0},
     static_map_ns::detail::get_slot<storage_ref_type>(impl_->storage_ref()));
   auto const is_filled  = static_map_ns::detail::slot_is_filled<Key, T>(this->empty_key_sentinel());
   auto zipped_out_begin = thrust::make_zip_iterator(thrust::make_tuple(keys_out, values_out));

--- a/include/cuco/detail/static_map/static_map.inl
+++ b/include/cuco/detail/static_map/static_map.inl
@@ -242,9 +242,8 @@ std::pair<KeyOut, ValueOut>
 static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::retrieve_all(
   KeyOut keys_out, ValueOut values_out, cuda_stream_ref stream) const
 {
-  // XXX: thrust counting iterator doesn't work if size_type is larger than 32-bit
   auto const begin = thrust::make_transform_iterator(
-    thrust::counting_iterator<size_type>(0),
+    thrust::counting_iterator<size_type>{0},
     static_map_ns::detail::get_slot<storage_ref_type>(impl_->storage_ref()));
   auto const is_filled  = static_map_ns::detail::slot_is_filled<Key, T>(this->empty_key_sentinel());
   auto zipped_out_begin = thrust::make_zip_iterator(thrust::make_tuple(keys_out, values_out));

--- a/include/cuco/detail/static_map/static_map.inl
+++ b/include/cuco/detail/static_map/static_map.inl
@@ -237,13 +237,22 @@ template <class Key,
           class ProbingScheme,
           class Allocator,
           class Storage>
-template <typename OutputIt>
-OutputIt
+template <typename KeyOut, typename ValueOut>
+std::pair<KeyOut, ValueOut>
 static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::retrieve_all(
-  OutputIt output_begin, cuda_stream_ref stream) const
+  KeyOut keys_out, ValueOut values_out, cuda_stream_ref stream) const
 {
-  auto const is_filled = detail::slot_is_filled(this->empty_key_sentinel());
-  return impl_->retrieve_all(output_begin, is_filled, stream);
+  // XXX: thrust counting iterator doesn't work if size_type is larger than 32-bit
+  auto const begin = thrust::make_transform_iterator(
+    thrust::counting_iterator<size_type>(0),
+    static_map_ns::detail::get_slot<storage_ref_type>(impl_->storage_ref()));
+
+  auto const is_filled  = static_map_ns::detail::slot_is_filled<Key, T>(this->empty_key_sentinel());
+  auto zipped_out_begin = thrust::make_zip_iterator(thrust::make_tuple(keys_out, values_out));
+  auto const zipped_out_end = impl_->retrieve_all(begin, zipped_out_begin, is_filled, stream);
+  auto const num            = std::distance(zipped_out_begin, zipped_out_end);
+
+  return std::make_pair(keys_out + num, values_out + num);
 }
 
 template <class Key,
@@ -258,7 +267,7 @@ static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::
 static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::size(
   cuda_stream_ref stream) const noexcept
 {
-  auto const is_filled = detail::slot_is_filled(this->empty_key_sentinel());
+  auto const is_filled = static_map_ns::detail::slot_is_filled<Key, T>(this->empty_key_sentinel());
   return impl_->size(is_filled, stream);
 }
 

--- a/include/cuco/detail/static_set/static_set.inl
+++ b/include/cuco/detail/static_set/static_set.inl
@@ -221,8 +221,13 @@ template <typename OutputIt>
 OutputIt static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::retrieve_all(
   OutputIt output_begin, cuda_stream_ref stream) const
 {
+  // XXX: thrust counting iterator doesn't work if size_type is larger than 32-bit
+  auto const begin =
+    thrust::make_transform_iterator(thrust::counting_iterator<size_type>(0),
+                                    detail::get_slot<storage_ref_type>(impl_->storage_ref()));
+
   auto const is_filled = detail::slot_is_filled(this->empty_key_sentinel());
-  return impl_->retrieve_all(output_begin, is_filled, stream);
+  return impl_->retrieve_all(begin, output_begin, is_filled, stream);
 }
 
 template <class Key,

--- a/include/cuco/detail/static_set/static_set.inl
+++ b/include/cuco/detail/static_set/static_set.inl
@@ -221,12 +221,11 @@ template <typename OutputIt>
 OutputIt static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::retrieve_all(
   OutputIt output_begin, cuda_stream_ref stream) const
 {
-  // XXX: thrust counting iterator doesn't work if size_type is larger than 32-bit
   auto const begin =
-    thrust::make_transform_iterator(thrust::counting_iterator<size_type>(0),
+    thrust::make_transform_iterator(thrust::counting_iterator<size_type>{0},
                                     detail::get_slot<storage_ref_type>(impl_->storage_ref()));
-
   auto const is_filled = static_set_ns::detail::slot_is_filled(this->empty_key_sentinel());
+
   return impl_->retrieve_all(begin, output_begin, is_filled, stream);
 }
 

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -417,19 +417,24 @@ class static_map {
    * @note This API synchronizes the given stream.
    * @note The order in which keys are returned is implementation defined and not guaranteed to be
    * consistent between subsequent calls to `retrieve_all`.
-   * @note Behavior is undefined if the range beginning at `output_begin` is smaller than the return
-   * value of `size()`.
+   * @note Behavior is undefined if the range beginning at `keys_out` or `values_out` is smaller
+   * than the return value of `size()`.
    *
-   * @tparam OutputIt Device accessible random access output iterator whose `value_type` is
-   * convertible from the container's `value_type`.
+   * @tparam KeyOut Device accessible random access output iterator whose `value_type` is
+   * convertible from `key_type`.
+   * @tparam ValueOut Device accesible random access output iterator whose `value_type` is
+   * convertible from `mapped_type`.
    *
-   * @param output_begin Beginning output iterator for key-value pairs
+   * @param keys_out Beginning output iterator for keys
+   * @param values_out Beginning output iterator for associated values
    * @param stream CUDA stream used for this operation
    *
-   * @return Iterator indicating the end of the output
+   * @return Pair of iterators indicating the last elements in the output
    */
-  template <typename OutputIt>
-  [[nodiscard]] OutputIt retrieve_all(OutputIt output_begin, cuda_stream_ref stream = {}) const;
+  template <typename KeyOut, typename ValueOut>
+  [[nodiscard]] std::pair<KeyOut, ValueOut> retrieve_all(KeyOut keys_out,
+                                                         ValueOut values_out,
+                                                         cuda_stream_ref stream = {}) const;
 
   /**
    * @brief Gets the number of elements in the container.


### PR DESCRIPTION
This PR modifies the public `experimental::static_map::retrieve_all` API to take a key iterator and a value iterator separately.