### PR TITLE
Expose `window_extent` to device ref

### DIFF
--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -242,6 +242,16 @@ class open_addressing_ref_impl {
   }
 
   /**
+   * @brief Gets the window extent of the current storage.
+   *
+   * @return The window extent.
+   */
+  [[nodiscard]] __host__ __device__ constexpr extent_type window_extent() const noexcept
+  {
+    return storage_ref_.window_extent();
+  }
+
+  /**
    * @brief Returns a const_iterator to one past the last slot.
    *
    * @return A const_iterator to one past the last slot

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -595,12 +595,12 @@ class open_addressing_ref_impl {
           case insert_result::DUPLICATE: return false;
           default: continue;
         }
-      } else if (group.any(state == detail::equal_result::EMPTY)) {
-        // Key doesn't exist, return false
-        return false;
-      } else {
-        ++probing_iter;
       }
+
+      // Key doesn't exist, return false
+      if (group.any(state == detail::equal_result::EMPTY)) { return false; }
+
+      ++probing_iter;
     }
   }
 

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -122,6 +122,26 @@ template <typename Key,
           typename ProbingScheme,
           typename StorageRef,
           typename... Operators>
+__host__ __device__ constexpr static_map_ref<Key,
+                                             T,
+                                             Scope,
+                                             KeyEqual,
+                                             ProbingScheme,
+                                             StorageRef,
+                                             Operators...>::extent_type
+static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::window_extent()
+  const noexcept
+{
+  return impl_.window_extent();
+}
+
+template <typename Key,
+          typename T,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
 __host__ __device__ constexpr Key
 static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::
   empty_key_sentinel() const noexcept

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -105,6 +105,24 @@ template <typename Key,
           typename ProbingScheme,
           typename StorageRef,
           typename... Operators>
+__host__ __device__ constexpr static_set_ref<Key,
+                                             Scope,
+                                             KeyEqual,
+                                             ProbingScheme,
+                                             StorageRef,
+                                             Operators...>::extent_type
+static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::window_extent()
+  const noexcept
+{
+  return impl_.window_extent();
+}
+
+template <typename Key,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
 __host__ __device__ constexpr Key
 static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::empty_key_sentinel()
   const noexcept

--- a/include/cuco/static_map_ref.cuh
+++ b/include/cuco/static_map_ref.cuh
@@ -146,6 +146,13 @@ class static_map_ref
   [[nodiscard]] __host__ __device__ constexpr auto capacity() const noexcept;
 
   /**
+   * @brief Gets the window extent of the current storage.
+   *
+   * @return The window extent.
+   */
+  [[nodiscard]] __host__ __device__ constexpr extent_type window_extent() const noexcept;
+
+  /**
    * @brief Gets the sentinel value used to represent an empty key slot.
    *
    * @return The sentinel value used to represent an empty key slot

--- a/include/cuco/static_set_ref.cuh
+++ b/include/cuco/static_set_ref.cuh
@@ -131,6 +131,13 @@ class static_set_ref
   [[nodiscard]] __host__ __device__ constexpr auto capacity() const noexcept;
 
   /**
+   * @brief Gets the window extent of the current storage.
+   *
+   * @return The window extent.
+   */
+  [[nodiscard]] __host__ __device__ constexpr extent_type window_extent() const noexcept;
+
+  /**
    * @brief Gets the sentinel value used to represent an empty key slot.
    *
    * @return The sentinel value used to represent an empty key slot

--- a/tests/static_map/capacity_test.cu
+++ b/tests/static_map/capacity_test.cu
@@ -75,7 +75,7 @@ TEST_CASE("Static map capacity", "")
 
   SECTION("Static window extent can be evaluated at build time.")
   {
-    std::size_t constexpr gold_capacity = 211;
+    std::size_t constexpr gold_extent = 211;
 
     using extent_type = cuco::experimental::extent<std::size_t, num_keys>;
     cuco::experimental::static_map<Key,
@@ -87,12 +87,10 @@ TEST_CASE("Static map capacity", "")
                                    AllocatorT,
                                    StorageT>
       map{extent_type{}, cuco::empty_key<Key>{-1}, cuco::empty_value<T>{-1}};
-    auto const capacity = map.capacity();
-    REQUIRE(capacity == gold_capacity);
 
     auto ref               = map.ref(cuco::experimental::insert);
     auto const num_windows = ref.window_extent();
-    STATIC_REQUIRE(static_cast<std::size_t>(num_windows) == gold_capacity);
+    STATIC_REQUIRE(static_cast<std::size_t>(num_windows) == gold_extent);
   }
 
   SECTION("Dynamic extent is evaluated at run time.")

--- a/tests/static_map/capacity_test.cu
+++ b/tests/static_map/capacity_test.cu
@@ -73,6 +73,28 @@ TEST_CASE("Static map capacity", "")
 
   constexpr std::size_t num_keys{400};
 
+  SECTION("Static window extent can be evaluated at build time.")
+  {
+    std::size_t constexpr gold_capacity = 211;
+
+    using extent_type = cuco::experimental::extent<std::size_t, num_keys>;
+    cuco::experimental::static_map<Key,
+                                   T,
+                                   extent_type,
+                                   cuda::thread_scope_device,
+                                   Equal,
+                                   ProbeT,
+                                   AllocatorT,
+                                   StorageT>
+      map{extent_type{}, cuco::empty_key<Key>{-1}, cuco::empty_value<T>{-1}};
+    auto const capacity = map.capacity();
+    REQUIRE(capacity == gold_capacity);
+
+    auto ref               = map.ref(cuco::experimental::insert);
+    auto const num_windows = ref.window_extent();
+    STATIC_REQUIRE(static_cast<std::size_t>(num_windows) == gold_capacity);
+  }
+
   SECTION("Dynamic extent is evaluated at run time.")
   {
     auto constexpr gold_capacity = 422;  // 211 x 2

--- a/tests/static_map/erase_test.cu
+++ b/tests/static_map/erase_test.cu
@@ -106,7 +106,7 @@ TEMPLATE_TEST_CASE_SIG(
   (int64_t, int32_t, cuco::test::probe_sequence::linear_probing, 2),
   (int64_t, int64_t, cuco::test::probe_sequence::linear_probing, 2))
 {
-  constexpr size_type num_keys{400};
+  constexpr size_type num_keys{1'000'000};
 
   using probe =
     std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,

--- a/tests/static_set/capacity_test.cu
+++ b/tests/static_set/capacity_test.cu
@@ -60,6 +60,20 @@ TEST_CASE("Static set capacity", "")
 
   constexpr std::size_t num_keys{400};
 
+  SECTION("Static window extent can be evaluated at build time.")
+  {
+    std::size_t constexpr gold_extent = 211;
+
+    using extent_type = cuco::experimental::extent<std::size_t, num_keys>;
+    cuco::experimental::
+      static_set<Key, extent_type, cuda::thread_scope_device, Equal, ProbeT, AllocatorT, StorageT>
+        set{extent_type{}, cuco::empty_key<Key>{-1}};
+
+    auto ref               = set.ref(cuco::experimental::insert);
+    auto const num_windows = ref.window_extent();
+    STATIC_REQUIRE(static_cast<std::size_t>(num_windows) == gold_extent);
+  }
+
   SECTION("Dynamic extent is evaluated at run time.")
   {
     auto constexpr gold_capacity = 422;  // 211 x 2


### PR DESCRIPTION
This is the first step to migrate shared memory code from the legacy map to the new map. It exposes the `window_extent` ref API thus it can be used to construct container device ref on shared memory.