### PR TITLE
Fix doxygen check with unsupported version.

### DIFF
--- a/ci/checks/doxygen.sh
+++ b/ci/checks/doxygen.sh
@@ -16,9 +16,9 @@ function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4
 # Doxygen supported version 1.8.20 to 1.9.1
 DOXYGEN_VERSION=$(doxygen --version)
 if [ $(version "$DOXYGEN_VERSION") -lt $(version "1.8.20") ] ||  [ $(version $DOXYGEN_VERSION) -gt $(version "1.9.1") ]; then
-￼  echo -e "Warning: Unsupported Doxygen version $DOXYGEN_VERSION"
-￼  echo -e "Expecting Doxygen version from 1.8.20 to 1.9.1"
-￼  exit 0
+  echo -e "Warning: Unsupported Doxygen version $DOXYGEN_VERSION"
+  echo -e "Expecting Doxygen version from 1.8.20 to 1.9.1"
+  exit 0
 fi
 
 # Run doxygen, ignore missing tag files error


### PR DESCRIPTION
While running `pre-commit`, I got this error:

```bash
./ci/checks/doxygen.sh: line 19: ￼: command not found
./ci/checks/doxygen.sh: line 20: ￼: command not found
./ci/checks/doxygen.sh: line 21: ￼: command not found
```

I have doxygen 1.9.7 installed, which isn't a supported version in this script. The Doxygen check is supposed to pass silently when run locally with an unsupported version (it runs properly in CI, instead).

It seems like there's an unrecognized symbol in the bash script from PR #177: https://github.com/NVIDIA/cuCollections/commit/05fb1dbe9fed4f446cecb0b024232ede1dea6926

This PR removes that symbol, fixing the error.