### PR TITLE
Improve implememtation details in experimental data structures

### DIFF
--- a/include/cuco/detail/extent/extent.inl
+++ b/include/cuco/detail/extent/extent.inl
@@ -80,8 +80,8 @@ template <int32_t CGSize, int32_t WindowSize, typename SizeType, std::size_t N>
     (static_cast<uint64_t>(std::numeric_limits<SizeType>::max()) < max_prime)
       ? std::numeric_limits<SizeType>::max()
       : static_cast<SizeType>(max_prime);
-  auto const size = SDIV(ext, CGSize * WindowSize);
-  if (size < 0 or size > max_value) { CUCO_FAIL("Invalid input extent"); }
+  auto const size = SDIV(std::max(ext, 1), CGSize * WindowSize);
+  if (size > max_value) { CUCO_FAIL("Invalid input extent"); }
 
   if constexpr (N == dynamic_extent) {
     return window_extent<CGSize, WindowSize, SizeType>{static_cast<SizeType>(

--- a/include/cuco/detail/extent/extent.inl
+++ b/include/cuco/detail/extent/extent.inl
@@ -81,7 +81,7 @@ template <int32_t CGSize, int32_t WindowSize, typename SizeType, std::size_t N>
       ? std::numeric_limits<SizeType>::max()
       : static_cast<SizeType>(max_prime);
   auto const size = SDIV(ext, CGSize * WindowSize);
-  if (size <= 0 or size > max_value) { CUCO_FAIL("Invalid input extent"); }
+  if (size < 0 or size > max_value) { CUCO_FAIL("Invalid input extent"); }
 
   if constexpr (N == dynamic_extent) {
     return window_extent<CGSize, WindowSize, SizeType>{static_cast<SizeType>(

--- a/include/cuco/detail/extent/extent.inl
+++ b/include/cuco/detail/extent/extent.inl
@@ -80,7 +80,8 @@ template <int32_t CGSize, int32_t WindowSize, typename SizeType, std::size_t N>
     (static_cast<uint64_t>(std::numeric_limits<SizeType>::max()) < max_prime)
       ? std::numeric_limits<SizeType>::max()
       : static_cast<SizeType>(max_prime);
-  auto const size = SDIV(std::max(ext, 1), CGSize * WindowSize);
+  auto const size =
+    SDIV(std::max(static_cast<SizeType>(ext), static_cast<SizeType>(1)), CGSize * WindowSize);
   if (size > max_value) { CUCO_FAIL("Invalid input extent"); }
 
   if constexpr (N == dynamic_extent) {

--- a/include/cuco/detail/storage/aow_storage.cuh
+++ b/include/cuco/detail/storage/aow_storage.cuh
@@ -175,6 +175,13 @@ class aow_storage_ref : public aow_storage_base<WindowSize, T, Extent> {
     __device__ constexpr reference operator*() const { return *current_; }
 
     /**
+     * @brief Access operator
+     *
+     * @return Pointer to the current slot
+     */
+    __device__ constexpr value_type* operator->() const { return current_; }
+
+    /**
      * Equality operator
      *
      * @return True if two iterators are identical

--- a/include/cuco/detail/storage/aow_storage.cuh
+++ b/include/cuco/detail/storage/aow_storage.cuh
@@ -191,7 +191,7 @@ class aow_storage_ref : public aow_storage_base<WindowSize, T, Extent> {
      */
     friend __device__ constexpr bool operator!=(iterator const& lhs, iterator const& rhs) noexcept
     {
-      return not lhs == rhs;
+      return not(lhs == rhs);
     }
 
    private:

--- a/include/cuco/extent.cuh
+++ b/include/cuco/extent.cuh
@@ -36,7 +36,7 @@ struct extent {
   constexpr extent() = default;
 
   /// Constructs from `SizeType`
-  __host__ __device__ constexpr explicit extent(SizeType) noexcept {}
+  __host__ __device__ constexpr extent(SizeType) noexcept {}
 
   /**
    * @brief Conversion to value_type.

--- a/include/cuco/probing_scheme.cuh
+++ b/include/cuco/probing_scheme.cuh
@@ -109,7 +109,7 @@ class double_hashing : private detail::probing_scheme_base<CGSize> {
    * @param hash1 First hasher
    * @param hash2 Second hasher
    */
-  __host__ __device__ constexpr double_hashing(Hash1 const& hash1 = {}, Hash2 const& hash2 = {});
+  __host__ __device__ constexpr double_hashing(Hash1 const& hash1 = {}, Hash2 const& hash2 = {1});
 
   /**
    * @brief Operator to return a probing iterator

--- a/include/cuco/probing_scheme.cuh
+++ b/include/cuco/probing_scheme.cuh
@@ -109,7 +109,7 @@ class double_hashing : private detail::probing_scheme_base<CGSize> {
    * @param hash1 First hasher
    * @param hash2 Second hasher
    */
-  __host__ __device__ constexpr double_hashing(Hash1 const& hash1 = {}, Hash2 const& hash2 = {1});
+  __host__ __device__ constexpr double_hashing(Hash1 const& hash1 = {}, Hash2 const& hash2 = {});
 
   /**
    * @brief Operator to return a probing iterator

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ ConfigureTest(UTILITY_TEST
 ###################################################################################################
 # - static_set tests ------------------------------------------------------------------------------
 ConfigureTest(STATIC_SET_TEST
+    static_set/capacity_test.cu
     static_set/heterogeneous_lookup_test.cu
     static_set/insert_and_find_test.cu
     static_set/large_input_test.cu

--- a/tests/static_set/capacity_test.cu
+++ b/tests/static_set/capacity_test.cu
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cuco/static_set.cuh>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("Static set capacity", "")
+{
+  using Key        = int32_t;
+  using ProbeT     = cuco::experimental::double_hashing<1, cuco::default_hash_function<Key>>;
+  using Equal      = thrust::equal_to<Key>;
+  using AllocatorT = cuco::cuda_allocator<std::byte>;
+  using StorageT   = cuco::experimental::aow_storage<2>;
+
+  SECTION("zero capacity is allowed.")
+  {
+    auto constexpr gold_capacity = 4;
+
+    using extent_type = cuco::experimental::extent<std::size_t, 0>;
+    cuco::experimental::
+      static_set<Key, extent_type, cuda::thread_scope_device, Equal, ProbeT, AllocatorT, StorageT>
+        set{extent_type{}, cuco::empty_key<Key>{-1}};
+    auto const capacity = set.capacity();
+    REQUIRE(capacity == gold_capacity);
+
+    auto ref                = set.ref(cuco::experimental::insert);
+    auto const ref_capacity = ref.capacity();
+    REQUIRE(ref_capacity == gold_capacity);
+  }
+
+  SECTION("negative capacity (ikr -_-||) is also allowed.")
+  {
+    auto constexpr gold_capacity = 4;
+
+    using extent_type = cuco::experimental::extent<int32_t>;
+    cuco::experimental::
+      static_set<Key, extent_type, cuda::thread_scope_device, Equal, ProbeT, AllocatorT, StorageT>
+        set{extent_type{-10}, cuco::empty_key<Key>{-1}};
+    auto const capacity = set.capacity();
+    REQUIRE(capacity == gold_capacity);
+
+    auto ref                = set.ref(cuco::experimental::insert);
+    auto const ref_capacity = ref.capacity();
+    REQUIRE(ref_capacity == gold_capacity);
+  }
+
+  constexpr std::size_t num_keys{400};
+
+  SECTION("Dynamic extent is evaluated at run time.")
+  {
+    auto constexpr gold_capacity = 422;  // 211 x 2
+
+    using extent_type = cuco::experimental::extent<std::size_t>;
+    cuco::experimental::
+      static_set<Key, extent_type, cuda::thread_scope_device, Equal, ProbeT, AllocatorT, StorageT>
+        set{num_keys, cuco::empty_key<Key>{-1}};
+    auto const capacity = set.capacity();
+    REQUIRE(capacity == gold_capacity);
+
+    auto ref                = set.ref(cuco::experimental::insert);
+    auto const ref_capacity = ref.capacity();
+    REQUIRE(ref_capacity == gold_capacity);
+  }
+
+  SECTION("Dynamic extent is evaluated at run time.")
+  {
+    auto constexpr gold_capacity = 412;  // 103 x 2 x 2
+
+    using probe = cuco::experimental::linear_probing<2, cuco::default_hash_function<Key>>;
+    auto set    = cuco::experimental::static_set<Key,
+                                              cuco::experimental::extent<std::size_t>,
+                                              cuda::thread_scope_device,
+                                              Equal,
+                                              probe,
+                                              AllocatorT,
+                                              StorageT>{num_keys, cuco::empty_key<Key>{-1}};
+
+    auto const capacity = set.capacity();
+    REQUIRE(capacity == gold_capacity);
+
+    auto ref                = set.ref(cuco::experimental::insert);
+    auto const ref_capacity = ref.capacity();
+    REQUIRE(ref_capacity == gold_capacity);
+  }
+}


### PR DESCRIPTION
This PR fixes issues and adds new features requested by https://github.com/rapidsai/cudf/pull/13807.

It:

- removes the requirement of the second hasher from double hashing must be constructible from an integer
- fixes an issue in map iterator `!=` operator
- overloads map iterator access operator
- allows zero capacity container
- adds `capacity_test` back since several corner cases need to be exercised