### PR TITLE
Fix compiler warnings when compiling with clang 17.

### DIFF
--- a/include/cuco/aow_storage.cuh
+++ b/include/cuco/aow_storage.cuh
@@ -66,7 +66,8 @@ class aow_storage : public detail::aow_storage_base<T, WindowSize, Extent> {
   using base_type::num_windows;
 
   /// Type of the allocator to (de)allocate windows
-  using allocator_type = typename std::allocator_traits<Allocator>::template rebind_alloc<window_type>;
+  using allocator_type =
+    typename std::allocator_traits<Allocator>::template rebind_alloc<window_type>;
   using window_deleter_type =
     detail::custom_deleter<size_type, allocator_type>;  ///< Type of window deleter
   using ref_type = aow_storage_ref<value_type, window_size, extent_type>;  ///< Storage ref type

--- a/include/cuco/aow_storage.cuh
+++ b/include/cuco/aow_storage.cuh
@@ -66,7 +66,7 @@ class aow_storage : public detail::aow_storage_base<T, WindowSize, Extent> {
   using base_type::num_windows;
 
   /// Type of the allocator to (de)allocate windows
-  using allocator_type = typename std::allocator_traits<Allocator>::rebind_alloc<window_type>;
+  using allocator_type = typename std::allocator_traits<Allocator>::template rebind_alloc<window_type>;
   using window_deleter_type =
     detail::custom_deleter<size_type, allocator_type>;  ///< Type of window deleter
   using ref_type = aow_storage_ref<value_type, window_size, extent_type>;  ///< Storage ref type

--- a/include/cuco/detail/open_addressing/open_addressing_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_impl.cuh
@@ -559,7 +559,7 @@ class open_addressing_impl {
                                       cuda_stream_ref stream) const
   {
     std::size_t temp_storage_bytes = 0;
-    using temp_allocator_type = typename std::allocator_traits<allocator_type>::rebind_alloc<char>;
+    using temp_allocator_type = typename std::allocator_traits<allocator_type>::template rebind_alloc<char>;
     auto temp_allocator       = temp_allocator_type{this->allocator()};
     auto d_num_out            = reinterpret_cast<size_type*>(
       std::allocator_traits<temp_allocator_type>::allocate(temp_allocator, sizeof(size_type)));

--- a/include/cuco/detail/open_addressing/open_addressing_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_impl.cuh
@@ -559,9 +559,10 @@ class open_addressing_impl {
                                       cuda_stream_ref stream) const
   {
     std::size_t temp_storage_bytes = 0;
-    using temp_allocator_type = typename std::allocator_traits<allocator_type>::template rebind_alloc<char>;
-    auto temp_allocator       = temp_allocator_type{this->allocator()};
-    auto d_num_out            = reinterpret_cast<size_type*>(
+    using temp_allocator_type =
+      typename std::allocator_traits<allocator_type>::template rebind_alloc<char>;
+    auto temp_allocator = temp_allocator_type{this->allocator()};
+    auto d_num_out      = reinterpret_cast<size_type*>(
       std::allocator_traits<temp_allocator_type>::allocate(temp_allocator, sizeof(size_type)));
     CUCO_CUDA_TRY(cub::DeviceSelect::If(nullptr,
                                         temp_storage_bytes,

--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -221,7 +221,7 @@ std::pair<KeyOut, ValueOut> static_map<Key, Value, Scope, Allocator>::retrieve_a
   auto zipped_out_begin = thrust::make_zip_iterator(thrust::make_tuple(keys_out, values_out));
 
   std::size_t temp_storage_bytes = 0;
-  using temp_allocator_type      = typename std::allocator_traits<Allocator>::rebind_alloc<char>;
+  using temp_allocator_type      = typename std::allocator_traits<Allocator>::template rebind_alloc<char>;
   auto temp_allocator            = temp_allocator_type{slot_allocator_};
   auto d_num_out                 = reinterpret_cast<std::size_t*>(
     std::allocator_traits<temp_allocator_type>::allocate(temp_allocator, sizeof(std::size_t)));

--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -221,9 +221,10 @@ std::pair<KeyOut, ValueOut> static_map<Key, Value, Scope, Allocator>::retrieve_a
   auto zipped_out_begin = thrust::make_zip_iterator(thrust::make_tuple(keys_out, values_out));
 
   std::size_t temp_storage_bytes = 0;
-  using temp_allocator_type      = typename std::allocator_traits<Allocator>::template rebind_alloc<char>;
-  auto temp_allocator            = temp_allocator_type{slot_allocator_};
-  auto d_num_out                 = reinterpret_cast<std::size_t*>(
+  using temp_allocator_type =
+    typename std::allocator_traits<Allocator>::template rebind_alloc<char>;
+  auto temp_allocator = temp_allocator_type{slot_allocator_};
+  auto d_num_out      = reinterpret_cast<std::size_t*>(
     std::allocator_traits<temp_allocator_type>::allocate(temp_allocator, sizeof(std::size_t)));
   cub::DeviceSelect::If(nullptr,
                         temp_storage_bytes,

--- a/include/cuco/detail/storage/counter_storage.cuh
+++ b/include/cuco/detail/storage/counter_storage.cuh
@@ -42,7 +42,7 @@ class counter_storage : public storage_base<cuco::experimental::extent<SizeType,
 
   using size_type      = SizeType;                        ///< Size type
   using value_type     = cuda::atomic<size_type, Scope>;  ///< Type of the counter
-  using allocator_type = typename std::allocator_traits<Allocator>::rebind_alloc<
+  using allocator_type = typename std::allocator_traits<Allocator>::template rebind_alloc<
     value_type>;  ///< Type of the allocator to (de)allocate counter
   using counter_deleter_type =
     custom_deleter<size_type, allocator_type>;  ///< Type of counter deleter

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -839,9 +839,9 @@ class static_map {
   using slot_type           = pair_atomic_type;                  ///< Type of hash map slots
   using atomic_ctr_type     = cuda::atomic<std::size_t, Scope>;  ///< Atomic counter type
   using allocator_type      = Allocator;                         ///< Allocator type
-  using slot_allocator_type = typename std::allocator_traits<Allocator>::rebind_alloc<
+  using slot_allocator_type = typename std::allocator_traits<Allocator>::template rebind_alloc<
     pair_atomic_type>;  ///< Type of the allocator to (de)allocate slots
-  using counter_allocator_type = typename std::allocator_traits<Allocator>::rebind_alloc<
+  using counter_allocator_type = typename std::allocator_traits<Allocator>::template rebind_alloc<
     atomic_ctr_type>;  ///< Type of the allocator to (de)allocate atomic counters
 
 #if !defined(CUCO_HAS_INDEPENDENT_THREADS)


### PR DESCRIPTION
```In file included from cuda.cc:1:
cuco/static_map.cuh:842:74: error: use
      'template' keyword to treat 'rebind_alloc' as a dependent template name
  842 |   using slot_allocator_type = typename std::allocator_traits<Allocator>::rebind_alloc<
      |                                                                          ^
```

This fixes the instances of this error I've hit so far.

References: #128