### PR TITLE
Add specialization for is_bitwise_comparable<cuco::pair>>

### DIFF
--- a/include/cuco/detail/traits.hpp
+++ b/include/cuco/detail/traits.hpp
@@ -25,6 +25,15 @@
 namespace cuco::detail {
 
 template <typename T, typename = void>
+struct is_bitwise_comparable_impl : std::false_type {
+};
+
+template <typename T>
+struct is_bitwise_comparable_impl<T, std::enable_if_t<std::has_unique_object_representations_v<T>>>
+  : std::true_type {
+};
+
+template <typename T, typename = void>
 struct is_std_pair_like : cuda::std::false_type {
 };
 

--- a/include/cuco/pair.cuh
+++ b/include/cuco/pair.cuh
@@ -148,7 +148,8 @@ __host__ __device__ constexpr bool operator==(cuco::pair<T1, T2> const& lhs,
 template <typename First, typename Second>
 struct is_bitwise_comparable<pair<First, Second>>
   : std::integral_constant<bool,
-                           is_bitwise_comparable_v<First> && is_bitwise_comparable_v<Second>> {
+                           is_bitwise_comparable_v<First> && is_bitwise_comparable_v<Second> &&
+                             sizeof(pair<First, Second>) == sizeof(First) + sizeof(Second)> {
 };
 
 }  // namespace cuco

--- a/include/cuco/pair.cuh
+++ b/include/cuco/pair.cuh
@@ -18,6 +18,7 @@
 
 #include <cuco/detail/traits.hpp>
 #include <cuco/detail/utils.cuh>
+#include <cuco/utility/traits.hpp>
 
 #include <thrust/device_reference.h>
 #include <thrust/tuple.h>
@@ -140,6 +141,15 @@ __host__ __device__ constexpr pair<std::decay_t<F>, std::decay_t<S>> make_pair(F
 template <class T1, class T2, class U1, class U2>
 __host__ __device__ constexpr bool operator==(cuco::pair<T1, T2> const& lhs,
                                               cuco::pair<U1, U2> const& rhs) noexcept;
+
+/**
+ * @brief A pair of bitwise comparable types is also bitwise comparable
+ */
+template <typename First, typename Second>
+struct is_bitwise_comparable<pair<First, Second>>
+  : std::integral_constant<bool,
+                           is_bitwise_comparable_v<First> && is_bitwise_comparable_v<Second>> {
+};
 
 }  // namespace cuco
 

--- a/include/cuco/utility/traits.hpp
+++ b/include/cuco/utility/traits.hpp
@@ -16,8 +16,7 @@
 
 #pragma once
 
-#include <thrust/device_reference.h>
-#include <thrust/tuple.h>
+#include <cuco/detail/traits.hpp>
 
 #include <type_traits>
 
@@ -36,15 +35,10 @@ namespace cuco {
  * if a `NaN` bit pattern were used as the empty sentinel value, it may not compare bitwise equal to
  * other `NaN` bit patterns.
  *
+ * @note By default, only types with unique object representations are allowed
  */
-template <typename T, typename = void>
-struct is_bitwise_comparable : std::false_type {
-};
-
-/// By default, only types with unique object representations are allowed
 template <typename T>
-struct is_bitwise_comparable<T, std::enable_if_t<std::has_unique_object_representations_v<T>>>
-  : std::true_type {
+struct is_bitwise_comparable : detail::is_bitwise_comparable_impl<T> {
 };
 
 template <typename T>


### PR DESCRIPTION
This PR fixes a bug introduced with the new `open_addressing_impl` abstraction layer:
Tl;dr, for the `packed_cas` code path in `cuco::experimental::static_map::insert()` we need to `bitwise_compare` a `cuco::pair`. However, since `cuco::pair` has no unique object representation by default, it is not `is_bitwise_comparable`. Compilation fails with an assertion error [here](https://github.com/NVIDIA/cuCollections/blob/51f68cae3a957fe83de055f76666db18e46cc89d/include/cuco/detail/bitwise_compare.cuh#L75).

This PR adds the missing specialization for `is_bitwise_comparable<cuco::pair>`.