### PR TITLE
Fix memory alignment issues in hash computation

### DIFF
--- a/include/cuco/detail/hash_functions/utils.cuh
+++ b/include/cuco/detail/hash_functions/utils.cuh
@@ -21,8 +21,9 @@ namespace cuco::detail {
 template <typename T, typename U, typename Extent>
 constexpr __host__ __device__ T load_chunk(U const* const data, Extent index) noexcept
 {
-  auto const chunks = reinterpret_cast<T const*>(data);
-  return chunks[index];
+  T chunk;
+  memcpy(&chunk, data + index, sizeof(T));
+  return chunk;
 }
 
 };  // namespace cuco::detail

--- a/include/cuco/detail/hash_functions/utils.cuh
+++ b/include/cuco/detail/hash_functions/utils.cuh
@@ -21,8 +21,9 @@ namespace cuco::detail {
 template <typename T, typename U, typename Extent>
 constexpr __host__ __device__ T load_chunk(U const* const data, Extent index) noexcept
 {
+  auto const bytes = reinterpret_cast<std::byte const*>(data);
   T chunk;
-  memcpy(&chunk, data + index, sizeof(T));
+  memcpy(&chunk, bytes + index * sizeof(T), sizeof(T));
   return chunk;
 }
 


### PR DESCRIPTION
When hashing large keys, e.g., strings, we traverse the input key iteratively in chunks of 4/8 bytes. The current implementation of the `load_chunk` function falsely assumes that the start of the key is always aligned to the chunk size, which is not always the case (see [discussion](https://github.com/rapidsai/cudf/pull/13612#discussion_r1267949464)).

Additionally, this PR fixes some uncaught `[-Wmaybe-uninitialized]` warnings when compiling the unit tests.