### PR TITLE
Rename `insert_pair` as `insert_element` in common kernels

### DIFF
--- a/include/cuco/detail/common_kernels.cuh
+++ b/include/cuco/detail/common_kernels.cuh
@@ -76,13 +76,15 @@ __global__ void insert_if_n(InputIterator first,
 
   while (idx < n) {
     if (pred(*(stencil + idx))) {
-      typename Ref::value_type const insert_pair{*(first + idx)};
+      typename Ref::value_type const insert_element{*(first + idx)};
       if constexpr (CGSize == 1) {
-        if (ref.insert(insert_pair)) { thread_num_successes++; };
+        if (ref.insert(insert_element)) { thread_num_successes++; };
       } else {
         auto const tile =
           cooperative_groups::tiled_partition<CGSize>(cooperative_groups::this_thread_block());
-        if (ref.insert(tile, insert_pair) && tile.thread_rank() == 0) { thread_num_successes++; };
+        if (ref.insert(tile, insert_element) && tile.thread_rank() == 0) {
+          thread_num_successes++;
+        };
       }
     }
     idx += loop_stride;
@@ -134,13 +136,13 @@ __global__ void insert_if_n(
 
   while (idx < n) {
     if (pred(*(stencil + idx))) {
-      typename Ref::value_type const insert_pair{*(first + idx)};
+      typename Ref::value_type const insert_element{*(first + idx)};
       if constexpr (CGSize == 1) {
-        ref.insert(insert_pair);
+        ref.insert(insert_element);
       } else {
         auto const tile =
           cooperative_groups::tiled_partition<CGSize>(cooperative_groups::this_thread_block());
-        ref.insert(tile, insert_pair);
+        ref.insert(tile, insert_element);
       }
     }
     idx += loop_stride;

--- a/include/cuco/detail/common_kernels.cuh
+++ b/include/cuco/detail/common_kernels.cuh
@@ -82,9 +82,7 @@ __global__ void insert_if_n(InputIterator first,
       } else {
         auto const tile =
           cooperative_groups::tiled_partition<CGSize>(cooperative_groups::this_thread_block());
-        if (ref.insert(tile, insert_element) && tile.thread_rank() == 0) {
-          thread_num_successes++;
-        };
+        if (ref.insert(tile, insert_element) && tile.thread_rank() == 0) { thread_num_successes++; }
       }
     }
     idx += loop_stride;


### PR DESCRIPTION
A minor cleanup to rename variables in detail implementations.