### PR TITLE
Fix alignment issue for data type larger than 16B

### DIFF
--- a/include/cuco/detail/utils.cuh
+++ b/include/cuco/detail/utils.cuh
@@ -144,6 +144,7 @@ template <std::size_t N>
 struct packed {
   using type = void;  ///< `void` type by default
 };
+
 /**
  * @brief Denotes the packed type when the size of the object is 8.
  */
@@ -151,6 +152,7 @@ template <>
 struct packed<sizeof(uint64_t)> {
   using type = uint64_t;  ///< Packed type as `uint64_t` if the size of the object is 8
 };
+
 /**
  * @brief Denotes the packed type when the size of the object is 4.
  */
@@ -158,6 +160,7 @@ template <>
 struct packed<sizeof(uint32_t)> {
   using type = uint32_t;  ///< Packed type as `uint32_t` if the size of the object is 4
 };
+
 template <typename Pair>
 using packed_t = typename packed<sizeof(Pair)>::type;
 
@@ -182,6 +185,7 @@ constexpr bool is_packable()
 {
   return not std::is_void<packed_t<Pair>>::value and std::has_unique_object_representations_v<Pair>;
 }
+
 /**
  * @brief Allows viewing a pair in a packed representation.
  *


### PR DESCRIPTION
Closes #347 

This fixes a bug where data is misaligned if it's larger than 16 bytes. The problem is not unveiled by CI since we are building for the full CUDA arch matrix thus custom types larger than 16 bytes are not exercised. 

It also includes minor cleanups by adding blank lines between different functions.