### PR TITLE
Clean up ref implementations with `has_payload` flag

### DIFF
--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -210,8 +210,8 @@ class operator_impl<
   __device__ bool insert(value_type const& value) noexcept
   {
     ref_type& ref_             = static_cast<ref_type&>(*this);
-    auto constexpr has_payload = false;
-    return ref_.impl_.insert<has_payload>(value.first, value, ref_.predicate_);
+    auto constexpr has_payload = true;
+    return ref_.impl_.insert<has_payload>(value, ref_.predicate_);
   }
 
   /**
@@ -225,8 +225,8 @@ class operator_impl<
                          value_type const& value) noexcept
   {
     auto& ref_                 = static_cast<ref_type&>(*this);
-    auto constexpr has_payload = false;
-    return ref_.impl_.insert<has_payload>(group, value.first, value, ref_.predicate_);
+    auto constexpr has_payload = true;
+    return ref_.impl_.insert<has_payload>(group, value, ref_.predicate_);
   }
 };
 
@@ -454,8 +454,8 @@ class operator_impl<
   __device__ thrust::pair<iterator, bool> insert_and_find(value_type const& value) noexcept
   {
     ref_type& ref_             = static_cast<ref_type&>(*this);
-    auto constexpr has_payload = false;
-    return ref_.impl_.insert_and_find<has_payload>(value.first, value, ref_.predicate_);
+    auto constexpr has_payload = true;
+    return ref_.impl_.insert_and_find<has_payload>(value, ref_.predicate_);
   }
 
   /**
@@ -475,8 +475,8 @@ class operator_impl<
     cooperative_groups::thread_block_tile<cg_size> const& group, value_type const& value) noexcept
   {
     ref_type& ref_             = static_cast<ref_type&>(*this);
-    auto constexpr has_payload = false;
-    return ref_.impl_.insert_and_find<has_payload>(group, value.first, value, ref_.predicate_);
+    auto constexpr has_payload = true;
+    return ref_.impl_.insert_and_find<has_payload>(group, value, ref_.predicate_);
   }
 };
 

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -101,8 +101,8 @@ class operator_impl<op::insert_tag,
   __device__ bool insert(value_type const& value) noexcept
   {
     ref_type& ref_             = static_cast<ref_type&>(*this);
-    auto constexpr has_payload = true;
-    return ref_.impl_.insert<has_payload>(value, value, ref_.predicate_);
+    auto constexpr has_payload = false;
+    return ref_.impl_.insert<has_payload>(value, ref_.predicate_);
   }
 
   /**
@@ -117,8 +117,8 @@ class operator_impl<op::insert_tag,
                          value_type const& value) noexcept
   {
     auto& ref_                 = static_cast<ref_type&>(*this);
-    auto constexpr has_payload = true;
-    return ref_.impl_.insert<has_payload>(group, value, value, ref_.predicate_);
+    auto constexpr has_payload = false;
+    return ref_.impl_.insert<has_payload>(group, value, ref_.predicate_);
   }
 };
 
@@ -182,8 +182,8 @@ class operator_impl<op::insert_and_find_tag,
   __device__ thrust::pair<iterator, bool> insert_and_find(value_type const& value) noexcept
   {
     ref_type& ref_             = static_cast<ref_type&>(*this);
-    auto constexpr has_payload = true;
-    return ref_.impl_.insert_and_find<has_payload>(value, value, ref_.predicate_);
+    auto constexpr has_payload = false;
+    return ref_.impl_.insert_and_find<has_payload>(value, ref_.predicate_);
   }
 
   /**
@@ -203,8 +203,8 @@ class operator_impl<op::insert_and_find_tag,
     cooperative_groups::thread_block_tile<cg_size> const& group, value_type const& value) noexcept
   {
     ref_type& ref_             = static_cast<ref_type&>(*this);
-    auto constexpr has_payload = true;
-    return ref_.impl_.insert_and_find<has_payload>(group, value, value, ref_.predicate_);
+    auto constexpr has_payload = false;
+    return ref_.impl_.insert_and_find<has_payload>(group, value, ref_.predicate_);
   }
 };
 


### PR DESCRIPTION
#356 introduces the `HasPayload` template boolean to distinguish code paths between map and set implementations thus the key input for base ref insert functions becomes redundant. This PR cleans up the base ref implementations by removing the key input and fixes a logical issue in #356: set doesn't have payload while map has.