### PR TITLE
Update to rapids-cmake 23.12.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
 
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/CUCO_RAPIDS.cmake)
-    file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-23.10/RAPIDS.cmake
+    file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-23.12/RAPIDS.cmake
          ${CMAKE_CURRENT_BINARY_DIR}/CUCO_RAPIDS.cmake)
 endif()
 include(${CMAKE_CURRENT_BINARY_DIR}/CUCO_RAPIDS.cmake)


### PR DESCRIPTION
This updates cuCollections to rapids-cmake 23.12. This comes with https://github.com/rapidsai/rapids-cmake/pull/464/, which updates libcudacxx to 2.1.0. That should unblock several cuCollections issues such as https://github.com/NVIDIA/cuCollections/issues/332, https://github.com/NVIDIA/cuCollections/issues/331, https://github.com/NVIDIA/cuCollections/issues/289.