### PR TITLE
Add function to re-initialize/clear a container

### DIFF
--- a/include/cuco/detail/open_addressing_impl.cuh
+++ b/include/cuco/detail/open_addressing_impl.cuh
@@ -125,12 +125,20 @@ class open_addressing_impl {
                                  Allocator const& alloc,
                                  cuda_stream_ref stream) noexcept
     : empty_key_sentinel_{empty_key_sentinel},
+      empty_slot_sentinel_{empty_slot_sentinel},
       predicate_{pred},
       probing_scheme_{probing_scheme},
       storage_{make_valid_extent<cg_size, window_size>(capacity), alloc}
   {
-    storage_.initialize(empty_slot_sentinel, stream);
+    clear(stream);
   }
+
+  /**
+   * @brief Clears the container and removes all stored elements.
+   *
+   * @param stream CUDA stream this operation is executed in
+   */
+  void clear(cuda_stream_ref stream) noexcept { storage_.initialize(empty_slot_sentinel_, stream); }
 
   /**
    * @brief Inserts all keys in the range `[first, last)` and returns the number of successful
@@ -526,6 +534,7 @@ class open_addressing_impl {
 
  protected:
   key_type empty_key_sentinel_;         ///< Key value that represents an empty slot
+  value_type empty_slot_sentinel_;      ///< Slot value that represents an empty slot
   key_equal predicate_;                 ///< Key equality binary predicate
   probing_scheme_type probing_scheme_;  ///< Probing scheme
   storage_type storage_;                ///< Slot window storage

--- a/include/cuco/detail/open_addressing_impl.cuh
+++ b/include/cuco/detail/open_addressing_impl.cuh
@@ -130,7 +130,7 @@ class open_addressing_impl {
       probing_scheme_{probing_scheme},
       storage_{make_valid_extent<cg_size, window_size>(capacity), alloc}
   {
-    clear(stream);
+    this->clear(stream);
   }
 
   /**
@@ -138,7 +138,21 @@ class open_addressing_impl {
    *
    * @param stream CUDA stream this operation is executed in
    */
-  void clear(cuda_stream_ref stream) noexcept { storage_.initialize(empty_slot_sentinel_, stream); }
+  void clear(cuda_stream_ref stream) noexcept
+  {
+    this->clear_async(stream);
+    stream.synchronize();
+  }
+
+  /**
+   * @brief Asynchronously clears the container and removes all stored elements.
+   *
+   * @param stream CUDA stream this operation is executed in
+   */
+  void clear_async(cuda_stream_ref stream) noexcept
+  {
+    storage_.initialize(empty_slot_sentinel_, stream);
+  }
 
   /**
    * @brief Inserts all keys in the range `[first, last)` and returns the number of successful

--- a/include/cuco/detail/open_addressing_impl.cuh
+++ b/include/cuco/detail/open_addressing_impl.cuh
@@ -106,8 +106,10 @@ class open_addressing_impl {
    * window size and it's computed via `make_valid_extent` factory. Insert operations will not
    * automatically grow the container. Attempting to insert more unique keys than the capacity of
    * the container results in undefined behavior.
-   * @note The `empty_key_sentinel` is reserved and behavior is undefined when attempting to insert
+   * @note Any `*_sentinel`s are reserved and behavior is undefined when attempting to insert
    * this sentinel value.
+   * @note If a non-default CUDA stream is provided, the caller is responsible for synchronizing the
+   * stream before the object is first used.
    *
    * @param capacity The requested lower-bound size
    * @param empty_key_sentinel The reserved key value for empty slots
@@ -130,7 +132,7 @@ class open_addressing_impl {
       probing_scheme_{probing_scheme},
       storage_{make_valid_extent<cg_size, window_size>(capacity), alloc}
   {
-    this->clear(stream);
+    this->clear_async(stream);
   }
 
   /**

--- a/include/cuco/detail/open_addressing_impl.cuh
+++ b/include/cuco/detail/open_addressing_impl.cuh
@@ -136,7 +136,8 @@ class open_addressing_impl {
   }
 
   /**
-   * @brief Clears the container and removes all stored elements.
+   * @brief Erases all elements from the container. After this call, `size()` returns zero.
+   * Invalidates any references, pointers, or iterators referring to contained elements.
    *
    * @param stream CUDA stream this operation is executed in
    */
@@ -147,7 +148,8 @@ class open_addressing_impl {
   }
 
   /**
-   * @brief Asynchronously clears the container and removes all stored elements.
+   * @brief Asynchronously erases all elements from the container. After this call, `size()` returns
+   * zero. Invalidates any references, pointers, or iterators referring to contained elements.
    *
    * @param stream CUDA stream this operation is executed in
    */

--- a/include/cuco/detail/static_map/static_map.inl
+++ b/include/cuco/detail/static_map/static_map.inl
@@ -65,7 +65,21 @@ template <class Key,
 void static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::clear(
   cuda_stream_ref stream) noexcept
 {
-  return impl_->clear(stream);
+  impl_->clear(stream);
+}
+
+template <class Key,
+          class T,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
+void static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::clear_async(
+  cuda_stream_ref stream) noexcept
+{
+  impl_->clear_async(stream);
 }
 
 template <class Key,

--- a/include/cuco/detail/static_map/static_map.inl
+++ b/include/cuco/detail/static_map/static_map.inl
@@ -62,6 +62,20 @@ template <class Key,
           class ProbingScheme,
           class Allocator,
           class Storage>
+void static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::clear(
+  cuda_stream_ref stream) noexcept
+{
+  return impl_->clear(stream);
+}
+
+template <class Key,
+          class T,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
 template <typename InputIt>
 static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::size_type
 static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::insert(

--- a/include/cuco/detail/static_set/static_set.inl
+++ b/include/cuco/detail/static_set/static_set.inl
@@ -53,6 +53,19 @@ template <class Key,
           class ProbingScheme,
           class Allocator,
           class Storage>
+void static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::clear(
+  cuda_stream_ref stream) noexcept
+{
+  return impl_->clear(stream);
+}
+
+template <class Key,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
 template <typename InputIt>
 static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::size_type
 static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::insert(

--- a/include/cuco/detail/static_set/static_set.inl
+++ b/include/cuco/detail/static_set/static_set.inl
@@ -56,7 +56,20 @@ template <class Key,
 void static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::clear(
   cuda_stream_ref stream) noexcept
 {
-  return impl_->clear(stream);
+  impl_->clear(stream);
+}
+
+template <class Key,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
+void static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::clear_async(
+  cuda_stream_ref stream) noexcept
+{
+  impl_->clear_async(stream);
 }
 
 template <class Key,

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -182,6 +182,13 @@ class static_map {
                        cuda_stream_ref stream              = {});
 
   /**
+   * @brief Clears the container and removes all stored elements.
+   *
+   * @param stream CUDA stream this operation is executed in
+   */
+  void clear(cuda_stream_ref stream = {}) noexcept;
+
+  /**
    * @brief Inserts all keys in the range `[first, last)` and returns the number of successful
    * insertions.
    *

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -189,6 +189,13 @@ class static_map {
   void clear(cuda_stream_ref stream = {}) noexcept;
 
   /**
+   * @brief Asynchronously clears the container and removes all stored elements.
+   *
+   * @param stream CUDA stream this operation is executed in
+   */
+  void clear_async(cuda_stream_ref stream = {}) noexcept;
+
+  /**
    * @brief Inserts all keys in the range `[first, last)` and returns the number of successful
    * insertions.
    *

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -184,14 +184,16 @@ class static_map {
                        cuda_stream_ref stream              = {});
 
   /**
-   * @brief Clears the container and removes all stored elements.
+   * @brief Erases all elements from the container. After this call, `size()` returns zero.
+   * Invalidates any references, pointers, or iterators referring to contained elements.
    *
    * @param stream CUDA stream this operation is executed in
    */
   void clear(cuda_stream_ref stream = {}) noexcept;
 
   /**
-   * @brief Asynchronously clears the container and removes all stored elements.
+   * @brief Asynchronously erases all elements from the container. After this call, `size()` returns
+   * zero. Invalidates any references, pointers, or iterators referring to contained elements.
    *
    * @param stream CUDA stream this operation is executed in
    */

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -162,8 +162,10 @@ class static_map {
    * automatically grow the map. Attempting to insert more unique keys than the capacity of the map
    * results in undefined behavior.
    *
-   * The `empty_key_sentinel` is reserved and behavior is undefined when attempting to insert
+   * @note Any `*_sentinel`s are reserved and behavior is undefined when attempting to insert
    * this sentinel value.
+   * @note If a non-default CUDA stream is provided, the caller is responsible for synchronizing the
+   * stream before the object is first used.
    *
    * @param capacity The requested lower-bound map size
    * @param empty_key_sentinel The reserved key value for empty slots

--- a/include/cuco/static_set.cuh
+++ b/include/cuco/static_set.cuh
@@ -163,6 +163,13 @@ class static_set {
   void clear(cuda_stream_ref stream = {}) noexcept;
 
   /**
+   * @brief Asynchronously clears the container and removes all stored elements.
+   *
+   * @param stream CUDA stream this operation is executed in
+   */
+  void clear_async(cuda_stream_ref stream = {}) noexcept;
+
+  /**
    * @brief Inserts all keys in the range `[first, last)` and returns the number of successful
    * insertions.
    *

--- a/include/cuco/static_set.cuh
+++ b/include/cuco/static_set.cuh
@@ -138,8 +138,10 @@ class static_set {
    * automatically grow the set. Attempting to insert more unique keys than the capacity of the map
    * results in undefined behavior.
    *
-   * The `empty_key_sentinel` is reserved and behavior is undefined when attempting to insert
+   * @note Any `*_sentinel`s are reserved and behavior is undefined when attempting to insert
    * this sentinel value.
+   * @note If a non-default CUDA stream is provided, the caller is responsible for synchronizing the
+   * stream before the object is first used.
    *
    * @param capacity The requested lower-bound set size
    * @param empty_key_sentinel The reserved key value for empty slots

--- a/include/cuco/static_set.cuh
+++ b/include/cuco/static_set.cuh
@@ -158,14 +158,16 @@ class static_set {
                        cuda_stream_ref stream              = {});
 
   /**
-   * @brief Clears the container and removes all stored elements.
+   * @brief Erases all elements from the container. After this call, `size()` returns zero.
+   * Invalidates any references, pointers, or iterators referring to contained elements.
    *
    * @param stream CUDA stream this operation is executed in
    */
   void clear(cuda_stream_ref stream = {}) noexcept;
 
   /**
-   * @brief Asynchronously clears the container and removes all stored elements.
+   * @brief Asynchronously erases all elements from the container. After this call, `size()` returns
+   * zero. Invalidates any references, pointers, or iterators referring to contained elements.
    *
    * @param stream CUDA stream this operation is executed in
    */

--- a/include/cuco/static_set.cuh
+++ b/include/cuco/static_set.cuh
@@ -156,6 +156,13 @@ class static_set {
                        cuda_stream_ref stream              = {});
 
   /**
+   * @brief Clears the container and removes all stored elements.
+   *
+   * @param stream CUDA stream this operation is executed in
+   */
+  void clear(cuda_stream_ref stream = {}) noexcept;
+
+  /**
    * @brief Inserts all keys in the range `[first, last)` and returns the number of successful
    * insertions.
    *

--- a/tests/static_set/size_test.cu
+++ b/tests/static_set/size_test.cu
@@ -35,8 +35,10 @@ TEST_CASE("Size computation", "")
 
   auto const num_successes = set.insert(d_keys.begin(), d_keys.end());
 
-  auto const size = set.size();
-
-  REQUIRE(size == num_keys);
+  REQUIRE(set.size() == num_keys);
   REQUIRE(num_successes == num_keys);
+
+  set.clear();
+
+  REQUIRE(set.size() == 0);
 }


### PR DESCRIPTION
This PR adds `clear(stream)` and `clear_async(stream)` for both `cuco::experimental::static_set` `cuco::experimental::static_map`.