### PR TITLE
Fix potential logic issues in CG erase

### DIFF
--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -595,12 +595,12 @@ class open_addressing_ref_impl {
           case insert_result::DUPLICATE: return false;
           default: continue;
         }
-      } else if (group.any(state == detail::equal_result::EMPTY)) {
-        // Key doesn't exist, return false
-        return false;
-      } else {
-        ++probing_iter;
       }
+
+      // Key doesn't exist, return false
+      if (group.any(state == detail::equal_result::EMPTY)) { return false; }
+
+      ++probing_iter;
     }
   }
 

--- a/tests/static_map/erase_test.cu
+++ b/tests/static_map/erase_test.cu
@@ -106,7 +106,7 @@ TEMPLATE_TEST_CASE_SIG(
   (int64_t, int32_t, cuco::test::probe_sequence::linear_probing, 2),
   (int64_t, int64_t, cuco::test::probe_sequence::linear_probing, 2))
 {
-  constexpr size_type num_keys{400};
+  constexpr size_type num_keys{1'000'000};
 
   using probe =
     std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,


### PR DESCRIPTION
This PR updates the CG erase code to be the same as it is in the legacy implementation. It also increases the input size for the erase tests and thus has a higher chance of uncovering potential issues in the code.

Ran the new tests on both sm75 and sm61 for about 30 mins and no tests failed.