### PR TITLE
Fix hash to size conversion

### DIFF
--- a/include/cuco/detail/probing_scheme_impl.inl
+++ b/include/cuco/detail/probing_scheme_impl.inl
@@ -100,7 +100,7 @@ __host__ __device__ constexpr auto linear_probing<CGSize, Hash>::operator()(
 {
   using size_type = typename Extent::value_type;
   return detail::probing_iterator<Extent>{
-    cuco::detail::sanitize_hash<size_type>(hash_(probe_key)) % upper_bound,
+    cuco::detail::hash_to_index<size_type>(hash_(probe_key)) % upper_bound,
     1,  // step size is 1
     upper_bound};
 }
@@ -114,7 +114,7 @@ __host__ __device__ constexpr auto linear_probing<CGSize, Hash>::operator()(
 {
   using size_type = typename Extent::value_type;
   return detail::probing_iterator<Extent>{
-    cuco::detail::sanitize_hash<size_type>(hash_(probe_key) + g.thread_rank()) % upper_bound,
+    cuco::detail::hash_to_index<size_type>(hash_(probe_key), g.thread_rank()) % upper_bound,
     cg_size,
     upper_bound};
 }
@@ -133,9 +133,9 @@ __host__ __device__ constexpr auto double_hashing<CGSize, Hash1, Hash2>::operato
 {
   using size_type = typename Extent::value_type;
   return detail::probing_iterator<Extent>{
-    cuco::detail::sanitize_hash<size_type>(hash1_(probe_key)) % upper_bound,
+    cuco::detail::hash_to_index<size_type>(hash1_(probe_key)) % upper_bound,
     max(size_type{1},
-        cuco::detail::sanitize_hash<size_type>(hash2_(probe_key)) %
+        cuco::detail::hash_to_index<size_type>(hash2_(probe_key)) %
           upper_bound),  // step size in range [1, prime - 1]
     upper_bound};
 }
@@ -149,8 +149,8 @@ __host__ __device__ constexpr auto double_hashing<CGSize, Hash1, Hash2>::operato
 {
   using size_type = typename Extent::value_type;
   return detail::probing_iterator<Extent>{
-    cuco::detail::sanitize_hash<size_type>(hash1_(probe_key) + g.thread_rank()) % upper_bound,
-    static_cast<size_type>((cuco::detail::sanitize_hash<size_type>(hash2_(probe_key)) %
+    cuco::detail::hash_to_index<size_type>(hash1_(probe_key), g.thread_rank()) % upper_bound,
+    static_cast<size_type>((cuco::detail::hash_to_index<size_type>(hash2_(probe_key)) %
                               (upper_bound.value() / cg_size - 1) +
                             1) *
                            cg_size),


### PR DESCRIPTION
This PR fixes some issues in the helper function for converting a hash value into a valid size.

Hash values are always unsigned, but the size type is set by the user and can thus be any integer type.
The problem occurs when the size type is signed and the hash value exceeds the range of the size type (see [repro](https://godbolt.org/z/a9qnaPbeo)).

The proposed solution fixes this: https://godbolt.org/z/46fqEaaEx
The `thread_rank` parameter can be defaulted for non-CG probing, and I also double-checked that the compiler is able to use that information to apply optimizations: https://godbolt.org/z/x3b6c1aMh