### PR TITLE
Clean up detail utility functions

### DIFF
--- a/benchmarks/hash_bench.cu
+++ b/benchmarks/hash_bench.cu
@@ -16,7 +16,6 @@
 
 #include <defaults.hpp>
 
-#include <cuco/detail/utility/math.hpp>
 #include <cuco/hash_functions.cuh>
 
 #include <nvbench/nvbench.cuh>
@@ -70,7 +69,7 @@ void hash_eval(nvbench::state& state, nvbench::type_list<Hash>)
   bool const materialize_result = false;
   constexpr auto block_size     = 128;
   auto const num_keys  = state.get_int64_or_default("NumInputs", cuco::benchmark::defaults::N * 10);
-  auto const grid_size = cuco::detail::ceiling_div(num_keys, block_size * 16);
+  auto const grid_size = (num_keys + block_size * 16 - 1) / block_size * 16;
 
   thrust::device_vector<typename Hash::result_type> hash_values((materialize_result) ? num_keys
                                                                                      : 1);

--- a/benchmarks/hash_bench.cu
+++ b/benchmarks/hash_bench.cu
@@ -16,7 +16,7 @@
 
 #include <defaults.hpp>
 
-#include <cuco/detail/utils.hpp>
+#include <cuco/detail/utility/math.hpp>
 #include <cuco/hash_functions.cuh>
 
 #include <nvbench/nvbench.cuh>
@@ -70,7 +70,7 @@ void hash_eval(nvbench::state& state, nvbench::type_list<Hash>)
   bool const materialize_result = false;
   constexpr auto block_size     = 128;
   auto const num_keys  = state.get_int64_or_default("NumInputs", cuco::benchmark::defaults::N * 10);
-  auto const grid_size = SDIV(num_keys, block_size * 16);
+  auto const grid_size = cuco::detail::ceiling_div(num_keys, block_size * 16);
 
   thrust::device_vector<typename Hash::result_type> hash_values((materialize_result) ? num_keys
                                                                                      : 1);

--- a/include/cuco/detail/common_kernels.cuh
+++ b/include/cuco/detail/common_kernels.cuh
@@ -71,8 +71,8 @@ __global__ void insert_if_n(InputIterator first,
   __shared__ typename BlockReduce::TempStorage temp_storage;
   typename Ref::size_type thread_num_successes = 0;
 
-  auto const loop_stride = cuco::detail::grid_stride<CGSize>();
-  auto idx               = cuco::detail::global_thread_id<CGSize>();
+  auto const loop_stride = cuco::detail::grid_stride() / CGSize;
+  auto idx               = cuco::detail::global_thread_id() / CGSize;
 
   while (idx < n) {
     if (pred(*(stencil + idx))) {
@@ -129,8 +129,8 @@ template <int32_t CGSize,
 __global__ void insert_if_n(
   InputIterator first, cuco::detail::index_type n, StencilIt stencil, Predicate pred, Ref ref)
 {
-  auto const loop_stride = cuco::detail::grid_stride<CGSize>();
-  auto idx               = cuco::detail::global_thread_id<CGSize>();
+  auto const loop_stride = cuco::detail::grid_stride() / CGSize;
+  auto idx               = cuco::detail::global_thread_id() / CGSize;
 
   while (idx < n) {
     if (pred(*(stencil + idx))) {
@@ -190,8 +190,8 @@ __global__ void contains_if_n(InputIt first,
 
   auto const block       = cg::this_thread_block();
   auto const thread_idx  = block.thread_rank();
-  auto const loop_stride = cuco::detail::grid_stride<CGSize>();
-  auto idx               = cuco::detail::global_thread_id<CGSize>();
+  auto const loop_stride = cuco::detail::grid_stride() / CGSize;
+  auto idx               = cuco::detail::global_thread_id() / CGSize;
 
   __shared__ bool output_buffer[BlockSize / CGSize];
 

--- a/include/cuco/detail/extent/extent.inl
+++ b/include/cuco/detail/extent/extent.inl
@@ -81,7 +81,7 @@ template <int32_t CGSize, int32_t WindowSize, typename SizeType, std::size_t N>
     (static_cast<uint64_t>(std::numeric_limits<SizeType>::max()) < max_prime)
       ? std::numeric_limits<SizeType>::max()
       : static_cast<SizeType>(max_prime);
-  auto const size = cuco::detail::ceiling_div(
+  auto const size = cuco::detail::int_div_ceil(
     std::max(static_cast<SizeType>(ext), static_cast<SizeType>(1)), CGSize * WindowSize);
   if (size > max_value) { CUCO_FAIL("Invalid input extent"); }
 

--- a/include/cuco/detail/extent/extent.inl
+++ b/include/cuco/detail/extent/extent.inl
@@ -18,6 +18,7 @@
 
 #include <cuco/detail/error.hpp>
 #include <cuco/detail/prime.hpp>  // TODO move to detail/extent/
+#include <cuco/detail/utility/math.hpp>
 #include <cuco/detail/utils.hpp>
 #include <cuco/utility/fast_int.cuh>
 
@@ -80,8 +81,8 @@ template <int32_t CGSize, int32_t WindowSize, typename SizeType, std::size_t N>
     (static_cast<uint64_t>(std::numeric_limits<SizeType>::max()) < max_prime)
       ? std::numeric_limits<SizeType>::max()
       : static_cast<SizeType>(max_prime);
-  auto const size =
-    SDIV(std::max(static_cast<SizeType>(ext), static_cast<SizeType>(1)), CGSize * WindowSize);
+  auto const size = cuco::detail::ceiling_div(
+    std::max(static_cast<SizeType>(ext), static_cast<SizeType>(1)), CGSize * WindowSize);
   if (size > max_value) { CUCO_FAIL("Invalid input extent"); }
 
   if constexpr (N == dynamic_extent) {

--- a/include/cuco/detail/open_addressing_impl.cuh
+++ b/include/cuco/detail/open_addressing_impl.cuh
@@ -187,10 +187,7 @@ class open_addressing_impl {
       detail::counter_storage<size_type, thread_scope, allocator_type>{this->allocator()};
     counter.reset(stream);
 
-    auto const grid_size =
-      (cg_size * num_keys +
-       cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
-      (cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE);
+    auto const grid_size = cuco::detail::compute_grid_size(num_keys, cg_size);
 
     auto const always_true = thrust::constant_iterator<bool>{true};
     detail::insert_if_n<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
@@ -268,10 +265,7 @@ class open_addressing_impl {
       detail::counter_storage<size_type, thread_scope, allocator_type>{this->allocator()};
     counter.reset(stream);
 
-    auto const grid_size =
-      (cg_size * num_keys +
-       cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
-      (cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE);
+    auto const grid_size = cuco::detail::compute_grid_size(num_keys, cg_size);
 
     detail::insert_if_n<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
       <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
@@ -313,10 +307,7 @@ class open_addressing_impl {
     auto const num_keys = cuco::detail::distance(first, last);
     if (num_keys == 0) { return; }
 
-    auto const grid_size =
-      (cg_size * num_keys +
-       cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
-      (cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE);
+    auto const grid_size = cuco::detail::compute_grid_size(num_keys, cg_size);
 
     detail::insert_if_n<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
       <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
@@ -347,10 +338,7 @@ class open_addressing_impl {
     auto const num_keys = cuco::detail::distance(first, last);
     if (num_keys == 0) { return; }
 
-    auto const grid_size =
-      (cg_size * num_keys +
-       cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
-      (cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE);
+    auto const grid_size = cuco::detail::compute_grid_size(num_keys, cg_size);
 
     auto const always_true = thrust::constant_iterator<bool>{true};
     detail::contains_if_n<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
@@ -399,10 +387,7 @@ class open_addressing_impl {
     auto const num_keys = cuco::detail::distance(first, last);
     if (num_keys == 0) { return; }
 
-    auto const grid_size =
-      (cg_size * num_keys +
-       cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
-      (cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE);
+    auto const grid_size = cuco::detail::compute_grid_size(num_keys, cg_size);
 
     detail::contains_if_n<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
       <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
@@ -492,10 +477,7 @@ class open_addressing_impl {
       detail::counter_storage<size_type, thread_scope, allocator_type>{this->allocator()};
     counter.reset(stream);
 
-    auto const grid_size =
-      (storage_.num_windows() +
-       cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
-      (cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE);
+    auto const grid_size = cuco::detail::compute_grid_size(storage_.num_windows());
 
     // TODO: custom kernel to be replaced by cub::DeviceReduce::Sum when cub version is bumped to
     // v2.1.0

--- a/include/cuco/detail/open_addressing_impl.cuh
+++ b/include/cuco/detail/open_addressing_impl.cuh
@@ -219,10 +219,7 @@ class open_addressing_impl {
     auto const num_keys = cuco::detail::distance(first, last);
     if (num_keys == 0) { return; }
 
-    auto const grid_size =
-      (cg_size * num_keys +
-       cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
-      (cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE);
+    auto const grid_size = cuco::detail::compute_grid_size(num_keys, cg_size);
 
     auto const always_true = thrust::constant_iterator<bool>{true};
     detail::insert_if_n<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>

--- a/include/cuco/detail/open_addressing_impl.cuh
+++ b/include/cuco/detail/open_addressing_impl.cuh
@@ -20,7 +20,7 @@
 #include <cuco/detail/common_functors.cuh>
 #include <cuco/detail/common_kernels.cuh>
 #include <cuco/detail/storage/counter_storage.cuh>
-#include <cuco/detail/tuning.cuh>
+#include <cuco/detail/utility/cuda.hpp>
 #include <cuco/extent.cuh>
 #include <cuco/probing_scheme.cuh>
 #include <cuco/storage.cuh>
@@ -188,12 +188,13 @@ class open_addressing_impl {
     counter.reset(stream);
 
     auto const grid_size =
-      (cg_size * num_keys + detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
-      (detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE);
+      (cg_size * num_keys +
+       cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
+      (cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE);
 
     auto const always_true = thrust::constant_iterator<bool>{true};
-    detail::insert_if_n<cg_size, detail::CUCO_DEFAULT_BLOCK_SIZE>
-      <<<grid_size, detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+    detail::insert_if_n<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
+      <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
         first, num_keys, always_true, thrust::identity{}, counter.data(), container_ref);
 
     return counter.load_to_host(stream);
@@ -219,12 +220,13 @@ class open_addressing_impl {
     if (num_keys == 0) { return; }
 
     auto const grid_size =
-      (cg_size * num_keys + detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
-      (detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE);
+      (cg_size * num_keys +
+       cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
+      (cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE);
 
     auto const always_true = thrust::constant_iterator<bool>{true};
-    detail::insert_if_n<cg_size, detail::CUCO_DEFAULT_BLOCK_SIZE>
-      <<<grid_size, detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+    detail::insert_if_n<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
+      <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
         first, num_keys, always_true, thrust::identity{}, container_ref);
   }
 
@@ -270,11 +272,12 @@ class open_addressing_impl {
     counter.reset(stream);
 
     auto const grid_size =
-      (cg_size * num_keys + detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
-      (detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE);
+      (cg_size * num_keys +
+       cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
+      (cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE);
 
-    detail::insert_if_n<cg_size, detail::CUCO_DEFAULT_BLOCK_SIZE>
-      <<<grid_size, detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+    detail::insert_if_n<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
+      <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
         first, num_keys, stencil, pred, counter.data(), container_ref);
 
     return counter.load_to_host(stream);
@@ -314,11 +317,12 @@ class open_addressing_impl {
     if (num_keys == 0) { return; }
 
     auto const grid_size =
-      (cg_size * num_keys + detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
-      (detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE);
+      (cg_size * num_keys +
+       cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
+      (cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE);
 
-    detail::insert_if_n<cg_size, detail::CUCO_DEFAULT_BLOCK_SIZE>
-      <<<grid_size, detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+    detail::insert_if_n<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
+      <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
         first, num_keys, stencil, pred, container_ref);
   }
 
@@ -347,12 +351,13 @@ class open_addressing_impl {
     if (num_keys == 0) { return; }
 
     auto const grid_size =
-      (cg_size * num_keys + detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
-      (detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE);
+      (cg_size * num_keys +
+       cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
+      (cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE);
 
     auto const always_true = thrust::constant_iterator<bool>{true};
-    detail::contains_if_n<cg_size, detail::CUCO_DEFAULT_BLOCK_SIZE>
-      <<<grid_size, detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+    detail::contains_if_n<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
+      <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
         first, num_keys, always_true, thrust::identity{}, output_begin, container_ref);
   }
 
@@ -398,11 +403,12 @@ class open_addressing_impl {
     if (num_keys == 0) { return; }
 
     auto const grid_size =
-      (cg_size * num_keys + detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
-      (detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE);
+      (cg_size * num_keys +
+       cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
+      (cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE);
 
-    detail::contains_if_n<cg_size, detail::CUCO_DEFAULT_BLOCK_SIZE>
-      <<<grid_size, detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+    detail::contains_if_n<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
+      <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
         first, num_keys, stencil, pred, output_begin, container_ref);
   }
 
@@ -490,13 +496,14 @@ class open_addressing_impl {
     counter.reset(stream);
 
     auto const grid_size =
-      (storage_.num_windows() + detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
-      (detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE);
+      (storage_.num_windows() +
+       cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
+      (cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE);
 
     // TODO: custom kernel to be replaced by cub::DeviceReduce::Sum when cub version is bumped to
     // v2.1.0
-    detail::size<detail::CUCO_DEFAULT_BLOCK_SIZE>
-      <<<grid_size, detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+    detail::size<cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
+      <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
         storage_.ref(), is_filled, counter.data());
 
     return counter.load_to_host(stream);

--- a/include/cuco/detail/open_addressing_impl.cuh
+++ b/include/cuco/detail/open_addressing_impl.cuh
@@ -187,7 +187,7 @@ class open_addressing_impl {
       detail::counter_storage<size_type, thread_scope, allocator_type>{this->allocator()};
     counter.reset(stream);
 
-    auto const grid_size = cuco::detail::compute_grid_size(num_keys, cg_size);
+    auto const grid_size = cuco::detail::grid_size(num_keys, cg_size);
 
     auto const always_true = thrust::constant_iterator<bool>{true};
     detail::insert_if_n<cg_size, cuco::detail::default_block_size()>
@@ -216,7 +216,7 @@ class open_addressing_impl {
     auto const num_keys = cuco::detail::distance(first, last);
     if (num_keys == 0) { return; }
 
-    auto const grid_size = cuco::detail::compute_grid_size(num_keys, cg_size);
+    auto const grid_size = cuco::detail::grid_size(num_keys, cg_size);
 
     auto const always_true = thrust::constant_iterator<bool>{true};
     detail::insert_if_n<cg_size, cuco::detail::default_block_size()>
@@ -265,7 +265,7 @@ class open_addressing_impl {
       detail::counter_storage<size_type, thread_scope, allocator_type>{this->allocator()};
     counter.reset(stream);
 
-    auto const grid_size = cuco::detail::compute_grid_size(num_keys, cg_size);
+    auto const grid_size = cuco::detail::grid_size(num_keys, cg_size);
 
     detail::insert_if_n<cg_size, cuco::detail::default_block_size()>
       <<<grid_size, cuco::detail::default_block_size(), 0, stream>>>(
@@ -307,7 +307,7 @@ class open_addressing_impl {
     auto const num_keys = cuco::detail::distance(first, last);
     if (num_keys == 0) { return; }
 
-    auto const grid_size = cuco::detail::compute_grid_size(num_keys, cg_size);
+    auto const grid_size = cuco::detail::grid_size(num_keys, cg_size);
 
     detail::insert_if_n<cg_size, cuco::detail::default_block_size()>
       <<<grid_size, cuco::detail::default_block_size(), 0, stream>>>(
@@ -338,7 +338,7 @@ class open_addressing_impl {
     auto const num_keys = cuco::detail::distance(first, last);
     if (num_keys == 0) { return; }
 
-    auto const grid_size = cuco::detail::compute_grid_size(num_keys, cg_size);
+    auto const grid_size = cuco::detail::grid_size(num_keys, cg_size);
 
     auto const always_true = thrust::constant_iterator<bool>{true};
     detail::contains_if_n<cg_size, cuco::detail::default_block_size()>
@@ -387,7 +387,7 @@ class open_addressing_impl {
     auto const num_keys = cuco::detail::distance(first, last);
     if (num_keys == 0) { return; }
 
-    auto const grid_size = cuco::detail::compute_grid_size(num_keys, cg_size);
+    auto const grid_size = cuco::detail::grid_size(num_keys, cg_size);
 
     detail::contains_if_n<cg_size, cuco::detail::default_block_size()>
       <<<grid_size, cuco::detail::default_block_size(), 0, stream>>>(
@@ -477,7 +477,7 @@ class open_addressing_impl {
       detail::counter_storage<size_type, thread_scope, allocator_type>{this->allocator()};
     counter.reset(stream);
 
-    auto const grid_size = cuco::detail::compute_grid_size(storage_.num_windows());
+    auto const grid_size = cuco::detail::grid_size(storage_.num_windows());
 
     // TODO: custom kernel to be replaced by cub::DeviceReduce::Sum when cub version is bumped to
     // v2.1.0

--- a/include/cuco/detail/open_addressing_impl.cuh
+++ b/include/cuco/detail/open_addressing_impl.cuh
@@ -190,8 +190,8 @@ class open_addressing_impl {
     auto const grid_size = cuco::detail::compute_grid_size(num_keys, cg_size);
 
     auto const always_true = thrust::constant_iterator<bool>{true};
-    detail::insert_if_n<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
-      <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+    detail::insert_if_n<cg_size, cuco::detail::default_block_size()>
+      <<<grid_size, cuco::detail::default_block_size(), 0, stream>>>(
         first, num_keys, always_true, thrust::identity{}, counter.data(), container_ref);
 
     return counter.load_to_host(stream);
@@ -219,8 +219,8 @@ class open_addressing_impl {
     auto const grid_size = cuco::detail::compute_grid_size(num_keys, cg_size);
 
     auto const always_true = thrust::constant_iterator<bool>{true};
-    detail::insert_if_n<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
-      <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+    detail::insert_if_n<cg_size, cuco::detail::default_block_size()>
+      <<<grid_size, cuco::detail::default_block_size(), 0, stream>>>(
         first, num_keys, always_true, thrust::identity{}, container_ref);
   }
 
@@ -267,8 +267,8 @@ class open_addressing_impl {
 
     auto const grid_size = cuco::detail::compute_grid_size(num_keys, cg_size);
 
-    detail::insert_if_n<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
-      <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+    detail::insert_if_n<cg_size, cuco::detail::default_block_size()>
+      <<<grid_size, cuco::detail::default_block_size(), 0, stream>>>(
         first, num_keys, stencil, pred, counter.data(), container_ref);
 
     return counter.load_to_host(stream);
@@ -309,8 +309,8 @@ class open_addressing_impl {
 
     auto const grid_size = cuco::detail::compute_grid_size(num_keys, cg_size);
 
-    detail::insert_if_n<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
-      <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+    detail::insert_if_n<cg_size, cuco::detail::default_block_size()>
+      <<<grid_size, cuco::detail::default_block_size(), 0, stream>>>(
         first, num_keys, stencil, pred, container_ref);
   }
 
@@ -341,8 +341,8 @@ class open_addressing_impl {
     auto const grid_size = cuco::detail::compute_grid_size(num_keys, cg_size);
 
     auto const always_true = thrust::constant_iterator<bool>{true};
-    detail::contains_if_n<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
-      <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+    detail::contains_if_n<cg_size, cuco::detail::default_block_size()>
+      <<<grid_size, cuco::detail::default_block_size(), 0, stream>>>(
         first, num_keys, always_true, thrust::identity{}, output_begin, container_ref);
   }
 
@@ -389,8 +389,8 @@ class open_addressing_impl {
 
     auto const grid_size = cuco::detail::compute_grid_size(num_keys, cg_size);
 
-    detail::contains_if_n<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
-      <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+    detail::contains_if_n<cg_size, cuco::detail::default_block_size()>
+      <<<grid_size, cuco::detail::default_block_size(), 0, stream>>>(
         first, num_keys, stencil, pred, output_begin, container_ref);
   }
 
@@ -481,8 +481,8 @@ class open_addressing_impl {
 
     // TODO: custom kernel to be replaced by cub::DeviceReduce::Sum when cub version is bumped to
     // v2.1.0
-    detail::size<cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
-      <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+    detail::size<cuco::detail::default_block_size()>
+      <<<grid_size, cuco::detail::default_block_size(), 0, stream>>>(
         storage_.ref(), is_filled, counter.data());
 
     return counter.load_to_host(stream);

--- a/include/cuco/detail/prime.hpp
+++ b/include/cuco/detail/prime.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <cuco/detail/utils.hpp>
+#include <cuco/detail/utility/math.hpp>
 
 #include <algorithm>
 #include <array>
@@ -20154,7 +20154,7 @@ constexpr T get_valid_capacity(T capacity) noexcept
     if constexpr (not uses_vector_load) { return cg_size; }
   }();
 
-  auto const c         = SDIV(capacity, stride);
+  auto const c         = ceiling_div(capacity, stride);
   auto const min_prime = std::lower_bound(primes.begin(), primes.end(), c);
   return *min_prime * stride;
 }

--- a/include/cuco/detail/prime.hpp
+++ b/include/cuco/detail/prime.hpp
@@ -20154,7 +20154,7 @@ constexpr T get_valid_capacity(T capacity) noexcept
     if constexpr (not uses_vector_load) { return cg_size; }
   }();
 
-  auto const c         = ceiling_div(capacity, stride);
+  auto const c         = int_div_ceil(capacity, stride);
   auto const min_prime = std::lower_bound(primes.begin(), primes.end(), c);
   return *min_prime * stride;
 }

--- a/include/cuco/detail/static_map/kernels.cuh
+++ b/include/cuco/detail/static_map/kernels.cuh
@@ -50,8 +50,8 @@ namespace detail {
 template <int32_t CGSize, int32_t BlockSize, typename InputIterator, typename Ref>
 __global__ void insert_or_assign(InputIterator first, cuco::detail::index_type n, Ref ref)
 {
-  auto const loop_stride = cuco::detail::grid_stride<CGSize>();
-  auto idx               = cuco::detail::global_thread_id<CGSize>();
+  auto const loop_stride = cuco::detail::grid_stride() / CGSize;
+  auto idx               = cuco::detail::global_thread_id() / CGSize;
 
   while (idx < n) {
     typename Ref::value_type const insert_pair{*(first + idx)};
@@ -93,8 +93,8 @@ __global__ void find(InputIt first, cuco::detail::index_type n, OutputIt output_
 
   auto const block       = cg::this_thread_block();
   auto const thread_idx  = block.thread_rank();
-  auto const loop_stride = cuco::detail::grid_stride<CGSize>();
-  auto idx               = cuco::detail::global_thread_id<CGSize>();
+  auto const loop_stride = cuco::detail::grid_stride() / CGSize;
+  auto idx               = cuco::detail::global_thread_id() / CGSize;
 
   __shared__ typename Ref::mapped_type output_buffer[BlockSize / CGSize];
 

--- a/include/cuco/detail/static_map/kernels.cuh
+++ b/include/cuco/detail/static_map/kernels.cuh
@@ -16,7 +16,7 @@
 #pragma once
 
 #include <cuco/detail/bitwise_compare.cuh>
-#include <cuco/detail/utils.hpp>
+#include <cuco/detail/utility/cuda.cuh>
 
 #include <cub/block/block_reduce.cuh>
 
@@ -91,11 +91,11 @@ __global__ void find(InputIt first, cuco::detail::index_type n, OutputIt output_
 {
   namespace cg = cooperative_groups;
 
-  auto const block      = cg::this_thread_block();
-  auto const thread_idx = block.thread_rank();
+  auto const block       = cg::this_thread_block();
+  auto const thread_idx  = block.thread_rank();
+  auto const loop_stride = cuco::detail::grid_stride<CGSize>();
+  auto idx               = cuco::detail::global_thread_id<CGSize>();
 
-  cuco::detail::index_type const loop_stride = gridDim.x * BlockSize / CGSize;
-  cuco::detail::index_type idx               = (BlockSize * blockIdx.x + threadIdx.x) / CGSize;
   __shared__ typename Ref::mapped_type output_buffer[BlockSize / CGSize];
 
   while (idx - thread_idx < n) {  // the whole thread block falls into the same iteration

--- a/include/cuco/detail/static_map/kernels.cuh
+++ b/include/cuco/detail/static_map/kernels.cuh
@@ -50,8 +50,8 @@ namespace detail {
 template <int32_t CGSize, int32_t BlockSize, typename InputIterator, typename Ref>
 __global__ void insert_or_assign(InputIterator first, cuco::detail::index_type n, Ref ref)
 {
-  cuco::detail::index_type const loop_stride = gridDim.x * BlockSize / CGSize;
-  cuco::detail::index_type idx               = (BlockSize * blockIdx.x + threadIdx.x) / CGSize;
+  auto const loop_stride = cuco::detail::grid_stride<CGSize>();
+  auto idx               = cuco::detail::global_thread_id<CGSize>();
 
   while (idx < n) {
     typename Ref::value_type const insert_pair{*(first + idx)};

--- a/include/cuco/detail/static_map/static_map.inl
+++ b/include/cuco/detail/static_map/static_map.inl
@@ -176,7 +176,7 @@ void static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Stora
   auto const num = cuco::detail::distance(first, last);
   if (num == 0) { return; }
 
-  auto const grid_size = cuco::detail::compute_grid_size(num, cg_size);
+  auto const grid_size = cuco::detail::grid_size(num, cg_size);
 
   static_map_ns::detail::insert_or_assign<cg_size, cuco::detail::default_block_size()>
     <<<grid_size, cuco::detail::default_block_size(), 0, stream>>>(
@@ -286,7 +286,7 @@ void static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Stora
   auto const num_keys = cuco::detail::distance(first, last);
   if (num_keys == 0) { return; }
 
-  auto const grid_size = cuco::detail::compute_grid_size(num_keys, cg_size);
+  auto const grid_size = cuco::detail::grid_size(num_keys, cg_size);
 
   static_map_ns::detail::find<cg_size, cuco::detail::default_block_size()>
     <<<grid_size, cuco::detail::default_block_size(), 0, stream>>>(

--- a/include/cuco/detail/static_map/static_map.inl
+++ b/include/cuco/detail/static_map/static_map.inl
@@ -17,7 +17,7 @@
 #include <cuco/cuda_stream_ref.hpp>
 #include <cuco/detail/static_map/functors.cuh>
 #include <cuco/detail/static_map/kernels.cuh>
-#include <cuco/detail/tuning.cuh>
+#include <cuco/detail/utility/cuda.hpp>
 #include <cuco/detail/utils.hpp>
 #include <cuco/operator.hpp>
 #include <cuco/static_map_ref.cuh>
@@ -289,11 +289,12 @@ void static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Stora
   if (num_keys == 0) { return; }
 
   auto const grid_size =
-    (cg_size * num_keys + detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
-    (detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE);
+    (cg_size * num_keys +
+     cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
+    (cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE);
 
-  static_map_ns::detail::find<cg_size, detail::CUCO_DEFAULT_BLOCK_SIZE>
-    <<<grid_size, detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+  static_map_ns::detail::find<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
+    <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
       first, num_keys, output_begin, ref(op::find));
 }
 

--- a/include/cuco/detail/static_map/static_map.inl
+++ b/include/cuco/detail/static_map/static_map.inl
@@ -178,8 +178,8 @@ void static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Stora
 
   auto const grid_size = cuco::detail::compute_grid_size(num, cg_size);
 
-  static_map_ns::detail::insert_or_assign<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
-    <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+  static_map_ns::detail::insert_or_assign<cg_size, cuco::detail::default_block_size()>
+    <<<grid_size, cuco::detail::default_block_size(), 0, stream>>>(
       first, num, ref(op::insert_or_assign));
 }
 
@@ -288,8 +288,8 @@ void static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Stora
 
   auto const grid_size = cuco::detail::compute_grid_size(num_keys, cg_size);
 
-  static_map_ns::detail::find<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
-    <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+  static_map_ns::detail::find<cg_size, cuco::detail::default_block_size()>
+    <<<grid_size, cuco::detail::default_block_size(), 0, stream>>>(
       first, num_keys, output_begin, ref(op::find));
 }
 

--- a/include/cuco/detail/static_map/static_map.inl
+++ b/include/cuco/detail/static_map/static_map.inl
@@ -176,12 +176,10 @@ void static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Stora
   auto const num = cuco::detail::distance(first, last);
   if (num == 0) { return; }
 
-  auto const grid_size =
-    (cg_size * num + detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
-    (detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE);
+  auto const grid_size = cuco::detail::compute_grid_size(num, cg_size);
 
-  static_map_ns::detail::insert_or_assign<cg_size, detail::CUCO_DEFAULT_BLOCK_SIZE>
-    <<<grid_size, detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+  static_map_ns::detail::insert_or_assign<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
+    <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
       first, num, ref(op::insert_or_assign));
 }
 

--- a/include/cuco/detail/static_map/static_map.inl
+++ b/include/cuco/detail/static_map/static_map.inl
@@ -288,10 +288,7 @@ void static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Stora
   auto const num_keys = cuco::detail::distance(first, last);
   if (num_keys == 0) { return; }
 
-  auto const grid_size =
-    (cg_size * num_keys +
-     cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
-    (cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE);
+  auto const grid_size = cuco::detail::compute_grid_size(num_keys, cg_size);
 
   static_map_ns::detail::find<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
     <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(

--- a/include/cuco/detail/static_multimap/static_multimap.inl
+++ b/include/cuco/detail/static_multimap/static_multimap.inl
@@ -294,7 +294,7 @@ OutputIt static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::retrieve(
     return cg_size();
   }();
 
-  auto const grid_size = detail::compute_grid_size(num_keys, cg_size());
+  auto const grid_size = detail::grid_size(num_keys, cg_size());
 
   CUCO_CUDA_TRY(cudaMemsetAsync(d_counter_.get(), 0, sizeof(atomic_ctr_type), stream));
   std::size_t h_counter;
@@ -333,7 +333,7 @@ OutputIt static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::retrieve_
     return cg_size();
   }();
 
-  auto const grid_size = detail::compute_grid_size(num_keys, cg_size());
+  auto const grid_size = detail::grid_size(num_keys, cg_size());
 
   CUCO_CUDA_TRY(cudaMemsetAsync(d_counter_.get(), 0, sizeof(atomic_ctr_type), stream));
   std::size_t h_counter;

--- a/include/cuco/detail/static_multimap/static_multimap.inl
+++ b/include/cuco/detail/static_multimap/static_multimap.inl
@@ -299,9 +299,8 @@ OutputIt static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::retrieve(
   CUCO_CUDA_TRY(cudaMemsetAsync(d_counter_.get(), 0, sizeof(atomic_ctr_type), stream));
   std::size_t h_counter;
 
-  detail::
-    retrieve<detail::CUCO_DEFAULT_BLOCK_SIZE, flushing_cg_size, cg_size(), buffer_size, is_outer>
-    <<<grid_size, detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+  detail::retrieve<detail::default_block_size(), flushing_cg_size, cg_size(), buffer_size, is_outer>
+    <<<grid_size, detail::default_block_size(), 0, stream>>>(
       first, num_keys, output_begin, d_counter_.get(), view, key_equal);
 
   CUCO_CUDA_TRY(cudaMemcpyAsync(
@@ -339,9 +338,8 @@ OutputIt static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::retrieve_
   CUCO_CUDA_TRY(cudaMemsetAsync(d_counter_.get(), 0, sizeof(atomic_ctr_type), stream));
   std::size_t h_counter;
 
-  detail::
-    retrieve<detail::CUCO_DEFAULT_BLOCK_SIZE, flushing_cg_size, cg_size(), buffer_size, is_outer>
-    <<<grid_size, detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+  detail::retrieve<detail::default_block_size(), flushing_cg_size, cg_size(), buffer_size, is_outer>
+    <<<grid_size, detail::default_block_size(), 0, stream>>>(
       first, num_keys, output_begin, d_counter_.get(), view, key_equal);
 
   CUCO_CUDA_TRY(cudaMemcpyAsync(

--- a/include/cuco/detail/static_set/kernels.cuh
+++ b/include/cuco/detail/static_set/kernels.cuh
@@ -55,8 +55,8 @@ __global__ void find(InputIt first, cuco::detail::index_type n, OutputIt output_
 
   auto const block       = cg::this_thread_block();
   auto const thread_idx  = block.thread_rank();
-  auto const loop_stride = cuco::detail::grid_stride<CGSize>();
-  auto idx               = cuco::detail::global_thread_id<CGSize>();
+  auto const loop_stride = cuco::detail::grid_stride() / CGSize;
+  auto idx               = cuco::detail::global_thread_id() / CGSize;
 
   __shared__ typename Ref::key_type output_buffer[BlockSize / CGSize];
 

--- a/include/cuco/detail/static_set/kernels.cuh
+++ b/include/cuco/detail/static_set/kernels.cuh
@@ -16,7 +16,7 @@
 #pragma once
 
 #include <cuco/detail/bitwise_compare.cuh>
-#include <cuco/detail/utils.hpp>
+#include <cuco/detail/utility/cuda.cuh>
 
 #include <cub/block/block_reduce.cuh>
 
@@ -53,11 +53,11 @@ __global__ void find(InputIt first, cuco::detail::index_type n, OutputIt output_
 {
   namespace cg = cooperative_groups;
 
-  auto const block      = cg::this_thread_block();
-  auto const thread_idx = block.thread_rank();
+  auto const block       = cg::this_thread_block();
+  auto const thread_idx  = block.thread_rank();
+  auto const loop_stride = cuco::detail::grid_stride<CGSize>();
+  auto idx               = cuco::detail::global_thread_id<CGSize>();
 
-  cuco::detail::index_type const loop_stride = gridDim.x * BlockSize / CGSize;
-  cuco::detail::index_type idx               = (BlockSize * blockIdx.x + threadIdx.x) / CGSize;
   __shared__ typename Ref::key_type output_buffer[BlockSize / CGSize];
 
   while (idx - thread_idx < n) {  // the whole thread block falls into the same iteration

--- a/include/cuco/detail/static_set/static_set.inl
+++ b/include/cuco/detail/static_set/static_set.inl
@@ -17,7 +17,7 @@
 #include <cuco/cuda_stream_ref.hpp>
 #include <cuco/detail/static_set/functors.cuh>
 #include <cuco/detail/static_set/kernels.cuh>
-#include <cuco/detail/tuning.cuh>
+#include <cuco/detail/utility/cuda.hpp>
 #include <cuco/detail/utils.hpp>
 #include <cuco/operator.hpp>
 #include <cuco/static_set_ref.cuh>
@@ -228,11 +228,12 @@ void static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>
   if (num_keys == 0) { return; }
 
   auto const grid_size =
-    (cg_size * num_keys + detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
-    (detail::CUCO_DEFAULT_STRIDE * detail::CUCO_DEFAULT_BLOCK_SIZE);
+    (cg_size * num_keys +
+     cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
+    (cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE);
 
-  static_set_ns::detail::find<cg_size, detail::CUCO_DEFAULT_BLOCK_SIZE>
-    <<<grid_size, detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+  static_set_ns::detail::find<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
+    <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
       first, num_keys, output_begin, ref(op::find));
 }
 

--- a/include/cuco/detail/static_set/static_set.inl
+++ b/include/cuco/detail/static_set/static_set.inl
@@ -227,10 +227,7 @@ void static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>
   auto const num_keys = cuco::detail::distance(first, last);
   if (num_keys == 0) { return; }
 
-  auto const grid_size =
-    (cg_size * num_keys +
-     cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
-    (cuco::detail::CUCO_DEFAULT_STRIDE * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE);
+  auto const grid_size = cuco::detail::compute_grid_size(num_keys, cg_size);
 
   static_set_ns::detail::find<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
     <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(

--- a/include/cuco/detail/static_set/static_set.inl
+++ b/include/cuco/detail/static_set/static_set.inl
@@ -227,7 +227,7 @@ void static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>
   auto const num_keys = cuco::detail::distance(first, last);
   if (num_keys == 0) { return; }
 
-  auto const grid_size = cuco::detail::compute_grid_size(num_keys, cg_size);
+  auto const grid_size = cuco::detail::grid_size(num_keys, cg_size);
 
   static_set_ns::detail::find<cg_size, cuco::detail::default_block_size()>
     <<<grid_size, cuco::detail::default_block_size(), 0, stream>>>(

--- a/include/cuco/detail/static_set/static_set.inl
+++ b/include/cuco/detail/static_set/static_set.inl
@@ -229,8 +229,8 @@ void static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>
 
   auto const grid_size = cuco::detail::compute_grid_size(num_keys, cg_size);
 
-  static_set_ns::detail::find<cg_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE>
-    <<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+  static_set_ns::detail::find<cg_size, cuco::detail::default_block_size()>
+    <<<grid_size, cuco::detail::default_block_size(), 0, stream>>>(
       first, num_keys, output_begin, ref(op::find));
 }
 

--- a/include/cuco/detail/storage/aow_storage.inl
+++ b/include/cuco/detail/storage/aow_storage.inl
@@ -71,7 +71,7 @@ void aow_storage<T, WindowSize, Extent, Allocator>::initialize(value_type key,
   auto constexpr stride  = 4;
   auto const grid_size   = cuco::detail::compute_grid_size(this->num_windows(), cg_size, stride);
 
-  detail::initialize<<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+  detail::initialize<<<grid_size, cuco::detail::default_block_size(), 0, stream>>>(
     this->data(), this->num_windows(), key);
 }
 

--- a/include/cuco/detail/storage/aow_storage.inl
+++ b/include/cuco/detail/storage/aow_storage.inl
@@ -67,10 +67,9 @@ template <typename T, int32_t WindowSize, typename Extent, typename Allocator>
 void aow_storage<T, WindowSize, Extent, Allocator>::initialize(value_type key,
                                                                cuda_stream_ref stream) noexcept
 {
-  auto constexpr stride = 4;
-  auto const grid_size =
-    (this->num_windows() + stride * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
-    (stride * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE);
+  auto constexpr cg_size = 1;
+  auto constexpr stride  = 4;
+  auto const grid_size   = cuco::detail::compute_grid_size(this->num_windows(), cg_size, stride);
 
   detail::initialize<<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
     this->data(), this->num_windows(), key);

--- a/include/cuco/detail/storage/aow_storage.inl
+++ b/include/cuco/detail/storage/aow_storage.inl
@@ -19,7 +19,7 @@
 #include <cuco/cuda_stream_ref.hpp>
 #include <cuco/detail/storage/kernels.cuh>
 #include <cuco/detail/storage/storage_base.cuh>
-#include <cuco/detail/tuning.cuh>
+#include <cuco/detail/utility/cuda.hpp>
 #include <cuco/extent.cuh>
 
 #include <cuda/std/array>
@@ -68,10 +68,11 @@ void aow_storage<T, WindowSize, Extent, Allocator>::initialize(value_type key,
                                                                cuda_stream_ref stream) noexcept
 {
   auto constexpr stride = 4;
-  auto const grid_size  = (this->num_windows() + stride * detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
-                         (stride * detail::CUCO_DEFAULT_BLOCK_SIZE);
+  auto const grid_size =
+    (this->num_windows() + stride * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE - 1) /
+    (stride * cuco::detail::CUCO_DEFAULT_BLOCK_SIZE);
 
-  detail::initialize<<<grid_size, detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
+  detail::initialize<<<grid_size, cuco::detail::CUCO_DEFAULT_BLOCK_SIZE, 0, stream>>>(
     this->data(), this->num_windows(), key);
 }
 

--- a/include/cuco/detail/storage/aow_storage.inl
+++ b/include/cuco/detail/storage/aow_storage.inl
@@ -69,7 +69,7 @@ void aow_storage<T, WindowSize, Extent, Allocator>::initialize(value_type key,
 {
   auto constexpr cg_size = 1;
   auto constexpr stride  = 4;
-  auto const grid_size   = cuco::detail::compute_grid_size(this->num_windows(), cg_size, stride);
+  auto const grid_size   = cuco::detail::grid_size(this->num_windows(), cg_size, stride);
 
   detail::initialize<<<grid_size, cuco::detail::default_block_size(), 0, stream>>>(
     this->data(), this->num_windows(), key);

--- a/include/cuco/detail/storage/kernels.cuh
+++ b/include/cuco/detail/storage/kernels.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include <cuco/detail/utils.hpp>
+#include <cuco/detail/utility/cuda.cuh>
 
 #include <cstddef>
 
@@ -37,8 +37,8 @@ __global__ void initialize(WindowT* windows,
                            cuco::detail::index_type n,
                            typename WindowT::value_type value)
 {
-  cuco::detail::index_type const loop_stride = gridDim.x * blockDim.x;
-  cuco::detail::index_type idx               = blockDim.x * blockIdx.x + threadIdx.x;
+  auto const loop_stride = cuco::detail::grid_stride();
+  auto idx               = cuco::detail::global_thread_id();
 
   while (idx < n) {
     auto& window_slots = *(windows + idx);

--- a/include/cuco/detail/utility/cuda.cuh
+++ b/include/cuco/detail/utility/cuda.cuh
@@ -25,7 +25,7 @@ namespace detail {
  *
  * @return The global thread index
  */
-__device__ static constexpr index_type global_thread_id() noexcept
+__device__ static index_type global_thread_id() noexcept
 {
   return index_type{threadIdx.x} + index_type{blockDim.x} * index_type{blockIdx.x};
 }
@@ -35,7 +35,7 @@ __device__ static constexpr index_type global_thread_id() noexcept
  *
  * @return The grid stride
  */
-__device__ static constexpr index_type grid_stride() noexcept
+__device__ static index_type grid_stride() noexcept
 {
   return index_type{gridDim.x} * index_type{blockDim.x};
 }

--- a/include/cuco/detail/utility/cuda.cuh
+++ b/include/cuco/detail/utility/cuda.cuh
@@ -21,29 +21,23 @@ namespace cuco {
 namespace detail {
 
 /**
-￼   * @brief Returns the global thread index in a 1D scalar grid
-*
-* @tparam CGSize Number of threads in each CUDA Cooperative Group
-*
-* @return The global thread index
-￼   */
-template <index_type CGSize = 1>
+ * @brief Returns the global thread index in a 1D scalar grid
+ *
+ * @return The global thread index
+ */
 __device__ static constexpr index_type global_thread_id() noexcept
 {
-  return (index_type{threadIdx.x} + index_type{blockDim.x} * index_type{blockIdx.x}) / CGSize;
+  return index_type{threadIdx.x} + index_type{blockDim.x} * index_type{blockIdx.x};
 }
 
 /**
-￼   * @brief Returns the grid stride of a 1D grid
-*
-* @tparam CGSize Number of threads in each CUDA Cooperative Group
-*
-* @return The grid stride
-￼   */
-template <index_type CGSize = 1>
+ * @brief Returns the grid stride of a 1D grid
+ *
+ * @return The grid stride
+ */
 __device__ static constexpr index_type grid_stride() noexcept
 {
-  return index_type{gridDim.x} * index_type{blockDim.x} / CGSize;
+  return index_type{gridDim.x} * index_type{blockDim.x};
 }
 
 }  // namespace detail

--- a/include/cuco/detail/utility/cuda.cuh
+++ b/include/cuco/detail/utility/cuda.cuh
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+
+#pragma once
+
+#include <cuco/detail/utility/cuda.hpp>
+
+namespace cuco {
+namespace detail {
+
+/**
+￼   * @brief Returns the global thread index in a 1D scalar grid
+*
+* @tparam CGSize Number of threads in each CUDA Cooperative Group
+*
+* @return The global thread index
+￼   */
+template <index_type CGSize = 1>
+__device__ static constexpr index_type global_thread_id() noexcept
+{
+  return (index_type{threadIdx.x} + index_type{blockDim.x} * index_type{blockIdx.x}) / CGSize;
+}
+
+/**
+￼   * @brief Returns the grid stride of a 1D grid
+*
+* @tparam CGSize Number of threads in each CUDA Cooperative Group
+*
+* @return The grid stride
+￼   */
+template <index_type CGSize = 1>
+__device__ static constexpr index_type grid_stride() noexcept
+{
+  return index_type{gridDim.x} + index_type{blockDim.x} / CGSize;
+}
+
+}  // namespace detail
+}  // namespace cuco

--- a/include/cuco/detail/utility/cuda.cuh
+++ b/include/cuco/detail/utility/cuda.cuh
@@ -43,7 +43,7 @@ __device__ static constexpr index_type global_thread_id() noexcept
 template <index_type CGSize = 1>
 __device__ static constexpr index_type grid_stride() noexcept
 {
-  return index_type{gridDim.x} + index_type{blockDim.x} / CGSize;
+  return index_type{gridDim.x} * index_type{blockDim.x} / CGSize;
 }
 
 }  // namespace detail

--- a/include/cuco/detail/utility/cuda.hpp
+++ b/include/cuco/detail/utility/cuda.hpp
@@ -22,8 +22,10 @@ namespace detail {
 
 using index_type = int64_t;  ///< CUDA thread index type
 
-static constexpr int32_t CUCO_DEFAULT_BLOCK_SIZE = 128;  ///< Default block size
-static constexpr int32_t CUCO_DEFAULT_STRIDE     = 1;    ///< Default stride
+/// Default block size
+static constexpr int32_t default_block_size() noexcept { return 128; }
+/// Default stride
+static constexpr int32_t default_stride() noexcept { return 1; }
 
 /**
  * @brief Computes the desired 1D grid size with the given parameters
@@ -37,8 +39,8 @@ static constexpr int32_t CUCO_DEFAULT_STRIDE     = 1;    ///< Default stride
  */
 constexpr auto compute_grid_size(index_type num,
                                  int32_t cg_size    = 1,
-                                 int32_t stride     = CUCO_DEFAULT_STRIDE,
-                                 int32_t block_size = CUCO_DEFAULT_BLOCK_SIZE)
+                                 int32_t stride     = default_stride(),
+                                 int32_t block_size = default_block_size())
 {
   return int_div_ceil(cg_size * num, stride * block_size);
 }

--- a/include/cuco/detail/utility/cuda.hpp
+++ b/include/cuco/detail/utility/cuda.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 #pragma once
 
 namespace cuco {
-namespace experimental {
 namespace detail {
 
-static constexpr int CUCO_DEFAULT_BLOCK_SIZE = 128;
-static constexpr int CUCO_DEFAULT_STRIDE     = 1;
+using index_type = int64_t;  ///< CUDA thread index type
+
+static constexpr int32_t CUCO_DEFAULT_BLOCK_SIZE = 128;  ///< Default block size
+static constexpr int32_t CUCO_DEFAULT_STRIDE     = 1;    ///< Default stride
 
 }  // namespace detail
-}  // namespace experimental
 }  // namespace cuco

--- a/include/cuco/detail/utility/cuda.hpp
+++ b/include/cuco/detail/utility/cuda.hpp
@@ -40,7 +40,7 @@ constexpr auto compute_grid_size(index_type num,
                                  int32_t stride     = CUCO_DEFAULT_STRIDE,
                                  int32_t block_size = CUCO_DEFAULT_BLOCK_SIZE)
 {
-  return ceiling_div(cg_size * num, stride * block_size);
+  return int_div_ceil(cg_size * num, stride * block_size);
 }
 
 }  // namespace detail

--- a/include/cuco/detail/utility/cuda.hpp
+++ b/include/cuco/detail/utility/cuda.hpp
@@ -28,15 +28,15 @@ static constexpr int32_t CUCO_DEFAULT_STRIDE     = 1;    ///< Default stride
  *
  * @param num Number of elements to handle in the kernel
  * @param cg_size Number of threads per CUDA Cooperative Group
- * @param block_size Number of threads in each thread block
  * @param stride Number of elements to be handled by each thread
+ * @param block_size Number of threads in each thread block
  *
  * @return The resulting grid size
  */
 constexpr auto compute_grid_size(index_type num,
                                  int32_t cg_size    = 1,
-                                 int32_t block_size = CUCO_DEFAULT_BLOCK_SIZE,
-                                 int32_t stride     = CUCO_DEFAULT_STRIDE)
+                                 int32_t stride     = CUCO_DEFAULT_STRIDE,
+                                 int32_t block_size = CUCO_DEFAULT_BLOCK_SIZE)
 {
   return (cg_size * num + stride * block_size - 1) / (stride * block_size);
 }

--- a/include/cuco/detail/utility/cuda.hpp
+++ b/include/cuco/detail/utility/cuda.hpp
@@ -23,5 +23,23 @@ using index_type = int64_t;  ///< CUDA thread index type
 static constexpr int32_t CUCO_DEFAULT_BLOCK_SIZE = 128;  ///< Default block size
 static constexpr int32_t CUCO_DEFAULT_STRIDE     = 1;    ///< Default stride
 
+/**
+ * @brief Computes the desired 1D grid size with the given parameters
+ *
+ * @param num Number of elements to handle in the kernel
+ * @param cg_size Number of threads per CUDA Cooperative Group
+ * @param block_size Number of threads in each thread block
+ * @param stride Number of elements to be handled by each thread
+ *
+ * @return The resulting grid size
+ */
+constexpr auto compute_grid_size(index_type num,
+                                 int32_t cg_size    = 1,
+                                 int32_t block_size = CUCO_DEFAULT_BLOCK_SIZE,
+                                 int32_t stride     = CUCO_DEFAULT_STRIDE)
+{
+  return (cg_size * num + stride * block_size - 1) / (stride * block_size);
+}
+
 }  // namespace detail
 }  // namespace cuco

--- a/include/cuco/detail/utility/cuda.hpp
+++ b/include/cuco/detail/utility/cuda.hpp
@@ -23,9 +23,9 @@ namespace detail {
 using index_type = int64_t;  ///< CUDA thread index type
 
 /// Default block size
-static constexpr int32_t default_block_size() noexcept { return 128; }
+constexpr int32_t default_block_size() noexcept { return 128; }
 /// Default stride
-static constexpr int32_t default_stride() noexcept { return 1; }
+constexpr int32_t default_stride() noexcept { return 1; }
 
 /**
  * @brief Computes the desired 1D grid size with the given parameters

--- a/include/cuco/detail/utility/cuda.hpp
+++ b/include/cuco/detail/utility/cuda.hpp
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <cuco/detail/utility/math.hpp>
+
 namespace cuco {
 namespace detail {
 
@@ -38,7 +40,7 @@ constexpr auto compute_grid_size(index_type num,
                                  int32_t stride     = CUCO_DEFAULT_STRIDE,
                                  int32_t block_size = CUCO_DEFAULT_BLOCK_SIZE)
 {
-  return (cg_size * num + stride * block_size - 1) / (stride * block_size);
+  return ceiling_div(cg_size * num, stride * block_size);
 }
 
 }  // namespace detail

--- a/include/cuco/detail/utility/cuda.hpp
+++ b/include/cuco/detail/utility/cuda.hpp
@@ -37,10 +37,10 @@ static constexpr int32_t default_stride() noexcept { return 1; }
  *
  * @return The resulting grid size
  */
-constexpr auto compute_grid_size(index_type num,
-                                 int32_t cg_size    = 1,
-                                 int32_t stride     = default_stride(),
-                                 int32_t block_size = default_block_size())
+constexpr auto grid_size(index_type num,
+                         int32_t cg_size    = 1,
+                         int32_t stride     = default_stride(),
+                         int32_t block_size = default_block_size()) noexcept
 {
   return int_div_ceil(cg_size * num, stride * block_size);
 }

--- a/include/cuco/detail/utility/math.hpp
+++ b/include/cuco/detail/utility/math.hpp
@@ -35,7 +35,7 @@ namespace detail {
  * @return Ceiling of the integer division
  */
 template <typename T, typename U>
-constexpr T ceiling_div(T dividend, U divisor) noexcept
+constexpr T int_div_ceil(T dividend, U divisor) noexcept
 {
   static_assert(std::is_integral_v<T>);
   static_assert(std::is_integral_v<U>);

--- a/include/cuco/detail/utility/math.hpp
+++ b/include/cuco/detail/utility/math.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+
+#pragma once
+
+#include <type_traits>
+
+namespace cuco {
+namespace detail {
+
+/**
+ * @brief Ceiling of an integer division
+ *
+ * @tparam T Type of dividend
+ * @tparam U Type of divisor
+ *
+ * @throw If `T` is not an integral type
+ * @throw If `U` is not an integral type
+ *
+ * @param dividend Numerator
+ * @param divisor Denominator
+ *
+ * @return Ceiling of the integer division
+ */
+template <typename T, typename U>
+constexpr T ceiling_div(T dividend, U divisor) noexcept
+{
+  static_assert(std::is_integral_v<T>);
+  static_assert(std::is_integral_v<U>);
+  return (dividend + divisor - 1) / divisor;
+}
+
+}  // namespace detail
+}  // namespace cuco

--- a/include/cuco/detail/utils.hpp
+++ b/include/cuco/detail/utils.hpp
@@ -29,20 +29,6 @@ namespace detail {
 #define SDIV(x, y) (((x) + (y)-1) / (y))
 #endif
 
-template <typename Kernel>
-auto get_grid_size(Kernel kernel, std::size_t block_size, std::size_t dynamic_smem_bytes = 0)
-{
-  int grid_size{-1};
-  CUCO_CUDA_TRY(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-    &grid_size, kernel, block_size, dynamic_smem_bytes));
-  int dev_id{-1};
-  CUCO_CUDA_TRY(cudaGetDevice(&dev_id));
-  int num_sms{-1};
-  CUCO_CUDA_TRY(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev_id));
-  grid_size *= num_sms;
-  return grid_size;
-}
-
 template <typename Iterator>
 constexpr inline index_type distance(Iterator begin, Iterator end)
 {

--- a/include/cuco/detail/utils.hpp
+++ b/include/cuco/detail/utils.hpp
@@ -16,14 +16,13 @@
 #pragma once
 
 #include <cuco/detail/error.hpp>
+#include <cuco/detail/utility/cuda.hpp>
 
 #include <iterator>
 #include <type_traits>
 
 namespace cuco {
 namespace detail {
-
-using index_type = int64_t;  ///< index type for internal use
 
 // safe division
 #ifndef SDIV

--- a/include/cuco/detail/utils.hpp
+++ b/include/cuco/detail/utils.hpp
@@ -25,19 +25,6 @@ namespace detail {
 
 using index_type = int64_t;  ///< index type for internal use
 
-/**
- * @brief Compute the number of bits of a simple type.
- *
- * @tparam T The type we want to infer its size in bits
- *
- * @return Size of type T in bits
- */
-template <typename T>
-static constexpr std::size_t type_bits() noexcept
-{
-  return sizeof(T) * CHAR_BIT;
-}
-
 // safe division
 #ifndef SDIV
 #define SDIV(x, y) (((x) + (y)-1) / (y))

--- a/include/cuco/detail/utils.hpp
+++ b/include/cuco/detail/utils.hpp
@@ -24,11 +24,6 @@
 namespace cuco {
 namespace detail {
 
-// safe division
-#ifndef SDIV
-#define SDIV(x, y) (((x) + (y)-1) / (y))
-#endif
-
 template <typename Iterator>
 constexpr inline index_type distance(Iterator begin, Iterator end)
 {


### PR DESCRIPTION
This PR

- adds `grid_stride` and `global_thread_id` utilities in `detail/utility/cuda.cuh` (inspired by similar work in libcudf)
- adds `compute_grid_size` helper function in `detail/utility/cuda.hpp`
- renames `SDIV` as `ceiling_div` and moves it to `detail/utility/math.hpp`