### PR TITLE
Fix bugs in `insert_and_find`

### DIFF
--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -388,8 +388,9 @@ class open_addressing_ref_impl {
 #if __CUDA_ARCH__ < 700
     // Spinning to ensure that the write to the value part took place requires
     // independent thread scheduling introduced with the Volta architecture.
-    static_assert(cuco::detail::is_packable<value_type>(),
-                  "insert_and_find is not supported for pair types larger than 8 bytes on pre-Volta GPUs.");
+    static_assert(
+      cuco::detail::is_packable<value_type>(),
+      "insert_and_find is not supported for pair types larger than 8 bytes on pre-Volta GPUs.");
 #endif
 
     auto const key    = this->extract_key(value);
@@ -1046,7 +1047,7 @@ class open_addressing_ref_impl {
   {
     using mapped_type = decltype(this->empty_slot_sentinel_.second);
 
-    auto const expected_key     = expected.first;
+    auto const expected_key = expected.first;
 
     auto old_key = compare_and_swap(
       &address->first, expected_key, static_cast<key_type>(thrust::get<0>(desired)));

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -1104,7 +1104,16 @@ class open_addressing_ref_impl {
     }
   }
 
-  // TODO docs
+  /**
+   * @brief Waits until the slot payload has been updated
+   *
+   * @note The function will return once the slot payload is no longer equal to the sentinel value.
+   *
+   * @tparam T Map slot type
+   *
+   * @param slot The target slot to check payload with
+   * @param sentinel The slot sentinel value
+   */
   template <typename T>
   __device__ void wait_for_payload(T& slot, T const& sentinel) const noexcept
   {

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -398,7 +398,9 @@ class open_addressing_ref_impl {
 
         // If the key is already in the container, return false
         if (eq_res == detail::equal_result::EQUAL) {
-          this->wait_for_payload((window_ptr + i)->second, this->empty_slot_sentinel_.second);
+          if constexpr (has_payload) {
+            this->wait_for_payload((window_ptr + i)->second, this->empty_slot_sentinel_.second);
+          }
           return {iterator{&window_ptr[i]}, false};
         }
         if (eq_res == detail::equal_result::EMPTY or
@@ -415,11 +417,15 @@ class open_addressing_ref_impl {
           }();
           switch (res) {
             case insert_result::SUCCESS: {
-              this->wait_for_payload((window_ptr + i)->second, this->empty_slot_sentinel_.second);
+              if constexpr (has_payload) {
+                this->wait_for_payload((window_ptr + i)->second, this->empty_slot_sentinel_.second);
+              }
               return {iterator{&window_ptr[i]}, true};
             }
             case insert_result::DUPLICATE: {
-              this->wait_for_payload((window_ptr + i)->second, this->empty_slot_sentinel_.second);
+              if constexpr (has_payload) {
+                this->wait_for_payload((window_ptr + i)->second, this->empty_slot_sentinel_.second);
+              }
               return {iterator{&window_ptr[i]}, false};
             }
             default: continue;

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -406,19 +406,16 @@ class open_addressing_ref_impl {
               return packed_cas(window_ptr + i, window_slots[i], value);
             } else {
               auto const expected_payload = window_slots[i].second;
-              auto const res = cas_dependent_write(window_ptr + i, window_slots[i], value);
-              if (res == insert_result::SUCCESS) {
-                using mapped_type = decltype(this->empty_slot_sentinel_.second);
-                auto ref =
-                  cuda::atomic<mapped_type, cuda::thread_scope_device>{(window_ptr + i)->second};
-                mapped_type old;
-                int n = 0;
-                do {
-                  old = ref.load(cuda::std::memory_order_relaxed);
-                  printf(
-                    "old: %d expected_payload: %d n: %d\n", int(old), int(expected_payload), n);
-                } while (cuco::detail::bitwise_compare(old, expected_payload));
-              }
+              auto const res    = cas_dependent_write(window_ptr + i, window_slots[i], value);
+              using mapped_type = decltype(this->empty_slot_sentinel_.second);
+              auto ref =
+                cuda::atomic<mapped_type, cuda::thread_scope_device>{(window_ptr + i)->second};
+              mapped_type old;
+              int n = 0;
+              do {
+                old = ref.load(cuda::std::memory_order_relaxed);
+                printf("old: %d expected_payload: %d n: %d\n", int(old), int(expected_payload), n);
+              } while (cuco::detail::bitwise_compare(old, expected_payload));
               return res;
             }
           }();

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -405,14 +405,20 @@ class open_addressing_ref_impl {
             if constexpr (sizeof(value_type) <= 8) {
               return packed_cas(window_ptr + i, window_slots[i], value);
             } else {
-              auto const res    = cas_dependent_write(window_ptr + i, window_slots[i], value);
-              using mapped_type = decltype(this->empty_slot_sentinel_.second);
-              auto ref =
-                cuda::atomic<mapped_type, cuda::thread_scope_device>{(window_ptr + i)->second};
-              mapped_type old;
-              do {
-                old = ref.load(cuda::std::memory_order_relaxed);
-              } while (cuco::detail::bitwise_compare(old, window_slots[i].second));
+              auto const expected_payload = window_slots[i].second;
+              auto const res = cas_dependent_write(window_ptr + i, window_slots[i], value);
+              if (res == insert_result::SUCCESS) {
+                using mapped_type = decltype(this->empty_slot_sentinel_.second);
+                auto ref =
+                  cuda::atomic<mapped_type, cuda::thread_scope_device>{(window_ptr + i)->second};
+                mapped_type old;
+                int n = 0;
+                do {
+                  old = ref.load(cuda::std::memory_order_relaxed);
+                  printf(
+                    "old: %d expected_payload: %d n: %d\n", int(old), int(expected_payload), n);
+                } while (cuco::detail::bitwise_compare(old, expected_payload));
+              }
               return res;
             }
           }();

--- a/tests/static_map/insert_and_find_test.cu
+++ b/tests/static_map/insert_and_find_test.cu
@@ -26,7 +26,7 @@
 
 #include <catch2/catch_template_test_macros.hpp>
 
-static constexpr int Iters = 10'000;
+static constexpr int Iters = 10;
 
 template <typename Ref>
 __global__ void parallel_sum(Ref v)
@@ -72,7 +72,7 @@ TEMPLATE_TEST_CASE_SIG("Parallel insert-or-update",
     thrust::equal_to<Key>{},
     cuco::experimental::linear_probing<1, cuco::murmurhash3_32<Key>>{}};
 
-  static constexpr int Blocks  = 1024;
+  static constexpr int Blocks  = 64;
   static constexpr int Threads = 128;
 
   parallel_sum<<<Blocks, Threads>>>(
@@ -84,6 +84,10 @@ TEMPLATE_TEST_CASE_SIG("Parallel insert-or-update",
 
   thrust::sequence(thrust::device, d_keys.begin(), d_keys.end());
   m.find(d_keys.begin(), d_keys.end(), d_values.begin());
+
+  for (auto const t : d_values) {
+    printf("### %d\n", int(t));
+  }
 
   REQUIRE(cuco::test::all_of(
     d_values.begin(), d_values.end(), [] __device__(Value v) { return v == Blocks * Threads; }));

--- a/tests/static_map/insert_and_find_test.cu
+++ b/tests/static_map/insert_and_find_test.cu
@@ -26,7 +26,7 @@
 
 #include <catch2/catch_template_test_macros.hpp>
 
-static constexpr int Iters = 10;
+static constexpr int Iters = 10'000;
 
 template <typename Ref>
 __global__ void parallel_sum(Ref v)
@@ -36,15 +36,27 @@ __global__ void parallel_sum(Ref v)
     if constexpr (cuco::detail::is_packable<Ref::value_type>())
 #endif
     {
-      auto [iter, inserted] = v.insert_and_find(cuco::pair{i, 1});
-      // for debugging...
-      // if (iter->second < 0) {
-      //   asm("trap;");
-      // }
-      if (!inserted) {
-        auto ref =
-          cuda::atomic_ref<typename Ref::mapped_type, cuda::thread_scope_device>{iter->second};
-        ref.fetch_add(1);
+      auto constexpr cg_size = Ref::cg_size;
+      if constexpr (cg_size == 1) {
+        auto [iter, inserted] = v.insert_and_find(cuco::pair{i, 1});
+        // for debugging...
+        // if (iter->second < 0) {
+        //   asm("trap;");
+        // }
+        if (!inserted) {
+          auto ref =
+            cuda::atomic_ref<typename Ref::mapped_type, cuda::thread_scope_device>{iter->second};
+          ref.fetch_add(1);
+        }
+      } else {
+        auto const tile =
+          cooperative_groups::tiled_partition<cg_size>(cooperative_groups::this_thread_block());
+        auto [iter, inserted] = v.insert_and_find(tile, cuco::pair{i, 1});
+        if (!inserted and tile.thread_rank() == 0) {
+          auto ref =
+            cuda::atomic_ref<typename Ref::mapped_type, cuda::thread_scope_device>{iter->second};
+          ref.fetch_add(1);
+        }
       }
     }
 #if __CUDA_ARCH__ < 700
@@ -55,36 +67,62 @@ __global__ void parallel_sum(Ref v)
   }
 }
 
-TEMPLATE_TEST_CASE_SIG("Parallel insert-or-update",
-                       "",
-                       ((typename Key, typename Value), Key, Value),
-                       (int32_t, int32_t),
-                       (int32_t, int64_t),
-                       (int64_t, int32_t),
-                       (int64_t, int64_t))
+TEMPLATE_TEST_CASE_SIG(
+  "static_map insert_and_find tests",
+  "",
+  ((typename Key, typename Value, cuco::test::probe_sequence Probe, int CGSize),
+   Key,
+   Value,
+   Probe,
+   CGSize),
+  (int32_t, int32_t, cuco::test::probe_sequence::double_hashing, 1),
+  (int32_t, int64_t, cuco::test::probe_sequence::double_hashing, 1),
+  (int32_t, int32_t, cuco::test::probe_sequence::double_hashing, 2),
+  (int32_t, int64_t, cuco::test::probe_sequence::double_hashing, 2),
+  (int64_t, int32_t, cuco::test::probe_sequence::double_hashing, 1),
+  (int64_t, int64_t, cuco::test::probe_sequence::double_hashing, 1),
+  (int64_t, int32_t, cuco::test::probe_sequence::double_hashing, 2),
+  (int64_t, int64_t, cuco::test::probe_sequence::double_hashing, 2),
+  (int32_t, int32_t, cuco::test::probe_sequence::linear_probing, 1),
+  (int32_t, int64_t, cuco::test::probe_sequence::linear_probing, 1),
+  (int32_t, int32_t, cuco::test::probe_sequence::linear_probing, 2),
+  (int32_t, int64_t, cuco::test::probe_sequence::linear_probing, 2),
+  (int64_t, int32_t, cuco::test::probe_sequence::linear_probing, 1),
+  (int64_t, int64_t, cuco::test::probe_sequence::linear_probing, 1),
+  (int64_t, int32_t, cuco::test::probe_sequence::linear_probing, 2),
+  (int64_t, int64_t, cuco::test::probe_sequence::linear_probing, 2))
 {
-  cuco::empty_key<Key> empty_key_sentinel{-1};
-  cuco::empty_value<Value> empty_value_sentinel{-1};
-  auto m = cuco::experimental::static_map{
-    10 * Iters,
-    empty_key_sentinel,
-    empty_value_sentinel,
-    thrust::equal_to<Key>{},
-    cuco::experimental::linear_probing<1, cuco::murmurhash3_32<Key>>{}};
+  using probe =
+    std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
+                       cuco::experimental::linear_probing<CGSize, cuco::murmurhash3_32<Key>>,
+                       cuco::experimental::double_hashing<CGSize,
+                                                          cuco::murmurhash3_32<Key>,
+                                                          cuco::murmurhash3_32<Key>>>;
+
+  auto map = cuco::experimental::static_map<Key,
+                                            Value,
+                                            cuco::experimental::extent<std::size_t>,
+                                            cuda::thread_scope_device,
+                                            thrust::equal_to<Key>,
+                                            probe,
+                                            cuco::cuda_allocator<std::byte>,
+                                            cuco::experimental::storage<2>>{
+    10 * Iters, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};
 
   static constexpr int Blocks  = 1024;
   static constexpr int Threads = 128;
 
   parallel_sum<<<Blocks, Threads>>>(
-    m.ref(cuco::experimental::op::insert, cuco::experimental::op::insert_and_find));
+    map.ref(cuco::experimental::op::insert, cuco::experimental::op::insert_and_find));
   CUCO_CUDA_TRY(cudaDeviceSynchronize());
 
   thrust::device_vector<Key> d_keys(Iters);
   thrust::device_vector<Value> d_values(Iters);
 
   thrust::sequence(thrust::device, d_keys.begin(), d_keys.end());
-  m.find(d_keys.begin(), d_keys.end(), d_values.begin());
+  map.find(d_keys.begin(), d_keys.end(), d_values.begin());
 
-  REQUIRE(cuco::test::all_of(
-    d_values.begin(), d_values.end(), [] __device__(Value v) { return v == Blocks * Threads; }));
+  REQUIRE(cuco::test::all_of(d_values.begin(), d_values.end(), [] __device__(Value v) {
+    return v == (Blocks * Threads) / CGSize;
+  }));
 }

--- a/tests/static_map/insert_and_find_test.cu
+++ b/tests/static_map/insert_and_find_test.cu
@@ -37,6 +37,7 @@ __global__ void parallel_sum(Ref v)
 #endif
     {
       auto [iter, inserted] = v.insert_and_find(cuco::pair{i, 1});
+      if (inserted) { printf("key: %d payload:%d \n", int(iter->first), int(iter->second)); }
       // for debugging...
       // if (iter->second < 0) {
       //   asm("trap;");


### PR DESCRIPTION
This PR fixes bugs in the new `insert_and_find` implementation where the function should not return before the payload is updated. It also migrates the related tests to test the new map.