### PR TITLE
Move key equality functor and empty value sentinel to OA impl class

### DIFF
--- a/include/cuco/detail/equal_wrapper.cuh
+++ b/include/cuco/detail/equal_wrapper.cuh
@@ -38,6 +38,7 @@ enum class equal_result : int32_t { UNEQUAL = 0, EMPTY = 1, EQUAL = 2 };
  */
 template <typename T, typename Equal>
 struct equal_wrapper {
+  // TODO: Clean up the sentinel handling since it's duplicated in ref and equal wrapper
   T empty_sentinel_;  ///< Sentinel value
   Equal equal_;       ///< Custom equality callable
 

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -21,7 +21,6 @@
 #include <cuco/extent.cuh>
 #include <cuco/pair.cuh>
 #include <cuco/probing_scheme.cuh>
-#include <cuco/sentinel.cuh>
 
 #include <thrust/distance.h>
 #include <thrust/pair.h>
@@ -120,20 +119,18 @@ class open_addressing_ref_impl {
   /**
    * @brief Constructs open_addressing_ref_impl.
    *
-   * @param empty_key_sentinel The reserved key value for empty slots
    * @param empty_slot_sentinel Sentinel indicating an empty slot
    * @param predicate Key equality binary callable
    * @param probing_scheme Probing scheme
    * @param storage_ref Non-owning ref of slot storage
    */
   __host__ __device__ explicit constexpr open_addressing_ref_impl(
-    cuco::empty_key<key_type> empty_key_sentinel,
     value_type empty_slot_sentinel,
     key_equal const& predicate,
     probing_scheme_type const& probing_scheme,
     storage_ref_type storage_ref) noexcept
     : empty_slot_sentinel_{empty_slot_sentinel},
-      predicate_{empty_key_sentinel, predicate},
+      predicate_{this->extract_key(empty_slot_sentinel), predicate},
       probing_scheme_{probing_scheme},
       storage_ref_{storage_ref}
   {

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -150,13 +150,44 @@ class open_addressing_ref_impl {
   }
 
   /**
+   * @brief Gets the sentinel used to represent an empty slot.
+   *
+   * @return The sentinel value used to represent an empty slot
+   */
+  [[nodiscard]] __device__ constexpr value_type empty_slot_sentinel() const noexcept
+  {
+    return empty_slot_sentinel_;
+  }
+
+  /**
    * @brief Returns the function that compares keys for equality.
    *
    * @return The key equality predicate
    */
-  [[nodiscard]] __host__ __device__ constexpr auto key_eq() const noexcept
+  [[nodiscard]] __host__ __device__ constexpr detail::equal_wrapper<key_type, key_equal> key_eq()
+    const noexcept
   {
     return this->predicate_;
+  }
+
+  /**
+   * @brief Gets the probing scheme.
+   *
+   * @return The probing scheme used for the container
+   */
+  [[nodiscard]] __device__ constexpr probing_scheme_type const& probing_scheme() const noexcept
+  {
+    return probing_scheme_;
+  }
+
+  /**
+   * @brief Gets the non-owning storage ref.
+   *
+   * @return The non-owning storage ref of the container
+   */
+  [[nodiscard]] __device__ constexpr storage_ref_type storage_ref() const noexcept
+  {
+    return storage_ref_;
   }
 
   /**
@@ -185,21 +216,6 @@ class open_addressing_ref_impl {
    * @return An iterator to one past the last slot
    */
   [[nodiscard]] __host__ __device__ constexpr iterator end() noexcept { return storage_ref_.end(); }
-
-  /**
-   * @brief Extracts the key from a given value type.
-   *
-   * @return The key
-   */
-  template <typename Value>
-  [[nodiscard]] __host__ __device__ constexpr auto extract_key(Value const& value) const noexcept
-  {
-    if constexpr (this->has_payload) {
-      return value.first;
-    } else {
-      return value;
-    }
-  }
 
   /**
    * @brief Inserts an element.
@@ -675,37 +691,22 @@ class open_addressing_ref_impl {
     }
   }
 
-  /**
-   * @brief Gets the sentinel used to represent an empty slot.
-   *
-   * @return The sentinel value used to represent an empty slot
-   */
-  [[nodiscard]] __device__ constexpr value_type empty_slot_sentinel() const noexcept
-  {
-    return empty_slot_sentinel_;
-  }
-
-  /**
-   * @brief Gets the probing scheme.
-   *
-   * @return The probing scheme used for the container
-   */
-  [[nodiscard]] __device__ constexpr probing_scheme_type const& probing_scheme() const noexcept
-  {
-    return probing_scheme_;
-  }
-
-  /**
-   * @brief Gets the non-owning storage ref.
-   *
-   * @return The non-owning storage ref of the container
-   */
-  [[nodiscard]] __device__ constexpr storage_ref_type storage_ref() const noexcept
-  {
-    return storage_ref_;
-  }
-
  private:
+  /**
+   * @brief Extracts the key from a given value type.
+   *
+   * @return The key
+   */
+  template <typename Value>
+  [[nodiscard]] __host__ __device__ constexpr auto extract_key(Value const& value) const noexcept
+  {
+    if constexpr (this->has_payload) {
+      return value.first;
+    } else {
+      return value;
+    }
+  }
+
   /**
    * @brief Inserts the specified element with one single CAS operation.
    *

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -172,7 +172,7 @@ class open_addressing_ref_impl {
    *
    * @return The key equality predicate
    */
-  [[nodiscard]] __device__ constexpr detail::equal_wrapper<key_type, key_equal> const& key_eq()
+  [[nodiscard]] __device__ constexpr detail::equal_wrapper<key_type, key_equal> const& predicate()
     const noexcept
   {
     return this->predicate_;

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -141,7 +141,7 @@ class open_addressing_ref_impl {
    *
    * @return The sentinel value used to represent an empty key slot
    */
-  [[nodiscard]] __host__ __device__ constexpr auto empty_key_sentinel() const noexcept
+  [[nodiscard]] __host__ __device__ constexpr key_type const& empty_key_sentinel() const noexcept
   {
     return this->predicate_.empty_sentinel_;
   }
@@ -151,7 +151,7 @@ class open_addressing_ref_impl {
    *
    * @return The sentinel value used to represent an empty slot
    */
-  [[nodiscard]] __device__ constexpr value_type empty_slot_sentinel() const noexcept
+  [[nodiscard]] __device__ constexpr value_type const& empty_slot_sentinel() const noexcept
   {
     return empty_slot_sentinel_;
   }
@@ -161,7 +161,7 @@ class open_addressing_ref_impl {
    *
    * @return The key equality predicate
    */
-  [[nodiscard]] __host__ __device__ constexpr detail::equal_wrapper<key_type, key_equal> key_eq()
+  [[nodiscard]] __device__ constexpr detail::equal_wrapper<key_type, key_equal> const& key_eq()
     const noexcept
   {
     return this->predicate_;
@@ -182,7 +182,7 @@ class open_addressing_ref_impl {
    *
    * @return The non-owning storage ref of the container
    */
-  [[nodiscard]] __device__ constexpr storage_ref_type storage_ref() const noexcept
+  [[nodiscard]] __device__ constexpr storage_ref_type const& storage_ref() const noexcept
   {
     return storage_ref_;
   }
@@ -695,7 +695,8 @@ class open_addressing_ref_impl {
    * @return The key
    */
   template <typename Value>
-  [[nodiscard]] __host__ __device__ constexpr auto extract_key(Value const& value) const noexcept
+  [[nodiscard]] __host__ __device__ constexpr auto const& extract_key(
+    Value const& value) const noexcept
   {
     if constexpr (this->has_payload) {
       return value.first;

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -892,6 +892,7 @@ class open_addressing_ref_impl {
     }
   }
 
+  // TODO: Clean up the sentinel handling since it's duplicated in ref and equal wrapper
   value_type empty_slot_sentinel_;  ///< Sentinel value indicating an empty slot
   detail::equal_wrapper<key_type, key_equal> predicate_;  ///< Key equality binary callable
   probing_scheme_type probing_scheme_;                    ///< Probing scheme

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -147,11 +147,22 @@ class open_addressing_ref_impl {
   }
 
   /**
+   * @brief Gets the sentinel value used to represent an empty payload slot.
+   *
+   * @return The sentinel value used to represent an empty payload slot
+   */
+  template <bool Dummy = true, typename Enable = std::enable_if_t<has_payload and Dummy>>
+  [[nodiscard]] __host__ __device__ constexpr auto const& empty_value_sentinel() const noexcept
+  {
+    return this->extract_payload(this->empty_slot_sentinel());
+  }
+
+  /**
    * @brief Gets the sentinel used to represent an empty slot.
    *
    * @return The sentinel value used to represent an empty slot
    */
-  [[nodiscard]] __device__ constexpr value_type const& empty_slot_sentinel() const noexcept
+  [[nodiscard]] __host__ __device__ constexpr value_type const& empty_slot_sentinel() const noexcept
   {
     return empty_slot_sentinel_;
   }
@@ -692,6 +703,10 @@ class open_addressing_ref_impl {
   /**
    * @brief Extracts the key from a given value type.
    *
+   * @tparam Value Input type which is implicitly convertible to 'value_type'
+   *
+   * @param value The input value
+   *
    * @return The key
    */
   template <typename Value>
@@ -703,6 +718,24 @@ class open_addressing_ref_impl {
     } else {
       return value;
     }
+  }
+
+  /**
+   * @brief Extracts the payload from a given value type.
+   *
+   * @note This function is only available if `this->has_payload == true`
+   *
+   * @tparam Value Input type which is implicitly convertible to 'value_type'
+   *
+   * @param value The input value
+   *
+   * @return The payload
+   */
+  template <typename Value, typename Enable = std::enable_if_t<has_payload and sizeof(Value)>>
+  [[nodiscard]] __host__ __device__ constexpr auto const& extract_payload(
+    Value const& value) const noexcept
+  {
+    return value.second;
   }
 
   /**

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -44,8 +44,7 @@ __host__ __device__ constexpr static_map_ref<
                                 KeyEqual const& predicate,
                                 ProbingScheme const& probing_scheme,
                                 StorageRef storage_ref) noexcept
-  : impl_{empty_key_sentinel,
-          cuco::pair{empty_key_sentinel, empty_value_sentinel},
+  : impl_{cuco::pair{empty_key_sentinel, empty_value_sentinel},
           predicate,
           probing_scheme,
           storage_ref},

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -44,11 +44,8 @@ __host__ __device__ constexpr static_map_ref<
                                 KeyEqual const& predicate,
                                 ProbingScheme const& probing_scheme,
                                 StorageRef storage_ref) noexcept
-  : impl_{cuco::pair{empty_key_sentinel, empty_value_sentinel},
-          predicate,
-          probing_scheme,
-          storage_ref},
-    empty_value_sentinel_{empty_value_sentinel}
+  : impl_{
+      cuco::pair{empty_key_sentinel, empty_value_sentinel}, predicate, probing_scheme, storage_ref}
 {
 }
 
@@ -70,7 +67,7 @@ __host__ __device__ constexpr static_map_ref<Key,
   static_map_ref(
     static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, OtherOperators...>&&
       other) noexcept
-  : impl_{std::move(other.impl_)}, empty_value_sentinel_{std::move(other.empty_value_sentinel_)}
+  : impl_{std::move(other.impl_)}
 {
 }
 
@@ -113,7 +110,7 @@ __host__ __device__ constexpr T
 static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::
   empty_value_sentinel() const noexcept
 {
-  return empty_value_sentinel_;
+  return impl_.empty_value_sentinel();
 }
 
 template <typename Key,

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -44,9 +44,12 @@ __host__ __device__ constexpr static_map_ref<
                                 KeyEqual const& predicate,
                                 ProbingScheme const& probing_scheme,
                                 StorageRef storage_ref) noexcept
-  : impl_{cuco::pair{empty_key_sentinel, empty_value_sentinel}, probing_scheme, storage_ref},
-    empty_value_sentinel_{empty_value_sentinel},
-    predicate_{empty_key_sentinel, predicate}
+  : impl_{empty_key_sentinel,
+          cuco::pair{empty_key_sentinel, empty_value_sentinel},
+          predicate,
+          probing_scheme,
+          storage_ref},
+    empty_value_sentinel_{empty_value_sentinel}
 {
 }
 
@@ -68,9 +71,7 @@ __host__ __device__ constexpr static_map_ref<Key,
   static_map_ref(
     static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, OtherOperators...>&&
       other) noexcept
-  : impl_{std::move(other.impl_)},
-    predicate_{std::move(other.predicate_)},
-    empty_value_sentinel_{std::move(other.empty_value_sentinel_)}
+  : impl_{std::move(other.impl_)}, empty_value_sentinel_{std::move(other.empty_value_sentinel_)}
 {
 }
 
@@ -99,7 +100,7 @@ __host__ __device__ constexpr Key
 static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::
   empty_key_sentinel() const noexcept
 {
-  return predicate_.empty_sentinel_;
+  return impl_.empty_key_sentinel();
 }
 
 template <typename Key,
@@ -131,94 +132,6 @@ auto static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operator
     std::move(*this));
 }
 
-template <typename Key,
-          typename T,
-          cuda::thread_scope Scope,
-          typename KeyEqual,
-          typename ProbingScheme,
-          typename StorageRef,
-          typename... Operators>
-struct static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::
-  predicate_wrapper {
-  detail::equal_wrapper<key_type, key_equal> predicate_;
-
-  /**
-   * @brief Map predicate wrapper ctor.
-   *
-   * @param sentinel Sentinel value
-   * @param equal Equality binary callable
-   */
-  __host__ __device__ constexpr predicate_wrapper(key_type empty_key_sentinel,
-                                                  key_equal const& equal) noexcept
-    : predicate_{empty_key_sentinel, equal}
-  {
-  }
-
-  /**
-   * @brief Equality check with the given equality callable.
-   *
-   * @tparam U Right-hand side Element type
-   *
-   * @param lhs Left-hand side element to check equality
-   * @param rhs Right-hand side element to check equality
-   *
-   * @return `EQUAL` if `lhs` and `rhs` are equivalent. `UNEQUAL` otherwise.
-   */
-  template <typename U>
-  __device__ constexpr detail::equal_result equal_to(value_type const& lhs,
-                                                     U const& rhs) const noexcept
-  {
-    return predicate_.equal_to(lhs.first, rhs);
-  }
-
-  /**
-   * @brief Equality check with the given equality callable.
-   *
-   * @param lhs Left-hand side element to check equality
-   * @param rhs Right-hand side element to check equality
-   *
-   * @return `EQUAL` if `lhs` and `rhs` are equivalent. `UNEQUAL` otherwise.
-   */
-  __device__ constexpr detail::equal_result equal_to(value_type const& lhs,
-                                                     value_type const& rhs) const noexcept
-  {
-    return predicate_.equal_to(lhs.first, rhs.first);
-  }
-
-  /**
-   * @brief Equality check with the given equality callable.
-   *
-   * @param lhs Left-hand side key to check equality
-   * @param rhs Right-hand side key to check equality
-   *
-   * @return `EQUAL` if `lhs` and `rhs` are equivalent. `UNEQUAL` otherwise.
-   */
-  __device__ constexpr detail::equal_result equal_to(key_type const& lhs,
-                                                     key_type const& rhs) const noexcept
-  {
-    return predicate_.equal_to(lhs, rhs);
-  }
-
-  /**
-   * @brief Order-sensitive equality operator.
-   *
-   * @note Container keys MUST be always on the left-hand side.
-   *
-   * @tparam U Right-hand side Element type
-   *
-   * @param lhs Left-hand side element to check equality
-   * @param rhs Right-hand side element to check equality
-   *
-   * @return Three way equality comparison result
-   */
-  template <typename U>
-  __device__ constexpr detail::equal_result operator()(value_type const& lhs,
-                                                       U const& rhs) const noexcept
-  {
-    return predicate_(lhs.first, rhs);
-  }
-};
-
 namespace detail {
 
 template <typename Key,
@@ -249,7 +162,7 @@ class operator_impl<
   __device__ bool insert(value_type const& value) noexcept
   {
     ref_type& ref_ = static_cast<ref_type&>(*this);
-    return ref_.impl_.insert(value, ref_.predicate_);
+    return ref_.impl_.insert(value);
   }
 
   /**
@@ -263,7 +176,7 @@ class operator_impl<
                          value_type const& value) noexcept
   {
     auto& ref_ = static_cast<ref_type&>(*this);
-    return ref_.impl_.insert(group, value, ref_.predicate_);
+    return ref_.impl_.insert(group, value);
   }
 };
 
@@ -309,7 +222,7 @@ class operator_impl<
       auto const window_slots = storage_ref[*probing_iter];
 
       for (auto& slot_content : window_slots) {
-        auto const eq_res = ref_.predicate_(slot_content, key);
+        auto const eq_res = ref_.impl_.key_eq()(slot_content.first, key);
 
         // If the key is already in the container, update the payload and return
         if (eq_res == detail::equal_result::EQUAL) {
@@ -355,7 +268,7 @@ class operator_impl<
 
       auto const [state, intra_window_index] = [&]() {
         for (auto i = 0; i < window_size; ++i) {
-          switch (ref_.predicate_(window_slots[i], key)) {
+          switch (ref_.impl_.key_eq()(window_slots[i].first, key)) {
             case detail::equal_result::EMPTY:
               return detail::window_probing_results{detail::equal_result::EMPTY, i};
             case detail::equal_result::EQUAL:
@@ -420,7 +333,7 @@ class operator_impl<
 
     // if key success or key was already present in the map
     if (cuco::detail::bitwise_compare(*old_key_ptr, expected_key) or
-        (ref_.predicate_.equal_to(*old_key_ptr, value.first) == detail::equal_result::EQUAL)) {
+        (ref_.impl_.key_eq().equal_to(*old_key_ptr, value.first) == detail::equal_result::EQUAL)) {
       // Update payload
       ref_.impl_.atomic_store(&slot->second, value.second);
       return true;
@@ -491,7 +404,7 @@ class operator_impl<
   __device__ thrust::pair<iterator, bool> insert_and_find(value_type const& value) noexcept
   {
     ref_type& ref_ = static_cast<ref_type&>(*this);
-    return ref_.impl_.insert_and_find(value, ref_.predicate_);
+    return ref_.impl_.insert_and_find(value);
   }
 
   /**
@@ -511,7 +424,7 @@ class operator_impl<
     cooperative_groups::thread_block_tile<cg_size> const& group, value_type const& value) noexcept
   {
     ref_type& ref_ = static_cast<ref_type&>(*this);
-    return ref_.impl_.insert_and_find(group, value, ref_.predicate_);
+    return ref_.impl_.insert_and_find(group, value);
   }
 };
 
@@ -551,7 +464,7 @@ class operator_impl<
   {
     // CRTP: cast `this` to the actual ref type
     auto const& ref_ = static_cast<ref_type const&>(*this);
-    return ref_.impl_.contains(key, ref_.predicate_);
+    return ref_.impl_.contains(key);
   }
 
   /**
@@ -572,7 +485,7 @@ class operator_impl<
     cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey const& key) const noexcept
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
-    return ref_.impl_.contains(group, key, ref_.predicate_);
+    return ref_.impl_.contains(group, key);
   }
 };
 
@@ -640,7 +553,7 @@ class operator_impl<
   {
     // CRTP: cast `this` to the actual ref type
     auto const& ref_ = static_cast<ref_type const&>(*this);
-    return ref_.impl_.find(key, ref_.predicate_);
+    return ref_.impl_.find(key);
   }
 
   /**
@@ -661,7 +574,7 @@ class operator_impl<
     cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey const& key) const noexcept
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
-    return ref_.impl_.find(group, key, ref_.predicate_);
+    return ref_.impl_.find(group, key);
   }
 };
 

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -218,7 +218,7 @@ class operator_impl<
       auto const window_slots = storage_ref[*probing_iter];
 
       for (auto& slot_content : window_slots) {
-        auto const eq_res = ref_.impl_.key_eq()(slot_content.first, key);
+        auto const eq_res = ref_.impl_.predicate()(slot_content.first, key);
 
         // If the key is already in the container, update the payload and return
         if (eq_res == detail::equal_result::EQUAL) {
@@ -264,7 +264,7 @@ class operator_impl<
 
       auto const [state, intra_window_index] = [&]() {
         for (auto i = 0; i < window_size; ++i) {
-          switch (ref_.impl_.key_eq()(window_slots[i].first, key)) {
+          switch (ref_.impl_.predicate()(window_slots[i].first, key)) {
             case detail::equal_result::EMPTY:
               return detail::window_probing_results{detail::equal_result::EMPTY, i};
             case detail::equal_result::EQUAL:
@@ -329,7 +329,8 @@ class operator_impl<
 
     // if key success or key was already present in the map
     if (cuco::detail::bitwise_compare(*old_key_ptr, expected_key) or
-        (ref_.impl_.key_eq().equal_to(*old_key_ptr, value.first) == detail::equal_result::EQUAL)) {
+        (ref_.impl_.predicate().equal_to(*old_key_ptr, value.first) ==
+         detail::equal_result::EQUAL)) {
       // Update payload
       ref_.impl_.atomic_store(&slot->second, value.second);
       return true;

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -41,8 +41,7 @@ __host__ __device__ constexpr static_set_ref<
                                 KeyEqual const& predicate,
                                 ProbingScheme const& probing_scheme,
                                 StorageRef storage_ref) noexcept
-  : impl_{empty_key_sentinel, probing_scheme, storage_ref},
-    predicate_{empty_key_sentinel, predicate}
+  : impl_{empty_key_sentinel, empty_key_sentinel, predicate, probing_scheme, storage_ref}
 {
 }
 
@@ -62,7 +61,7 @@ __host__ __device__ constexpr static_set_ref<Key,
   static_set_ref(
     static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, OtherOperators...>&&
       other) noexcept
-  : impl_{std::move(other.impl_)}, predicate_{std::move(other.predicate_)}
+  : impl_{std::move(other.impl_)}
 {
 }
 
@@ -89,7 +88,7 @@ __host__ __device__ constexpr Key
 static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::empty_key_sentinel()
   const noexcept
 {
-  return predicate_.empty_sentinel_;
+  return impl_.empty_key_sentinel();
 }
 
 template <typename Key,
@@ -138,7 +137,7 @@ class operator_impl<op::insert_tag,
   __device__ bool insert(Value const& value) noexcept
   {
     ref_type& ref_ = static_cast<ref_type&>(*this);
-    return ref_.impl_.insert(value, ref_.predicate_);
+    return ref_.impl_.insert(value);
   }
 
   /**
@@ -156,7 +155,7 @@ class operator_impl<op::insert_tag,
                          Value const& value) noexcept
   {
     auto& ref_ = static_cast<ref_type&>(*this);
-    return ref_.impl_.insert(group, value, ref_.predicate_);
+    return ref_.impl_.insert(group, value);
   }
 };
 
@@ -223,7 +222,7 @@ class operator_impl<op::insert_and_find_tag,
   __device__ thrust::pair<iterator, bool> insert_and_find(Value const& value) noexcept
   {
     ref_type& ref_ = static_cast<ref_type&>(*this);
-    return ref_.impl_.insert_and_find(value, ref_.predicate_);
+    return ref_.impl_.insert_and_find(value);
   }
 
   /**
@@ -246,7 +245,7 @@ class operator_impl<op::insert_and_find_tag,
     cooperative_groups::thread_block_tile<cg_size> const& group, Value const& value) noexcept
   {
     ref_type& ref_ = static_cast<ref_type&>(*this);
-    return ref_.impl_.insert_and_find(group, value, ref_.predicate_);
+    return ref_.impl_.insert_and_find(group, value);
   }
 };
 
@@ -283,7 +282,7 @@ class operator_impl<op::contains_tag,
   [[nodiscard]] __device__ bool contains(ProbeKey const& key) const noexcept
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
-    return ref_.impl_.contains(key, ref_.predicate_);
+    return ref_.impl_.contains(key);
   }
 
   /**
@@ -304,7 +303,7 @@ class operator_impl<op::contains_tag,
     cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey const& key) const noexcept
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
-    return ref_.impl_.contains(group, key, ref_.predicate_);
+    return ref_.impl_.contains(group, key);
   }
 };
 
@@ -370,7 +369,7 @@ class operator_impl<op::find_tag,
   {
     // CRTP: cast `this` to the actual ref type
     auto const& ref_ = static_cast<ref_type const&>(*this);
-    return ref_.impl_.find(key, ref_.predicate_);
+    return ref_.impl_.find(key);
   }
 
   /**
@@ -391,7 +390,7 @@ class operator_impl<op::find_tag,
     cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey const& key) const noexcept
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
-    return ref_.impl_.find(group, key, ref_.predicate_);
+    return ref_.impl_.find(group, key);
   }
 };
 

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -41,7 +41,7 @@ __host__ __device__ constexpr static_set_ref<
                                 KeyEqual const& predicate,
                                 ProbingScheme const& probing_scheme,
                                 StorageRef storage_ref) noexcept
-  : impl_{empty_key_sentinel, empty_key_sentinel, predicate, probing_scheme, storage_ref}
+  : impl_{empty_key_sentinel, predicate, probing_scheme, storage_ref}
 {
 }
 

--- a/include/cuco/static_map_ref.cuh
+++ b/include/cuco/static_map_ref.cuh
@@ -161,8 +161,7 @@ class static_map_ref
   [[nodiscard]] __host__ __device__ auto with(NewOperators... ops) && noexcept;
 
  private:
-  impl_type impl_;                    ///< Static map ref implementation
-  mapped_type empty_value_sentinel_;  ///< Empty value sentinel
+  impl_type impl_;  ///< Static map ref implementation
 
   // Mixins need to be friends with this class in order to access private members
   template <typename Op, typename Ref>

--- a/include/cuco/static_map_ref.cuh
+++ b/include/cuco/static_map_ref.cuh
@@ -67,7 +67,8 @@ class static_map_ref
   : public detail::operator_impl<
       Operators,
       static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>>... {
-  using impl_type = detail::open_addressing_ref_impl<Key, Scope, ProbingScheme, StorageRef>;
+  using impl_type =
+    detail::open_addressing_ref_impl<Key, Scope, KeyEqual, ProbingScheme, StorageRef>;
 
   static_assert(sizeof(T) <= 8, "Container does not support payload types larger than 8 bytes.");
 
@@ -160,10 +161,7 @@ class static_map_ref
   [[nodiscard]] __host__ __device__ auto with(NewOperators... ops) && noexcept;
 
  private:
-  struct predicate_wrapper;
-
   impl_type impl_;                    ///< Static map ref implementation
-  predicate_wrapper predicate_;       ///< Key equality binary callable
   mapped_type empty_value_sentinel_;  ///< Empty value sentinel
 
   // Mixins need to be friends with this class in order to access private members

--- a/include/cuco/static_set_ref.cuh
+++ b/include/cuco/static_set_ref.cuh
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <cuco/detail/equal_wrapper.cuh>
 #include <cuco/detail/open_addressing/open_addressing_ref_impl.cuh>
 #include <cuco/hash_functions.cuh>
 #include <cuco/operator.hpp>
@@ -65,9 +64,11 @@ class static_set_ref
   : public detail::operator_impl<
       Operators,
       static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>>... {
-  using impl_type = detail::open_addressing_ref_impl<Key, Scope, ProbingScheme, StorageRef>;
+  using impl_type =
+    detail::open_addressing_ref_impl<Key, Scope, KeyEqual, ProbingScheme, StorageRef>;
 
  public:
+  // TODO use impl_type::* aliases
   using key_type            = Key;                                     ///< Key Type
   using probing_scheme_type = ProbingScheme;                           ///< Type of probing scheme
   using storage_ref_type    = StorageRef;                              ///< Type of storage ref
@@ -142,7 +143,6 @@ class static_set_ref
 
  private:
   impl_type impl_;
-  detail::equal_wrapper<key_type, key_equal> predicate_;  ///< Key equality binary callable
 
   // Mixins need to be friends with this class in order to access private members
   template <typename Op, typename Ref>

--- a/include/cuco/static_set_ref.cuh
+++ b/include/cuco/static_set_ref.cuh
@@ -68,7 +68,6 @@ class static_set_ref
     detail::open_addressing_ref_impl<Key, Scope, KeyEqual, ProbingScheme, StorageRef>;
 
  public:
-  // TODO use impl_type::* aliases
   using key_type            = Key;                                     ///< Key Type
   using probing_scheme_type = ProbingScheme;                           ///< Type of probing scheme
   using storage_ref_type    = StorageRef;                              ///< Type of storage ref


### PR DESCRIPTION
This PR moves the logic for handling the key equality predicate and the `empty_value_sentinel` (for `static_map`)  to the OA impl class.