### PR TITLE
Move old single map to `cuco::legacy` namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Similar to how [Thrust](https://github.com/thrust/thrust) and [CUB](https://gith
 
 `cuCollections` is still under heavy development. Users should expect breaking changes and refactoring to be common.
 
+### Major Updates
+__01/02/2024__ The legacy `static_map` is moved to `cuco::legacy` namespace.
+
 ## Getting cuCollections
 
 `cuCollections` is header only and can be incorporated manually into your project by downloading the headers and placing them into your source tree.

--- a/include/cuco/detail/dynamic_map.inl
+++ b/include/cuco/detail/dynamic_map.inl
@@ -31,7 +31,7 @@ dynamic_map<Key, Value, Scope, Allocator>::dynamic_map(std::size_t initial_capac
     max_load_factor_(0.60),
     alloc_{alloc}
 {
-  submaps_.push_back(std::make_unique<static_map<Key, Value, Scope, Allocator>>(
+  submaps_.push_back(std::make_unique<cuco::legacy::static_map<Key, Value, Scope, Allocator>>(
     initial_capacity,
     empty_key<Key>{empty_key_sentinel},
     empty_value<Value>{empty_value_sentinel},
@@ -62,7 +62,7 @@ dynamic_map<Key, Value, Scope, Allocator>::dynamic_map(std::size_t initial_capac
                "The empty key sentinel and erased key sentinel cannot be the same value.",
                std::runtime_error);
 
-  submaps_.push_back(std::make_unique<static_map<Key, Value, Scope, Allocator>>(
+  submaps_.push_back(std::make_unique<cuco::legacy::static_map<Key, Value, Scope, Allocator>>(
     initial_capacity,
     empty_key<Key>{empty_key_sentinel_},
     empty_value<Value>{empty_value_sentinel_},
@@ -90,7 +90,7 @@ void dynamic_map<Key, Value, Scope, Allocator>::reserve(std::size_t n, cudaStrea
     else {
       submap_capacity = capacity_;
       if (erased_key_sentinel_ != empty_key_sentinel_) {
-        submaps_.push_back(std::make_unique<static_map<Key, Value, Scope, Allocator>>(
+        submaps_.push_back(std::make_unique<cuco::legacy::static_map<Key, Value, Scope, Allocator>>(
           submap_capacity,
           empty_key<Key>{empty_key_sentinel_},
           empty_value<Value>{empty_value_sentinel_},
@@ -98,7 +98,7 @@ void dynamic_map<Key, Value, Scope, Allocator>::reserve(std::size_t n, cudaStrea
           alloc_,
           stream));
       } else {
-        submaps_.push_back(std::make_unique<static_map<Key, Value, Scope, Allocator>>(
+        submaps_.push_back(std::make_unique<cuco::legacy::static_map<Key, Value, Scope, Allocator>>(
           submap_capacity,
           empty_key<Key>{empty_key_sentinel_},
           empty_value<Value>{empty_value_sentinel_},

--- a/include/cuco/detail/static_map_kernels.cuh
+++ b/include/cuco/detail/static_map_kernels.cuh
@@ -21,8 +21,7 @@
 
 #include <cooperative_groups.h>
 
-namespace cuco {
-namespace detail {
+namespace cuco::legacy::detail {
 namespace cg = cooperative_groups;
 
 /**
@@ -578,5 +577,4 @@ __global__ void contains(
   }
 }
 
-}  // namespace detail
-}  // namespace cuco
+}  // namespace cuco::legacy::detail

--- a/include/cuco/dynamic_map.cuh
+++ b/include/cuco/dynamic_map.cuh
@@ -106,10 +106,12 @@ class dynamic_map {
   using mapped_type     = Value;                             ///< Type of mapped values
   using atomic_ctr_type = cuda::atomic<std::size_t, Scope>;  ///< Atomic counter type
   using view_type =
-    typename static_map<Key, Value, Scope>::device_view;  ///< Type for submap device view
+    typename cuco::legacy::static_map<Key, Value, Scope>::device_view;  ///< Type for submap device
+                                                                        ///< view
   using mutable_view_type =
-    typename static_map<Key, Value, Scope>::device_mutable_view;  ///< Type for submap mutable
-                                                                  ///< device view
+    typename cuco::legacy::static_map<Key, Value, Scope>::device_mutable_view;  ///< Type for submap
+                                                                                ///< mutable device
+                                                                                ///< view
 
   dynamic_map(dynamic_map const&) = delete;
   dynamic_map(dynamic_map&&)      = delete;
@@ -347,7 +349,7 @@ class dynamic_map {
   std::size_t capacity_{};   ///< Maximum number of keys that can be inserted
   float max_load_factor_{};  ///< Max load factor before capacity growth
 
-  std::vector<std::unique_ptr<static_map<key_type, mapped_type, Scope>>>
+  std::vector<std::unique_ptr<cuco::legacy::static_map<key_type, mapped_type, Scope>>>
     submaps_;                                      ///< vector of pointers to each submap
   thrust::device_vector<view_type> submap_views_;  ///< vector of device views for each submap
   thrust::device_vector<mutable_view_type>

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -747,6 +747,8 @@ class static_map {
 template <typename Key, typename Value, cuda::thread_scope Scope, typename Allocator>
 class dynamic_map;
 
+namespace legacy {
+
 /**
  * @brief A GPU-accelerated, unordered, associative container of key-value
  * pairs with unique keys.
@@ -2127,6 +2129,7 @@ class static_map {
   slot_allocator_type slot_allocator_{};        ///< Allocator used to allocate slots
   counter_allocator_type counter_allocator_{};  ///< Allocator used to allocate `num_successes_`
 };
+}  // namespace legacy
 }  // namespace cuco
 
 #include <cuco/detail/static_map.inl>

--- a/tests/static_map/custom_type_test.cu
+++ b/tests/static_map/custom_type_test.cu
@@ -115,7 +115,7 @@ TEMPLATE_TEST_CASE_SIG("User defined key and value type",
 
   constexpr std::size_t num      = 100;
   constexpr std::size_t capacity = num * 2;
-  cuco::static_map<Key, Value> map{
+  cuco::legacy::static_map<Key, Value> map{
     capacity, cuco::empty_key<Key>{sentinel_key}, cuco::empty_value<Value>{sentinel_value}};
 
   thrust::device_vector<Key> insert_keys(num);


### PR DESCRIPTION
This PR moves the old `static_map` to `cuco::legacy` namespace