### PR TITLE
Add `insert_or_assign` for map

### DIFF
--- a/include/cuco/detail/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing_ref_impl.cuh
@@ -41,17 +41,18 @@ enum class insert_result : int32_t { CONTINUE = 0, SUCCESS = 1, DUPLICATE = 2 };
 /**
  * @brief Helper struct to store intermediate window probing results.
  */
-struct window_results {
+struct window_probing_results {
   detail::equal_result state_;  ///< Equal result
   int32_t intra_window_index_;  ///< Intra-window index
 
   /**
-   * @brief Constructs window_results.
+   * @brief Constructs window_probing_results.
    *
    * @param state The three way equality result
    * @param index Intra-window index
    */
-  __device__ explicit constexpr window_results(detail::equal_result state, int32_t index) noexcept
+  __device__ explicit constexpr window_probing_results(detail::equal_result state,
+                                                       int32_t index) noexcept
     : state_{state}, intra_window_index_{index}
   {
   }
@@ -221,13 +222,15 @@ class open_addressing_ref_impl {
       auto const [state, intra_window_index] = [&]() {
         for (auto i = 0; i < window_size; ++i) {
           switch (predicate(window_slots[i], key)) {
-            case detail::equal_result::EMPTY: return window_results{detail::equal_result::EMPTY, i};
-            case detail::equal_result::EQUAL: return window_results{detail::equal_result::EQUAL, i};
+            case detail::equal_result::EMPTY:
+              return window_probing_results{detail::equal_result::EMPTY, i};
+            case detail::equal_result::EQUAL:
+              return window_probing_results{detail::equal_result::EQUAL, i};
             default: continue;
           }
         }
         // returns dummy index `-1` for UNEQUAL
-        return window_results{detail::equal_result::UNEQUAL, -1};
+        return window_probing_results{detail::equal_result::UNEQUAL, -1};
       }();
 
       // If the key is already in the container, return false
@@ -345,13 +348,15 @@ class open_addressing_ref_impl {
       auto const [state, intra_window_index] = [&]() {
         for (auto i = 0; i < window_size; ++i) {
           switch (predicate(window_slots[i], key)) {
-            case detail::equal_result::EMPTY: return window_results{detail::equal_result::EMPTY, i};
-            case detail::equal_result::EQUAL: return window_results{detail::equal_result::EQUAL, i};
+            case detail::equal_result::EMPTY:
+              return window_probing_results{detail::equal_result::EMPTY, i};
+            case detail::equal_result::EQUAL:
+              return window_probing_results{detail::equal_result::EQUAL, i};
             default: continue;
           }
         }
         // returns dummy index `-1` for UNEQUAL
-        return window_results{detail::equal_result::UNEQUAL, -1};
+        return window_probing_results{detail::equal_result::UNEQUAL, -1};
       }();
 
       auto* slot_ptr = (storage_ref_.data() + *probing_iter)->data() + intra_window_index;
@@ -541,13 +546,15 @@ class open_addressing_ref_impl {
       auto const [state, intra_window_index] = [&]() {
         for (auto i = 0; i < window_size; ++i) {
           switch (predicate(window_slots[i], key)) {
-            case detail::equal_result::EMPTY: return window_results{detail::equal_result::EMPTY, i};
-            case detail::equal_result::EQUAL: return window_results{detail::equal_result::EQUAL, i};
+            case detail::equal_result::EMPTY:
+              return window_probing_results{detail::equal_result::EMPTY, i};
+            case detail::equal_result::EQUAL:
+              return window_probing_results{detail::equal_result::EQUAL, i};
             default: continue;
           }
         }
         // returns dummy index `-1` for UNEQUAL
-        return window_results{detail::equal_result::UNEQUAL, -1};
+        return window_probing_results{detail::equal_result::UNEQUAL, -1};
       }();
 
       // Find a match for the probe key, thus return an iterator to the entry

--- a/include/cuco/detail/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing_ref_impl.cuh
@@ -35,6 +35,28 @@ namespace cuco {
 namespace experimental {
 namespace detail {
 
+/// Three-way insert result enum
+enum class insert_result : int32_t { CONTINUE = 0, SUCCESS = 1, DUPLICATE = 2 };
+
+/**
+ * @brief Helper struct to store intermediate window probing results.
+ */
+struct window_results {
+  detail::equal_result state_;  ///< Equal result
+  int32_t intra_window_index_;  ///< Intra-window index
+
+  /**
+   * @brief Constructs window_results.
+   *
+   * @param state The three way equality result
+   * @param index Intra-window index
+   */
+  __device__ explicit constexpr window_results(detail::equal_result state, int32_t index) noexcept
+    : state_{state}, intra_window_index_{index}
+  {
+  }
+};
+
 /**
  * @brief Common device non-owning "ref" implementation class.
  *
@@ -546,28 +568,6 @@ class open_addressing_ref_impl {
   }
 
  private:
-  /// Three-way insert result enum
-  enum class insert_result : int32_t { CONTINUE = 0, SUCCESS = 1, DUPLICATE = 2 };
-
-  /**
-   * @brief Helper struct to store intermediate window probing results.
-   */
-  struct window_results {
-    detail::equal_result state_;  ///< Equal result
-    int32_t intra_window_index_;  ///< Intra-window index
-
-    /**
-     * @brief Constructs window_results.
-     *
-     * @param state The three way equality result
-     *@param Intra-window index
-     */
-    __device__ explicit constexpr window_results(detail::equal_result state, int32_t index) noexcept
-      : state_{state}, intra_window_index_{index}
-    {
-    }
-  };
-
   /**
    * @brief Compares the content of the address `address` (old value) with the `expected` value and,
    * only if they are the same, sets the content of `address` to `desired`.

--- a/include/cuco/detail/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing_ref_impl.cuh
@@ -574,7 +574,6 @@ class open_addressing_ref_impl {
     }
   }
 
- private:
   /**
    * @brief Compares the content of the address `address` (old value) with the `expected` value and,
    * only if they are the same, sets the content of `address` to `desired`.
@@ -659,6 +658,37 @@ class open_addressing_ref_impl {
     }
   }
 
+  /**
+   * @brief Gets the sentinel used to represent an empty slot.
+   *
+   * @return The sentinel value used to represent an empty slot
+   */
+  [[nodiscard]] __device__ constexpr value_type empty_slot_sentinel() const noexcept
+  {
+    return empty_slot_sentinel_;
+  }
+
+  /**
+   * @brief Gets the probing scheme.
+   *
+   * @return The probing scheme used for the container
+   */
+  [[nodiscard]] __device__ constexpr probing_scheme_type const& probing_scheme() const noexcept
+  {
+    return probing_scheme_;
+  }
+
+  /**
+   * @brief Gets the non-owning storage ref.
+   *
+   * @return The non-owning storage ref of the container
+   */
+  [[nodiscard]] __device__ constexpr storage_ref_type storage_ref() const noexcept
+  {
+    return storage_ref_;
+  }
+
+ private:
   /**
    * @brief Inserts the specified element with one single CAS operation.
    *

--- a/include/cuco/detail/static_map/kernels.cuh
+++ b/include/cuco/detail/static_map/kernels.cuh
@@ -30,7 +30,9 @@ namespace static_map_ns {
 namespace detail {
 
 /**
- * @brief TODO
+ * @brief For any key-value pair `{k, v}` in the range `[first, first + n)`, if a key equivalent to
+ * `k` already exists in the container, assigns `v` to the mapped_type corresponding to the key `k`.
+ * If the key does not exist, inserts the pair as if by insert.
  *
  * @note If multiple elements in `[first, first + n)` compare equal, it is unspecified which element
  * is inserted.
@@ -65,7 +67,7 @@ __global__ void insert_or_assign(InputIterator first, cuco::detail::index_type n
 }
 
 /**
- * @brief Finds the equivalent map elements of all keys in the range `[first, last)`.
+ * @brief Finds the equivalent map elements of all keys in the range `[first, first + n)`.
  *
  * @note If the key `*(first + i)` has a match in the container, copies the payload of its matched
  * element to `(output_begin + i)`. Else, copies the empty value sentinel. Uses the CUDA Cooperative

--- a/include/cuco/detail/static_map/kernels.cuh
+++ b/include/cuco/detail/static_map/kernels.cuh
@@ -30,8 +30,7 @@ namespace static_map_ns {
 namespace detail {
 
 /**
- * @brief Inserts all elements in the range `[first, first + n)` if `pred` of the corresponding
- * stencil returns true.
+ * @brief TODO
  *
  * @note If multiple elements in `[first, first + n)` compare equal, it is unspecified which element
  * is inserted.

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -320,11 +320,7 @@ class operator_impl<
         return detail::window_results{detail::equal_result::UNEQUAL, -1};
       }();
 
-      // If the key is already in the container, return false
-      if (group.any(state == detail::equal_result::EQUAL)) { return; }
-
       auto const group_contains_empty = group.ballot(state == detail::equal_result::EMPTY);
-
       if (group_contains_empty) {
         auto const src_lane = __ffs(group_contains_empty) - 1;
         auto const status =
@@ -334,6 +330,7 @@ class operator_impl<
                 value)
             : false;
 
+        // Exit if inserted or assigned
         if (group.shfl(status, src_lane)) { return; }
       } else {
         ++probing_iter;

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -381,7 +381,7 @@ class operator_impl<
     auto old_key      = ref_.impl_.compare_and_swap(&slot->first, expected_key, value.first);
     auto* old_key_ptr = reinterpret_cast<key_type*>(&old_key);
 
-    // if key success or key was alreay present in the map
+    // if key success or key was already present in the map
     if (cuco::detail::bitwise_compare(*old_key_ptr, expected_key) or
         (ref_.predicate_.equal_to(*old_key_ptr, value.first) == detail::equal_result::EQUAL)) {
       // Update payload

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -253,10 +253,10 @@ class operator_impl<
 
  public:
   /**
-   * @brief Inserts an element.
+   * @brief Inserts a key-value pair `{k, v}` if it's not present in the map. Otherwise, assigns `v`
+   * to the mapped_type corresponding to the key `k`.
    *
    * @param value The element to insert
-   * @return True if the given element is successfully inserted
    */
   __device__ void insert_or_assign(value_type const& value) noexcept
   {
@@ -290,9 +290,11 @@ class operator_impl<
   /**
    * @brief Inserts an element.
    *
+   * @brief Inserts a key-value pair `{k, v}` if it's not present in the map. Otherwise, assigns `v`
+   * to the mapped_type corresponding to the key `k`.
+   *
    * @param group The Cooperative Group used to perform group insert
    * @param value The element to insert
-   * @return True if the given element is successfully inserted
    */
   __device__ void insert_or_assign(cooperative_groups::thread_block_tile<cg_size> const& group,
                                    value_type const& value) noexcept
@@ -339,6 +341,18 @@ class operator_impl<
   }
 
  private:
+  /**
+   * @brief Attempts to insert an element into a slot or update the matching payload with the given
+   * element
+   *
+   * @brief Inserts a key-value pair `{k, v}` if it's not present in the map. Otherwise, assigns `v`
+   * to the mapped_type corresponding to the key `k`.
+   *
+   * @param group The Cooperative Group used to perform group insert
+   * @param value The element to insert
+   *
+   * @return Returns `true` if the given `value` is inserted or `value` has a match in the map.
+   */
   __device__ constexpr bool attempt_insert_or_assign(value_type* slot,
                                                      value_type const& value) noexcept
   {

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -310,14 +310,14 @@ class operator_impl<
         for (auto i = 0; i < window_size; ++i) {
           switch (ref_.predicate_(window_slots[i], key)) {
             case detail::equal_result::EMPTY:
-              return detail::window_results{detail::equal_result::EMPTY, i};
+              return detail::window_probing_results{detail::equal_result::EMPTY, i};
             case detail::equal_result::EQUAL:
-              return detail::window_results{detail::equal_result::EQUAL, i};
+              return detail::window_probing_results{detail::equal_result::EQUAL, i};
             default: continue;
           }
         }
         // returns dummy index `-1` for UNEQUAL
-        return detail::window_results{detail::equal_result::UNEQUAL, -1};
+        return detail::window_probing_results{detail::equal_result::UNEQUAL, -1};
       }();
 
       auto const group_contains_empty = group.ballot(state == detail::equal_result::EMPTY);

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -349,7 +349,7 @@ class operator_impl<
           (group.thread_rank() == src_lane)
             ? attempt_insert_or_assign(
                 (storage_ref.data() + *probing_iter)->data() + intra_window_index, value)
-            : true;
+            : false;
 
         // Exit if inserted or assigned
         if (group.shfl(status, src_lane)) { return; }

--- a/include/cuco/operator.hpp
+++ b/include/cuco/operator.hpp
@@ -34,6 +34,12 @@ struct insert_and_find_tag {
 } inline constexpr insert_and_find;
 
 /**
+ * @brief `insert_or_assign` operator tag
+ */
+struct insert_or_assign_tag {
+} inline constexpr insert_or_assign;
+
+/**
  * @brief `contains` operator tag
  */
 struct contains_tag {

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -296,6 +296,8 @@ class static_map {
    *
    * @note This function synchronizes the given stream. For asynchronous execution use
    * `insert_or_assign_async`.
+   * @note If multiple pairs in `[first, last)` compare equal, it is unspecified which pair is
+   * inserted or assigned.
    *
    * @tparam InputIt Device accessible random access input iterator where
    * <tt>std::is_convertible<std::iterator_traits<InputIt>::value_type,
@@ -312,6 +314,9 @@ class static_map {
    * @brief For any key-value pair `{k, v}` in the range `[first, last)`, if a key equivalent to `k`
    * already exists in the container, assigns `v` to the mapped_type corresponding to the key `k`.
    * If the key does not exist, inserts the pair as if by insert.
+   *
+   * @note If multiple pairs in `[first, last)` compare equal, it is unspecified which pair is
+   * inserted or assigned.
    *
    * @tparam InputIt Device accessible random access input iterator where
    * <tt>std::is_convertible<std::iterator_traits<InputIt>::value_type,

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -494,9 +494,9 @@ class static_map {
    * @return Pair of iterators indicating the last elements in the output
    */
   template <typename KeyOut, typename ValueOut>
-  [[nodiscard]] std::pair<KeyOut, ValueOut> retrieve_all(KeyOut keys_out,
-                                                         ValueOut values_out,
-                                                         cuda_stream_ref stream = {}) const;
+  std::pair<KeyOut, ValueOut> retrieve_all(KeyOut keys_out,
+                                           ValueOut values_out,
+                                           cuda_stream_ref stream = {}) const;
 
   /**
    * @brief Gets the number of elements in the container.

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -290,6 +290,41 @@ class static_map {
                        cuda_stream_ref stream = {}) noexcept;
 
   /**
+   * @brief For any key-value pair `{k, v}` in the range `[first, last)`, if a key equivalent to `k`
+   * already exists in the container, assigns `v` to the mapped_type corresponding to the key `k`.
+   * If the key does not exist, inserts the pair as if by insert.
+   *
+   * @note This function synchronizes the given stream. For asynchronous execution use
+   * `insert_or_assign_async`.
+   *
+   * @tparam InputIt Device accessible random access input iterator where
+   * <tt>std::is_convertible<std::iterator_traits<InputIt>::value_type,
+   * static_map<K, V>::value_type></tt> is `true`
+   *
+   * @param first Beginning of the sequence of keys
+   * @param last End of the sequence of keys
+   * @param stream CUDA stream used for insert
+   */
+  template <typename InputIt>
+  void insert_or_assign(InputIt first, InputIt last, cuda_stream_ref stream = {}) noexcept;
+
+  /**
+   * @brief For any key-value pair `{k, v}` in the range `[first, last)`, if a key equivalent to `k`
+   * already exists in the container, assigns `v` to the mapped_type corresponding to the key `k`.
+   * If the key does not exist, inserts the pair as if by insert.
+   *
+   * @tparam InputIt Device accessible random access input iterator where
+   * <tt>std::is_convertible<std::iterator_traits<InputIt>::value_type,
+   * static_map<K, V>::value_type></tt> is `true`
+   *
+   * @param first Beginning of the sequence of keys
+   * @param last End of the sequence of keys
+   * @param stream CUDA stream used for insert
+   */
+  template <typename InputIt>
+  void insert_or_assign_async(InputIt first, InputIt last, cuda_stream_ref stream = {}) noexcept;
+
+  /**
    * @brief Indicates whether the keys in the range `[first, last)` are contained in the map.
    *
    * @note This function synchronizes the given stream. For asynchronous execution use

--- a/include/cuco/static_set.cuh
+++ b/include/cuco/static_set.cuh
@@ -422,7 +422,7 @@ class static_set {
    * @return Iterator indicating the end of the output
    */
   template <typename OutputIt>
-  [[nodiscard]] OutputIt retrieve_all(OutputIt output_begin, cuda_stream_ref stream = {}) const;
+  OutputIt retrieve_all(OutputIt output_begin, cuda_stream_ref stream = {}) const;
 
   /**
    * @brief Gets the number of elements in the container.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,6 +74,7 @@ ConfigureTest(STATIC_MAP_TEST
     static_map/erase_test.cu
     static_map/heterogeneous_lookup_test.cu
     static_map/insert_and_find_test.cu
+    static_map/insert_or_assign_test.cu
     static_map/key_sentinel_test.cu
     static_map/shared_memory_test.cu
     static_map/stream_test.cu

--- a/tests/static_map/insert_or_assign_test.cu
+++ b/tests/static_map/insert_or_assign_test.cu
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <utils.hpp>
+
+#include <cuco/static_map.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/functional.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
+#include <thrust/sort.h>
+
+#include <catch2/catch_template_test_macros.hpp>
+
+using size_type = std::size_t;
+
+template <typename Map>
+__inline__ void test_insert_or_assign(Map& map, size_type num_keys)
+{
+  using Key   = typename Map::key_type;
+  using Value = typename Map::mapped_type;
+
+  // Insert pairs
+  auto pairs_begin =
+    thrust::make_transform_iterator(thrust::counting_iterator<size_type>(0),
+                                    [] __device__(auto i) { return cuco::pair<Key, Value>(i, i); });
+
+  auto const initial_size = map.insert(pairs_begin, pairs_begin + num_keys);
+  REQUIRE(initial_size == num_keys);  // all keys should be inserted
+
+  // Query pairs have the same keys but different payloads
+  auto query_pairs_begin = thrust::make_transform_iterator(
+    thrust::counting_iterator<size_type>(0),
+    [] __device__(auto i) { return cuco::pair<Key, Value>(i, i * 2); });
+
+  map.insert_or_assign(query_pairs_begin, query_pairs_begin + num_keys);
+
+  auto const updated_size = map.size();
+  // all keys are present in the map so the size shouldn't change
+  REQUIRE(updated_size == initial_size);
+
+  thrust::device_vector<Key> d_keys(num_keys);
+  thrust::device_vector<Key> d_values(num_keys);
+  map.retrieve_all(d_keys.begin(), d_values.begin());
+
+  auto gold_values_begin = thrust::make_transform_iterator(thrust::counting_iterator<size_type>(0),
+                                                           [] __device__(auto i) { return i * 2; });
+
+  thrust::sort(thrust::device, d_values.begin(), d_values.end());
+  REQUIRE(cuco::test::equal(
+    d_values.begin(), d_values.end(), gold_values_begin, thrust::equal_to<Value>{}));
+}
+
+TEMPLATE_TEST_CASE_SIG(
+  "Insert or assign",
+  "",
+  ((typename Key, typename Value, cuco::test::probe_sequence Probe, int CGSize),
+   Key,
+   Value,
+   Probe,
+   CGSize),
+  (int32_t, int32_t, cuco::test::probe_sequence::double_hashing, 1),
+  (int32_t, int64_t, cuco::test::probe_sequence::double_hashing, 1),
+  (int32_t, int32_t, cuco::test::probe_sequence::double_hashing, 2),
+  (int32_t, int64_t, cuco::test::probe_sequence::double_hashing, 2),
+  (int64_t, int32_t, cuco::test::probe_sequence::double_hashing, 1),
+  (int64_t, int64_t, cuco::test::probe_sequence::double_hashing, 1),
+  (int64_t, int32_t, cuco::test::probe_sequence::double_hashing, 2),
+  (int64_t, int64_t, cuco::test::probe_sequence::double_hashing, 2),
+  (int32_t, int32_t, cuco::test::probe_sequence::linear_probing, 1),
+  (int32_t, int64_t, cuco::test::probe_sequence::linear_probing, 1),
+  (int32_t, int32_t, cuco::test::probe_sequence::linear_probing, 2),
+  (int32_t, int64_t, cuco::test::probe_sequence::linear_probing, 2),
+  (int64_t, int32_t, cuco::test::probe_sequence::linear_probing, 1),
+  (int64_t, int64_t, cuco::test::probe_sequence::linear_probing, 1),
+  (int64_t, int32_t, cuco::test::probe_sequence::linear_probing, 2),
+  (int64_t, int64_t, cuco::test::probe_sequence::linear_probing, 2))
+{
+  constexpr size_type num_keys{400};
+
+  using probe =
+    std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
+                       cuco::experimental::linear_probing<CGSize, cuco::murmurhash3_32<Key>>,
+                       cuco::experimental::double_hashing<CGSize,
+                                                          cuco::murmurhash3_32<Key>,
+                                                          cuco::murmurhash3_32<Key>>>;
+
+  auto map = cuco::experimental::static_map<Key,
+                                            Value,
+                                            cuco::experimental::extent<size_type>,
+                                            cuda::thread_scope_device,
+                                            thrust::equal_to<Key>,
+                                            probe,
+                                            cuco::cuda_allocator<std::byte>,
+                                            cuco::experimental::storage<2>>{
+    num_keys, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};
+
+  test_insert_or_assign(map, num_keys);
+}


### PR DESCRIPTION
Closes #317

This PR adds `static_map::insert_or_assign`.

It also removes the `[[nodiscard]]` qualifier for `retrieve_all` since they shouldn't be necessary.