### PR TITLE
Remove extra mod

### DIFF
--- a/include/cuco/detail/hash_functions/xxhash.cuh
+++ b/include/cuco/detail/hash_functions/xxhash.cuh
@@ -339,7 +339,7 @@ struct XXHash_64 {
     }
 
     // remaining data can be processed in 4-byte chunks
-    if (((size % 32) % 8) >= 4) {
+    if ((size % 8) >= 4) {
       for (; offset <= size - 4; offset += 4) {
         h64 ^= (load_chunk<std::uint32_t>(bytes, offset / 4) & 0xffffffffull) * prime1;
         h64 = rotl(h64, 23) * prime2 + prime3;


### PR DESCRIPTION
This PR removes an extra modulus operation. 8 is a factor of 32, so `(x % 32) % 8 == x % 8`.

Ref: https://github.com/rapidsai/cudf/pull/13612/files#r1264529130

cc: @sleeepyjack