### PR TITLE
Fix typos in the documentation

### DIFF
--- a/include/cuco/detail/open_addressing_impl.cuh
+++ b/include/cuco/detail/open_addressing_impl.cuh
@@ -200,7 +200,7 @@ class open_addressing_impl {
   }
 
   /**
-   * @brief Asynchonously inserts all keys in the range `[first, last)`.
+   * @brief Asynchronously inserts all keys in the range `[first, last)`.
    *
    * @tparam InputIt Device accessible random access input iterator where
    * <tt>std::is_convertible<std::iterator_traits<InputIt>::value_type,
@@ -281,7 +281,7 @@ class open_addressing_impl {
   }
 
   /**
-   * @brief Asynchonously inserts keys in the range `[first, last)` if `pred` of the corresponding
+   * @brief Asynchronously inserts keys in the range `[first, last)` if `pred` of the corresponding
    * stencil returns true.
    *
    * @note The key `*(first + i)` is inserted if `pred( *(stencil + i) )` returns true.
@@ -323,7 +323,7 @@ class open_addressing_impl {
   }
 
   /**
-   * @brief Asynchonously indicates whether the keys in the range `[first, last)` are contained in
+   * @brief Asynchronously indicates whether the keys in the range `[first, last)` are contained in
    * the container.
    *
    * @tparam InputIt Device accessible input iterator
@@ -357,7 +357,7 @@ class open_addressing_impl {
   }
 
   /**
-   * @brief Asynchonously indicates whether the keys in the range `[first, last)` are contained in
+   * @brief Asynchronously indicates whether the keys in the range `[first, last)` are contained in
    * the container if `pred` of the corresponding stencil returns true.
    *
    * @note If `pred( *(stencil + i) )` is true, stores `true` or `false` to `(output_begin + i)`

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -221,7 +221,7 @@ class static_map {
   size_type insert(InputIt first, InputIt last, cuda_stream_ref stream = {});
 
   /**
-   * @brief Asynchonously inserts all keys in the range `[first, last)`.
+   * @brief Asynchronously inserts all keys in the range `[first, last)`.
    *
    * @tparam InputIt Device accessible random access input iterator where
    * <tt>std::is_convertible<std::iterator_traits<InputIt>::value_type,
@@ -263,7 +263,7 @@ class static_map {
     InputIt first, InputIt last, StencilIt stencil, Predicate pred, cuda_stream_ref stream = {});
 
   /**
-   * @brief Asynchonously inserts keys in the range `[first, last)` if `pred` of the corresponding
+   * @brief Asynchronously inserts keys in the range `[first, last)` if `pred` of the corresponding
    * stencil returns true.
    *
    * @note The key `*(first + i)` is inserted if `pred( *(stencil + i) )` returns true.
@@ -350,7 +350,7 @@ class static_map {
                 cuda_stream_ref stream = {}) const;
 
   /**
-   * @brief Asynchonously indicates whether the keys in the range `[first, last)` are contained in
+   * @brief Asynchronously indicates whether the keys in the range `[first, last)` are contained in
    * the map.
    *
    * @tparam InputIt Device accessible input iterator
@@ -401,7 +401,7 @@ class static_map {
                    cuda_stream_ref stream = {}) const;
 
   /**
-   * @brief Asynchonously indicates whether the keys in the range `[first, last)` are contained in
+   * @brief Asynchronously indicates whether the keys in the range `[first, last)` are contained in
    * the map if `pred` of the corresponding stencil returns true.
    *
    * @note If `pred( *(stencil + i) )` is true, stores `true` or `false` to `(output_begin + i)`

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -61,9 +61,9 @@ namespace experimental {
  * construction.
  *
  * @note Allows constant time concurrent modify or lookup operations from threads in device code.
- * @note cuCollections data stuctures always place the slot keys on the left-hand side when invoking
- * the key comparison predicate, i.e., `pred(slot_key, query_key)`. Order-sensitive `KeyEqual`
- * should be used with caution.
+ * @note cuCollections data structures always place the slot keys on the left-hand side when
+ * invoking the key comparison predicate, i.e., `pred(slot_key, query_key)`. Order-sensitive
+ * `KeyEqual` should be used with caution.
  * @note `ProbingScheme::cg_size` indicates how many threads are used to handle one independent
  * device operation. `cg_size == 1` uses the scalar (or non-CG) code paths.
  *
@@ -452,7 +452,7 @@ class static_map {
   void find(InputIt first, InputIt last, OutputIt output_begin, cuda_stream_ref stream = {}) const;
 
   /**
-   * @brief For all keys in the range `[first, last)`, asynchonously finds a payload with its key
+   * @brief For all keys in the range `[first, last)`, asynchronously finds a payload with its key
    * equivalent to the query key.
    *
    * @note If the key `*(first + i)` has a matched `element` in the map, copies the payload of

--- a/include/cuco/static_map_ref.cuh
+++ b/include/cuco/static_map_ref.cuh
@@ -31,7 +31,7 @@ namespace experimental {
  *
  * @note Concurrent modify and lookup will be supported if both kinds of operators are specified
  * during the ref construction.
- * @note cuCollections data stuctures always place the slot keys on the left-hand
+ * @note cuCollections data structures always place the slot keys on the left-hand
  * side when invoking the key comparison predicate.
  * @note Ref types are trivially-copyable and are intended to be passed by value.
  * @note `ProbingScheme::cg_size` indicates how many threads are used to handle one independent

--- a/include/cuco/static_set.cuh
+++ b/include/cuco/static_set.cuh
@@ -194,7 +194,7 @@ class static_set {
   size_type insert(InputIt first, InputIt last, cuda_stream_ref stream = {});
 
   /**
-   * @brief Asynchonously inserts all keys in the range `[first, last)`.
+   * @brief Asynchronously inserts all keys in the range `[first, last)`.
    *
    * @tparam InputIt Device accessible random access input iterator where
    * <tt>std::is_convertible<std::iterator_traits<InputIt>::value_type,
@@ -236,7 +236,7 @@ class static_set {
     InputIt first, InputIt last, StencilIt stencil, Predicate pred, cuda_stream_ref stream = {});
 
   /**
-   * @brief Asynchonously inserts keys in the range `[first, last)` if `pred` of the corresponding
+   * @brief Asynchronously inserts keys in the range `[first, last)` if `pred` of the corresponding
    * stencil returns true.
    *
    * @note The key `*(first + i)` is inserted if `pred( *(stencil + i) )` returns true.
@@ -283,7 +283,7 @@ class static_set {
                 cuda_stream_ref stream = {}) const;
 
   /**
-   * @brief Asynchonously indicates whether the keys in the range `[first, last)` are contained in
+   * @brief Asynchronously indicates whether the keys in the range `[first, last)` are contained in
    * the set.
    *
    * @tparam InputIt Device accessible input iterator
@@ -334,7 +334,7 @@ class static_set {
                    cuda_stream_ref stream = {}) const;
 
   /**
-   * @brief Asynchonously indicates whether the keys in the range `[first, last)` are contained in
+   * @brief Asynchronously indicates whether the keys in the range `[first, last)` are contained in
    * the set if `pred` of the corresponding stencil returns true.
    *
    * @note If `pred( *(stencil + i) )` is true, stores `true` or `false` to `(output_begin + i)`

--- a/include/cuco/static_set.cuh
+++ b/include/cuco/static_set.cuh
@@ -60,9 +60,9 @@ namespace experimental {
  * construction.
  *
  * @note Allows constant time concurrent modify or lookup operations from threads in device code.
- * @note cuCollections data stuctures always place the slot keys on the left-hand side when invoking
- * the key comparison predicate, i.e., `pred(slot_key, query_key)`. Order-sensitive `KeyEqual`
- * should be used with caution.
+ * @note cuCollections data structures always place the slot keys on the left-hand side when
+ * invoking the key comparison predicate, i.e., `pred(slot_key, query_key)`. Order-sensitive
+ * `KeyEqual` should be used with caution.
  * @note `ProbingScheme::cg_size` indicates how many threads are used to handle one independent
  * device operation. `cg_size == 1` uses the scalar (or non-CG) code paths.
  *
@@ -384,7 +384,7 @@ class static_set {
   void find(InputIt first, InputIt last, OutputIt output_begin, cuda_stream_ref stream = {}) const;
 
   /**
-   * @brief For all keys in the range `[first, last)`, asynchonously finds an element with key
+   * @brief For all keys in the range `[first, last)`, asynchronously finds an element with key
    * equivalent to the query key.
    *
    * @note If the key `*(first + i)` has a matched `element` in the set, copies `element` to

--- a/include/cuco/static_set_ref.cuh
+++ b/include/cuco/static_set_ref.cuh
@@ -34,7 +34,7 @@ namespace experimental {
  *
  * @note Concurrent modify and lookup will be supported if both kinds of operators are specified
  * during the ref construction.
- * @note cuCollections data stuctures always place the slot keys on the left-hand
+ * @note cuCollections data structures always place the slot keys on the left-hand
  * side when invoking the key comparison predicate.
  * @note Ref types are trivially-copyable and are intended to be passed by value.
  * @note `ProbingScheme::cg_size` indicates how many threads are used to handle one independent


### PR DESCRIPTION
This PR fixes several typos in the new containers' documentation.