### PR TITLE
Enable heterogeneous insert for static_set

### DIFF
--- a/include/cuco/detail/common_kernels.cuh
+++ b/include/cuco/detail/common_kernels.cuh
@@ -76,7 +76,7 @@ __global__ void insert_if_n(InputIterator first,
 
   while (idx < n) {
     if (pred(*(stencil + idx))) {
-      typename Ref::value_type const insert_element{*(first + idx)};
+      auto const insert_element{*(first + idx)};
       if constexpr (CGSize == 1) {
         if (ref.insert(insert_element)) { thread_num_successes++; };
       } else {
@@ -134,7 +134,7 @@ __global__ void insert_if_n(
 
   while (idx < n) {
     if (pred(*(stencil + idx))) {
-      typename Ref::value_type const insert_element{*(first + idx)};
+      auto const insert_element{*(first + idx)};
       if constexpr (CGSize == 1) {
         ref.insert(insert_element);
       } else {

--- a/include/cuco/detail/common_kernels.cuh
+++ b/include/cuco/detail/common_kernels.cuh
@@ -78,7 +78,7 @@ __global__ void insert_if_n(InputIt first,
 
   while (idx < n) {
     if (pred(*(stencil + idx))) {
-      typename std::iterator_traits<InputIt>::value_type const insert_element{*(first + idx)};
+      typename std::iterator_traits<InputIt>::value_type const& insert_element{*(first + idx)};
       if constexpr (CGSize == 1) {
         if (ref.insert(insert_element)) { thread_num_successes++; };
       } else {
@@ -136,7 +136,7 @@ __global__ void insert_if_n(
 
   while (idx < n) {
     if (pred(*(stencil + idx))) {
-      typename std::iterator_traits<InputIt>::value_type const insert_element{*(first + idx)};
+      typename std::iterator_traits<InputIt>::value_type const& insert_element{*(first + idx)};
       if constexpr (CGSize == 1) {
         ref.insert(insert_element);
       } else {
@@ -200,7 +200,7 @@ __global__ void contains_if_n(InputIt first,
   while (idx - thread_idx < n) {  // the whole thread block falls into the same iteration
     if constexpr (CGSize == 1) {
       if (idx < n) {
-        auto const key = *(first + idx);
+        typename std::iterator_traits<InputIt>::value_type const& key = *(first + idx);
         /*
          * The ld.relaxed.gpu instruction causes L1 to flush more frequently, causing increased
          * sector stores from L2 to global memory. By writing results to shared memory and then

--- a/include/cuco/detail/common_kernels.cuh
+++ b/include/cuco/detail/common_kernels.cuh
@@ -23,6 +23,8 @@
 
 #include <cooperative_groups.h>
 
+#include <iterator>
+
 namespace cuco {
 namespace experimental {
 namespace detail {
@@ -37,7 +39,7 @@ namespace detail {
  *
  * @tparam CGSize Number of threads in each CG
  * @tparam BlockSize Number of threads in each block
- * @tparam InputIterator Device accessible input iterator whose `value_type` is
+ * @tparam InputIt Device accessible input iterator whose `value_type` is
  * convertible to the `value_type` of the data structure
  * @tparam StencilIt Device accessible random access iterator whose value_type is
  * convertible to Predicate's argument type
@@ -55,12 +57,12 @@ namespace detail {
  */
 template <int32_t CGSize,
           int32_t BlockSize,
-          typename InputIterator,
+          typename InputIt,
           typename StencilIt,
           typename Predicate,
           typename AtomicT,
           typename Ref>
-__global__ void insert_if_n(InputIterator first,
+__global__ void insert_if_n(InputIt first,
                             cuco::detail::index_type n,
                             StencilIt stencil,
                             Predicate pred,
@@ -76,7 +78,7 @@ __global__ void insert_if_n(InputIterator first,
 
   while (idx < n) {
     if (pred(*(stencil + idx))) {
-      auto const insert_element{*(first + idx)};
+      typename std::iterator_traits<InputIt>::value_type const insert_element{*(first + idx)};
       if constexpr (CGSize == 1) {
         if (ref.insert(insert_element)) { thread_num_successes++; };
       } else {
@@ -106,7 +108,7 @@ __global__ void insert_if_n(InputIterator first,
  *
  * @tparam CGSize Number of threads in each CG
  * @tparam BlockSize Number of threads in each block
- * @tparam InputIterator Device accessible input iterator whose `value_type` is
+ * @tparam InputIt Device accessible input iterator whose `value_type` is
  * convertible to the `value_type` of the data structure
  * @tparam StencilIt Device accessible random access iterator whose value_type is
  * convertible to Predicate's argument type
@@ -122,19 +124,19 @@ __global__ void insert_if_n(InputIterator first,
  */
 template <int32_t CGSize,
           int32_t BlockSize,
-          typename InputIterator,
+          typename InputIt,
           typename StencilIt,
           typename Predicate,
           typename Ref>
 __global__ void insert_if_n(
-  InputIterator first, cuco::detail::index_type n, StencilIt stencil, Predicate pred, Ref ref)
+  InputIt first, cuco::detail::index_type n, StencilIt stencil, Predicate pred, Ref ref)
 {
   auto const loop_stride = cuco::detail::grid_stride() / CGSize;
   auto idx               = cuco::detail::global_thread_id() / CGSize;
 
   while (idx < n) {
     if (pred(*(stencil + idx))) {
-      auto const insert_element{*(first + idx)};
+      typename std::iterator_traits<InputIt>::value_type const insert_element{*(first + idx)};
       if constexpr (CGSize == 1) {
         ref.insert(insert_element);
       } else {
@@ -212,7 +214,7 @@ __global__ void contains_if_n(InputIt first,
     } else {
       auto const tile = cg::tiled_partition<CGSize>(cg::this_thread_block());
       if (idx < n) {
-        auto const key   = *(first + idx);
+        typename std::iterator_traits<InputIt>::value_type const key = *(first + idx);
         auto const found = pred(*(stencil + idx)) ? ref.contains(tile, key) : false;
         if (tile.thread_rank() == 0) { *(output_begin + idx) = found; }
       }

--- a/include/cuco/detail/common_kernels.cuh
+++ b/include/cuco/detail/common_kernels.cuh
@@ -214,7 +214,7 @@ __global__ void contains_if_n(InputIt first,
     } else {
       auto const tile = cg::tiled_partition<CGSize>(cg::this_thread_block());
       if (idx < n) {
-        typename std::iterator_traits<InputIt>::value_type const key = *(first + idx);
+        typename std::iterator_traits<InputIt>::value_type const& key = *(first + idx);
         auto const found = pred(*(stencil + idx)) ? ref.contains(tile, key) : false;
         if (tile.thread_rank() == 0) { *(output_begin + idx) = found; }
       }

--- a/include/cuco/detail/equal_wrapper.cuh
+++ b/include/cuco/detail/equal_wrapper.cuh
@@ -55,15 +55,16 @@ struct equal_wrapper {
   /**
    * @brief Equality check with the given equality callable.
    *
-   * @tparam U Right-hand side Element type
+   * @tparam LHS Left-hand side Element type
+   * @tparam RHS Right-hand side Element type
    *
    * @param lhs Left-hand side element to check equality
    * @param rhs Right-hand side element to check equality
    *
    * @return `EQUAL` if `lhs` and `rhs` are equivalent. `UNEQUAL` otherwise.
    */
-  template <typename U>
-  __device__ constexpr equal_result equal_to(T const& lhs, U const& rhs) const noexcept
+  template <typename LHS, typename RHS>
+  __device__ constexpr equal_result equal_to(LHS const& lhs, RHS const& rhs) const noexcept
   {
     return equal_(lhs, rhs) ? equal_result::EQUAL : equal_result::UNEQUAL;
   }
@@ -75,15 +76,16 @@ struct equal_wrapper {
    * first then perform a equality check with the given `equal_` callable, i.e., `equal_(lhs, rhs)`.
    * @note Container (like set or map) keys MUST be always on the left-hand side.
    *
-   * @tparam U Right-hand side Element type
+   * @tparam LHS Left-hand side Element type
+   * @tparam RHS Right-hand side Element type
    *
    * @param lhs Left-hand side element to check equality
    * @param rhs Right-hand side element to check equality
    *
    * @return Three way equality comparison result
    */
-  template <typename U>
-  __device__ constexpr equal_result operator()(T const& lhs, U const& rhs) const noexcept
+  template <typename LHS, typename RHS>
+  __device__ constexpr equal_result operator()(LHS const& lhs, RHS const& rhs) const noexcept
   {
     return cuco::detail::bitwise_compare(lhs, empty_sentinel_) ? equal_result::EMPTY
                                                                : this->equal_to(lhs, rhs);

--- a/include/cuco/detail/static_set/kernels.cuh
+++ b/include/cuco/detail/static_set/kernels.cuh
@@ -64,7 +64,7 @@ __global__ void find(InputIt first, cuco::detail::index_type n, OutputIt output_
 
   while (idx - thread_idx < n) {  // the whole thread block falls into the same iteration
     if (idx < n) {
-      typename std::iterator_traits<InputIt>::value_type const key = *(first + idx);
+      typename std::iterator_traits<InputIt>::value_type const& key = *(first + idx);
       if constexpr (CGSize == 1) {
         auto const found = ref.find(key);
         /*

--- a/include/cuco/detail/static_set/kernels.cuh
+++ b/include/cuco/detail/static_set/kernels.cuh
@@ -24,6 +24,8 @@
 
 #include <cooperative_groups.h>
 
+#include <iterator>
+
 namespace cuco {
 namespace experimental {
 namespace static_set_ns {
@@ -62,7 +64,7 @@ __global__ void find(InputIt first, cuco::detail::index_type n, OutputIt output_
 
   while (idx - thread_idx < n) {  // the whole thread block falls into the same iteration
     if (idx < n) {
-      auto const key = *(first + idx);
+      typename std::iterator_traits<InputIt>::value_type const key = *(first + idx);
       if constexpr (CGSize == 1) {
         auto const found = ref.find(key);
         /*

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -128,6 +128,8 @@ class operator_impl<op::insert_tag,
   /**
    * @brief Inserts an element.
    *
+   * @tparam Value Input type which is implicitly convertible to 'value_type'
+   *
    * @param value The element to insert
    *
    * @return True if the given element is successfully inserted
@@ -142,6 +144,8 @@ class operator_impl<op::insert_tag,
 
   /**
    * @brief Inserts an element.
+   *
+   * @tparam Value Input type which is implicitly convertible to 'value_type'
    *
    * @param group The Cooperative Group used to perform group insert
    * @param value The element to insert

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -132,7 +132,8 @@ class operator_impl<op::insert_tag,
    *
    * @return True if the given element is successfully inserted
    */
-  __device__ bool insert(value_type const& value) noexcept
+  template <typename Value>
+  __device__ bool insert(Value const& value) noexcept
   {
     ref_type& ref_             = static_cast<ref_type&>(*this);
     auto constexpr has_payload = false;
@@ -147,8 +148,9 @@ class operator_impl<op::insert_tag,
    *
    * @return True if the given element is successfully inserted
    */
+  template <typename Value>
   __device__ bool insert(cooperative_groups::thread_block_tile<cg_size> const& group,
-                         value_type const& value) noexcept
+                         Value const& value) noexcept
   {
     auto& ref_                 = static_cast<ref_type&>(*this);
     auto constexpr has_payload = false;
@@ -208,12 +210,15 @@ class operator_impl<op::insert_and_find_tag,
    * element that prevented the insertion) and a `bool` denoting whether the insertion took place or
    * not.
    *
+   * @tparam Value Input type which is implicitly convertible to 'value_type'
+   *
    * @param value The element to insert
    *
    * @return a pair consisting of an iterator to the element and a bool indicating whether the
    * insertion is successful or not.
    */
-  __device__ thrust::pair<iterator, bool> insert_and_find(value_type const& value) noexcept
+  template <typename Value>
+  __device__ thrust::pair<iterator, bool> insert_and_find(Value const& value) noexcept
   {
     ref_type& ref_             = static_cast<ref_type&>(*this);
     auto constexpr has_payload = false;
@@ -227,14 +232,17 @@ class operator_impl<op::insert_and_find_tag,
    * element that prevented the insertion) and a `bool` denoting whether the insertion took place or
    * not.
    *
+   * @tparam Value Input type which is implicitly convertible to 'value_type'
+   *
    * @param group The Cooperative Group used to perform group insert_and_find
    * @param value The element to insert
    *
    * @return a pair consisting of an iterator to the element and a bool indicating whether the
    * insertion is successful or not.
    */
+  template <typename Value>
   __device__ thrust::pair<iterator, bool> insert_and_find(
-    cooperative_groups::thread_block_tile<cg_size> const& group, value_type const& value) noexcept
+    cooperative_groups::thread_block_tile<cg_size> const& group, Value const& value) noexcept
   {
     ref_type& ref_             = static_cast<ref_type&>(*this);
     auto constexpr has_payload = false;

--- a/tests/static_set/heterogeneous_lookup_test.cu
+++ b/tests/static_set/heterogeneous_lookup_test.cu
@@ -41,6 +41,8 @@ struct key_pair {
   // Device equality operator is mandatory due to libcudacxx bug:
   // https://github.com/NVIDIA/libcudacxx/issues/223
   __device__ bool operator==(key_pair const& other) const { return a == other.a and b == other.b; }
+
+  __device__ operator T() const noexcept { return a; }
 };
 
 // probe key type
@@ -75,14 +77,15 @@ struct custom_key_equal {
   template <typename LHS, typename RHS>
   __device__ bool operator()(LHS const& lhs, RHS const& rhs) const
   {
-    return thrust::raw_reference_cast(lhs).a == thrust::raw_reference_cast(rhs).a;
+    return thrust::raw_reference_cast(lhs) == thrust::raw_reference_cast(rhs).a;
   }
 };
 
 TEMPLATE_TEST_CASE_SIG(
   "Heterogeneous lookup", "", ((typename T, int CGSize), T, CGSize), (int32_t, 1), (int32_t, 2))
 {
-  using Key        = key_pair<T>;
+  using Key        = T;
+  using InsertKey  = key_pair<T>;
   using ProbeKey   = key_triplet<T>;
   using probe_type = cuco::experimental::double_hashing<CGSize, custom_hasher, custom_hasher>;
 
@@ -98,15 +101,15 @@ TEMPLATE_TEST_CASE_SIG(
                                                probe_type>{
     capacity, cuco::empty_key<Key>{sentinel_key}, custom_key_equal{}, probe};
 
-  auto insert_pairs = thrust::make_transform_iterator(thrust::counting_iterator<int>(0),
-                                                      [] __device__(auto i) { return Key{i}; });
-  auto probe_keys   = thrust::make_transform_iterator(thrust::counting_iterator<int>(0),
+  auto insert_keys = thrust::make_transform_iterator(
+    thrust::counting_iterator<int>(0), [] __device__(auto i) { return InsertKey(i); });
+  auto probe_keys = thrust::make_transform_iterator(thrust::counting_iterator<int>(0),
                                                     [] __device__(auto i) { return ProbeKey(i); });
 
   SECTION("All inserted keys should be contained")
   {
     thrust::device_vector<bool> contained(num);
-    my_set.insert(insert_pairs, insert_pairs + num);
+    my_set.insert(insert_keys, insert_keys + num);
     my_set.contains(probe_keys, probe_keys + num, contained.begin());
     REQUIRE(cuco::test::all_of(contained.begin(), contained.end(), thrust::identity{}));
   }

--- a/tests/static_set/heterogeneous_lookup_test.cu
+++ b/tests/static_set/heterogeneous_lookup_test.cu
@@ -68,16 +68,16 @@ struct custom_hasher {
   template <typename CustomKey>
   __device__ uint32_t operator()(CustomKey const& k) const
   {
-    return thrust::raw_reference_cast(k).a;
+    return k.a;
   };
 };
 
 // User-defined device key equality
 struct custom_key_equal {
-  template <typename LHS, typename RHS>
-  __device__ bool operator()(LHS const& lhs, RHS const& rhs) const
+  template <typename SlotKey, typename InputKey>
+  __device__ bool operator()(SlotKey const& lhs, InputKey const& rhs) const
   {
-    return thrust::raw_reference_cast(lhs) == thrust::raw_reference_cast(rhs).a;
+    return lhs == rhs.a;
   }
 };
 

--- a/tests/static_set/heterogeneous_lookup_test.cu
+++ b/tests/static_set/heterogeneous_lookup_test.cu
@@ -42,7 +42,7 @@ struct key_pair {
   // https://github.com/NVIDIA/libcudacxx/issues/223
   __device__ bool operator==(key_pair const& other) const { return a == other.a and b == other.b; }
 
-  __device__ operator T() const noexcept { return a; }
+  __device__ explicit operator T() const noexcept { return a; }
 };
 
 // probe key type


### PR DESCRIPTION
Similar to heterogeneous lookup, this PR enables passing value types to the `insert`/`insert_and_find`/`insert_if` functions, that are not identical with the container's value type, but are convertible to it.

Superseeds #374
Closes #373