### PR TITLE
Migrate tests to excercise the new map

### DIFF
--- a/tests/static_map/custom_type_test.cu
+++ b/tests/static_map/custom_type_test.cu
@@ -27,6 +27,8 @@
 
 #include <catch2/catch_template_test_macros.hpp>
 
+#include <cuda/functional>
+
 #include <tuple>
 
 // User-defined key type
@@ -123,17 +125,18 @@ TEMPLATE_TEST_CASE_SIG("User defined key and value type",
                     thrust::counting_iterator<int>(0),
                     thrust::counting_iterator<int>(num),
                     insert_keys.begin(),
-                    [] __device__(auto i) { return Key{i}; });
+                    cuda::proclaim_return_type<Key>([] __device__(auto i) { return Key{i}; }));
 
   thrust::transform(thrust::device,
                     thrust::counting_iterator<int>(0),
                     thrust::counting_iterator<int>(num),
                     insert_values.begin(),
-                    [] __device__(auto i) { return Value{i}; });
+                    cuda::proclaim_return_type<Value>([] __device__(auto i) { return Value{i}; }));
 
-  auto insert_pairs =
-    thrust::make_transform_iterator(thrust::make_counting_iterator<int>(0),
-                                    [] __device__(auto i) { return cuco::pair<Key, Value>(i, i); });
+  auto insert_pairs = thrust::make_transform_iterator(
+    thrust::make_counting_iterator<int>(0),
+    cuda::proclaim_return_type<cuco::pair<Key, Value>>(
+      [] __device__(auto i) { return cuco::pair<Key, Value>(i, i); }));
 
   SECTION("All inserted keys-value pairs should be correctly recovered during find")
   {
@@ -151,9 +154,9 @@ TEMPLATE_TEST_CASE_SIG("User defined key and value type",
     REQUIRE(cuco::test::equal(insert_values.begin(),
                               insert_values.end(),
                               found_values.begin(),
-                              [] __device__(Value lhs, Value rhs) {
+                              cuda::proclaim_return_type<bool>([] __device__(Value lhs, Value rhs) {
                                 return std::tie(lhs.f, lhs.s) == std::tie(rhs.f, rhs.s);
-                              }));
+                              })));
   }
 
   SECTION("All inserted keys-value pairs should be contained")
@@ -175,7 +178,7 @@ TEMPLATE_TEST_CASE_SIG("User defined key and value type",
       insert_pairs,
       insert_pairs + num,
       thrust::counting_iterator<int>(0),
-      [] __device__(auto const& key) { return (key % 2) == 0; },
+      cuda::proclaim_return_type<bool>([] __device__(auto const& key) { return (key % 2) == 0; }),
       hash_custom_key{},
       custom_key_equals{});
 
@@ -187,12 +190,13 @@ TEMPLATE_TEST_CASE_SIG("User defined key and value type",
                  hash_custom_key{},
                  custom_key_equals{});
 
-    REQUIRE(cuco::test::equal(contained.begin(),
-                              contained.end(),
-                              thrust::counting_iterator<int>(0),
-                              [] __device__(auto const& idx_contained, auto const& idx) {
-                                return ((idx % 2) == 0) == idx_contained;
-                              }));
+    REQUIRE(cuco::test::equal(
+      contained.begin(),
+      contained.end(),
+      thrust::counting_iterator<int>(0),
+      cuda::proclaim_return_type<bool>([] __device__(auto const& idx_contained, auto const& idx) {
+        return ((idx % 2) == 0) == idx_contained;
+      })));
   }
 
   SECTION("Non-inserted keys-value pairs should not be contained")
@@ -212,9 +216,11 @@ TEMPLATE_TEST_CASE_SIG("User defined key and value type",
     map.insert(insert_pairs, insert_pairs + num, hash_custom_key{}, custom_key_equals{});
     auto view = map.get_device_view();
     REQUIRE(cuco::test::all_of(
-      insert_pairs, insert_pairs + num, [view] __device__(cuco::pair<Key, Value> const& pair) {
+      insert_pairs,
+      insert_pairs + num,
+      cuda::proclaim_return_type<bool>([view] __device__(cuco::pair<Key, Value> const& pair) {
         return view.contains(pair.first, hash_custom_key{}, custom_key_equals{});
-      }));
+      })));
   }
 
   SECTION("Inserting unique keys should return insert success.")
@@ -222,9 +228,11 @@ TEMPLATE_TEST_CASE_SIG("User defined key and value type",
     auto m_view = map.get_device_mutable_view();
     REQUIRE(cuco::test::all_of(insert_pairs,
                                insert_pairs + num,
-                               [m_view] __device__(cuco::pair<Key, Value> const& pair) mutable {
-                                 return m_view.insert(pair, hash_custom_key{}, custom_key_equals{});
-                               }));
+                               cuda::proclaim_return_type<bool>(
+                                 [m_view] __device__(cuco::pair<Key, Value> const& pair) mutable {
+                                   return m_view.insert(
+                                     pair, hash_custom_key{}, custom_key_equals{});
+                                 })));
   }
 
   SECTION("Cannot find any key in an empty hash map")
@@ -235,18 +243,21 @@ TEMPLATE_TEST_CASE_SIG("User defined key and value type",
       REQUIRE(cuco::test::all_of(
         insert_pairs,
         insert_pairs + num,
-        [view] __device__(cuco::pair<Key, Value> const& pair) mutable {
-          return view.find(pair.first, hash_custom_key{}, custom_key_equals{}) == view.end();
-        }));
+        cuda::proclaim_return_type<bool>(
+          [view] __device__(cuco::pair<Key, Value> const& pair) mutable {
+            return view.find(pair.first, hash_custom_key{}, custom_key_equals{}) == view.end();
+          })));
     }
 
     SECTION("const view")
     {
       auto const view = map.get_device_view();
       REQUIRE(cuco::test::all_of(
-        insert_pairs, insert_pairs + num, [view] __device__(cuco::pair<Key, Value> const& pair) {
+        insert_pairs,
+        insert_pairs + num,
+        cuda::proclaim_return_type<bool>([view] __device__(cuco::pair<Key, Value> const& pair) {
           return view.find(pair.first, hash_custom_key{}, custom_key_equals{}) == view.end();
-        }));
+        })));
     }
   }
 }

--- a/tests/static_map/duplicate_keys_test.cu
+++ b/tests/static_map/duplicate_keys_test.cu
@@ -29,6 +29,8 @@
 
 #include <catch2/catch_template_test_macros.hpp>
 
+#include <cuda/functional>
+
 using size_type = std::size_t;
 
 TEMPLATE_TEST_CASE_SIG(
@@ -83,7 +85,8 @@ TEMPLATE_TEST_CASE_SIG(
 
   auto pairs_begin = thrust::make_transform_iterator(
     thrust::make_counting_iterator<int>(0),
-    [] __device__(auto i) { return cuco::pair<Key, Value>(i / 2, i / 2); });
+    cuda::proclaim_return_type<cuco::pair<Key, Value>>(
+      [] __device__(auto i) { return cuco::pair<Key, Value>(i / 2, i / 2); }));
 
   thrust::device_vector<Value> d_results(num_keys);
   thrust::device_vector<bool> d_contained(num_keys);

--- a/tests/static_map/heterogeneous_lookup_test.cu
+++ b/tests/static_map/heterogeneous_lookup_test.cu
@@ -27,6 +27,8 @@
 
 #include <catch2/catch_template_test_macros.hpp>
 
+#include <cuda/functional>
+
 #include <tuple>
 
 // insert key type
@@ -115,8 +117,9 @@ TEMPLATE_TEST_CASE_SIG("Heterogeneous lookup",
   auto insert_pairs = thrust::make_transform_iterator(
     thrust::counting_iterator<int>(0),
     [] __device__(auto i) { return cuco::pair<InsertKey, Value>(i, i); });
-  auto probe_keys = thrust::make_transform_iterator(thrust::counting_iterator<int>(0),
-                                                    [] __device__(auto i) { return ProbeKey(i); });
+  auto probe_keys = thrust::make_transform_iterator(
+    thrust::counting_iterator<int>(0),
+    cuda::proclaim_return_type<ProbeKey>([] __device__(auto i) { return ProbeKey{i}; }));
 
   SECTION("All inserted keys-value pairs should be contained")
   {

--- a/tests/static_map/insert_and_find_test.cu
+++ b/tests/static_map/insert_and_find_test.cu
@@ -26,6 +26,8 @@
 
 #include <catch2/catch_template_test_macros.hpp>
 
+#include <cuda/functional>
+
 static constexpr int Iters = 10'000;
 
 template <typename Ref>
@@ -129,7 +131,8 @@ TEMPLATE_TEST_CASE_SIG(
   thrust::sequence(thrust::device, d_keys.begin(), d_keys.end());
   map.find(d_keys.begin(), d_keys.end(), d_values.begin());
 
-  REQUIRE(cuco::test::all_of(d_values.begin(), d_values.end(), [] __device__(Value v) {
-    return v == (Blocks * Threads) / CGSize;
-  }));
+  REQUIRE(cuco::test::all_of(
+    d_values.begin(), d_values.end(), cuda::proclaim_return_type<bool>([] __device__(Value v) {
+      return v == (Blocks * Threads) / CGSize;
+    })));
 }

--- a/tests/static_map/shared_memory_test.cu
+++ b/tests/static_map/shared_memory_test.cu
@@ -74,9 +74,8 @@ TEMPLATE_TEST_CASE_SIG("Shared memory static map",
                        (int64_t, int32_t),
                        (int64_t, int64_t))
 {
-  using MapType                = cuco::static_map<Key, Value>;
-  using DeviceViewType         = typename MapType::device_view;
-  using DeviceViewIteratorType = typename DeviceViewType::iterator;
+  using MapType        = cuco::static_map<Key, Value>;
+  using DeviceViewType = typename MapType::device_view;
 
   constexpr std::size_t number_of_maps  = 1000;
   constexpr std::size_t elements_in_map = 500;

--- a/tests/static_map/shared_memory_test.cu
+++ b/tests/static_map/shared_memory_test.cu
@@ -27,6 +27,8 @@
 
 #include <catch2/catch_template_test_macros.hpp>
 
+#include <cuda/functional>
+
 #include <limits>
 
 template <typename MapType, int CAPACITY>
@@ -126,9 +128,11 @@ TEMPLATE_TEST_CASE_SIG("Shared memory static map",
     auto zip = thrust::make_zip_iterator(
       thrust::make_tuple(d_keys_exist.begin(), d_keys_and_values_correct.begin()));
 
-    REQUIRE(cuco::test::all_of(zip, zip + d_keys_exist.size(), [] __device__(auto const& z) {
-      return thrust::get<0>(z) and thrust::get<1>(z);
-    }));
+    REQUIRE(cuco::test::all_of(zip,
+                               zip + d_keys_exist.size(),
+                               cuda::proclaim_return_type<bool>([] __device__(auto const& z) {
+                                 return thrust::get<0>(z) and thrust::get<1>(z);
+                               })));
   }
 
   SECTION("No key is found before insertion.")

--- a/tests/static_map/stream_test.cu
+++ b/tests/static_map/stream_test.cu
@@ -29,7 +29,7 @@
 
 #include <catch2/catch_template_test_macros.hpp>
 
-TEMPLATE_TEST_CASE_SIG("Unique sequence of keys on given stream",
+TEMPLATE_TEST_CASE_SIG("static_map: unique sequence of keys on given stream",
                        "",
                        ((typename Key, typename Value), Key, Value),
                        (int32_t, int32_t),
@@ -41,11 +41,14 @@ TEMPLATE_TEST_CASE_SIG("Unique sequence of keys on given stream",
   CUCO_CUDA_TRY(cudaStreamCreate(&stream));
 
   constexpr std::size_t num_keys{500'000};
-  cuco::static_map<Key, Value> map{1'000'000,
-                                   cuco::empty_key<Key>{-1},
-                                   cuco::empty_value<Value>{-1},
-                                   cuco::cuda_allocator<char>{},
-                                   stream};
+  auto map = cuco::experimental::static_map{
+    num_keys * 2,
+    cuco::empty_key<Key>{-1},
+    cuco::empty_value<Value>{-1},
+    thrust::equal_to<Key>{},
+    cuco::experimental::linear_probing<1, cuco::default_hash_function<Key>>{},
+    cuco::cuda_allocator<char>{},
+    stream};
 
   thrust::device_vector<Key> d_keys(num_keys);
   thrust::device_vector<Value> d_values(num_keys);
@@ -57,16 +60,13 @@ TEMPLATE_TEST_CASE_SIG("Unique sequence of keys on given stream",
     thrust::make_transform_iterator(thrust::make_counting_iterator<int>(0),
                                     [] __device__(auto i) { return cuco::pair<Key, Value>(i, i); });
 
-  auto hash_fn  = cuco::default_hash_function<Key>{};
-  auto equal_fn = thrust::equal_to<Value>{};
-
   // bulk function test cases
   SECTION("All inserted keys-value pairs should be correctly recovered during find")
   {
     thrust::device_vector<Value> d_results(num_keys);
 
-    map.insert(pairs_begin, pairs_begin + num_keys, hash_fn, equal_fn, stream);
-    map.find(d_keys.begin(), d_keys.end(), d_results.begin(), hash_fn, equal_fn, stream);
+    map.insert(pairs_begin, pairs_begin + num_keys, stream);
+    map.find(d_keys.begin(), d_keys.end(), d_results.begin(), stream);
     auto zip = thrust::make_zip_iterator(thrust::make_tuple(d_results.begin(), d_values.begin()));
 
     REQUIRE(cuco::test::all_of(
@@ -80,8 +80,8 @@ TEMPLATE_TEST_CASE_SIG("Unique sequence of keys on given stream",
   {
     thrust::device_vector<bool> d_contained(num_keys);
 
-    map.insert(pairs_begin, pairs_begin + num_keys, hash_fn, equal_fn, stream);
-    map.contains(d_keys.begin(), d_keys.end(), d_contained.begin(), hash_fn, equal_fn, stream);
+    map.insert(pairs_begin, pairs_begin + num_keys, stream);
+    map.contains(d_keys.begin(), d_keys.end(), d_contained.begin(), stream);
 
     REQUIRE(cuco::test::all_of(d_contained.begin(), d_contained.end(), thrust::identity{}, stream));
   }

--- a/tests/static_map/unique_sequence_test.cu
+++ b/tests/static_map/unique_sequence_test.cu
@@ -31,123 +31,6 @@
 
 #include <catch2/catch_template_test_macros.hpp>
 
-TEMPLATE_TEST_CASE_SIG("Unique sequence of keys",
-                       "",
-                       ((typename Key, typename Value), Key, Value),
-                       (int32_t, int32_t),
-                       (int32_t, int64_t),
-                       (int64_t, int32_t),
-                       (int64_t, int64_t))
-{
-  constexpr std::size_t num_keys{500'000};
-  cuco::static_map<Key, Value> map{
-    1'000'000, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};
-
-  auto m_view = map.get_device_mutable_view();
-  auto view   = map.get_device_view();
-
-  thrust::device_vector<Key> d_keys(num_keys);
-  thrust::device_vector<Value> d_values(num_keys);
-
-  thrust::sequence(thrust::device, d_keys.begin(), d_keys.end());
-  thrust::sequence(thrust::device, d_values.begin(), d_values.end());
-
-  auto pairs_begin =
-    thrust::make_transform_iterator(thrust::make_counting_iterator<int>(0),
-                                    [] __device__(auto i) { return cuco::pair<Key, Value>(i, i); });
-
-  thrust::device_vector<Value> d_results(num_keys);
-  thrust::device_vector<bool> d_contained(num_keys);
-
-  // bulk function test cases
-  SECTION("All inserted keys-value pairs should be correctly recovered during find")
-  {
-    map.insert(pairs_begin, pairs_begin + num_keys);
-    map.find(d_keys.begin(), d_keys.end(), d_results.begin());
-    auto zip = thrust::make_zip_iterator(thrust::make_tuple(d_results.begin(), d_values.begin()));
-
-    REQUIRE(cuco::test::all_of(zip, zip + num_keys, [] __device__(auto const& p) {
-      return thrust::get<0>(p) == thrust::get<1>(p);
-    }));
-  }
-
-  SECTION("All inserted keys-value pairs should be contained")
-  {
-    map.insert(pairs_begin, pairs_begin + num_keys);
-    map.contains(d_keys.begin(), d_keys.end(), d_contained.begin());
-
-    REQUIRE(cuco::test::all_of(d_contained.begin(), d_contained.end(), thrust::identity{}));
-  }
-
-  SECTION("Non-inserted keys-value pairs should not be contained")
-  {
-    map.contains(d_keys.begin(), d_keys.end(), d_contained.begin());
-
-    REQUIRE(cuco::test::none_of(d_contained.begin(), d_contained.end(), thrust::identity{}));
-  }
-
-  SECTION("Inserting unique keys should return insert success.")
-  {
-    REQUIRE(cuco::test::all_of(pairs_begin,
-                               pairs_begin + num_keys,
-                               [m_view] __device__(cuco::pair<Key, Value> const& pair) mutable {
-                                 return m_view.insert(pair);
-                               }));
-  }
-
-  SECTION("Cannot find any key in an empty hash map with non-const view")
-  {
-    SECTION("non-const view")
-    {
-      REQUIRE(cuco::test::all_of(pairs_begin,
-                                 pairs_begin + num_keys,
-                                 [view] __device__(cuco::pair<Key, Value> const& pair) mutable {
-                                   return view.find(pair.first) == view.end();
-                                 }));
-    }
-    SECTION("const view")
-    {
-      REQUIRE(cuco::test::all_of(
-        pairs_begin, pairs_begin + num_keys, [view] __device__(cuco::pair<Key, Value> const& pair) {
-          return view.find(pair.first) == view.end();
-        }));
-    }
-  }
-
-  SECTION("Keys are all found after inserting many keys.")
-  {
-    // Bulk insert keys
-    thrust::for_each(
-      thrust::device,
-      pairs_begin,
-      pairs_begin + num_keys,
-      [m_view] __device__(cuco::pair<Key, Value> const& pair) mutable { m_view.insert(pair); });
-
-    SECTION("non-const view")
-    {
-      // All keys should be found
-      REQUIRE(cuco::test::all_of(pairs_begin,
-                                 pairs_begin + num_keys,
-                                 [view] __device__(cuco::pair<Key, Value> const& pair) mutable {
-                                   auto const found = view.find(pair.first);
-                                   return (found != view.end()) and
-                                          (found->first.load() == pair.first and
-                                           found->second.load() == pair.second);
-                                 }));
-    }
-    SECTION("const view")
-    {
-      // All keys should be found
-      REQUIRE(cuco::test::all_of(
-        pairs_begin, pairs_begin + num_keys, [view] __device__(cuco::pair<Key, Value> const& pair) {
-          auto const found = view.find(pair.first);
-          return (found != view.end()) and
-                 (found->first.load() == pair.first and found->second.load() == pair.second);
-        }));
-    }
-  }
-}
-
 using size_type = int32_t;
 
 template <typename Map>
@@ -253,7 +136,7 @@ __inline__ void test_unique_sequence(Map& map, size_type num_keys)
 }
 
 TEMPLATE_TEST_CASE_SIG(
-  "Unique sequence",
+  "static_map: unique sequence",
   "",
   ((typename Key, typename Value, cuco::test::probe_sequence Probe, int CGSize),
    Key,


### PR DESCRIPTION
This PR migrates static map tests to test the new static map:

- Large type tests are not migrated since the new map doesn't support keys larger than 8 bytes
- Shared memory tests require related functions to be added into ref code thus would be in a separate PR