### PR TITLE
Move probe sequences to legacy namespace

### DIFF
--- a/include/cuco/detail/probe_sequence_impl.cuh
+++ b/include/cuco/detail/probe_sequence_impl.cuh
@@ -25,8 +25,7 @@
 
 #include <utility>
 
-namespace cuco {
-namespace detail {
+namespace cuco::legacy::detail {
 
 /**
  * @brief Base class of public probe sequence. This class should not be used directly.
@@ -461,5 +460,4 @@ class probe_sequence : public ProbeImpl::template impl<Key, Value, Scope> {
   }
 };  // class probe_sequence
 
-}  // namespace detail
-}  // namespace cuco
+}  // namespace cuco::legacy::detail

--- a/include/cuco/probe_sequences.cuh
+++ b/include/cuco/probe_sequences.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 
 #include <cuco/detail/probe_sequence_impl.cuh>
 
-namespace cuco {
+namespace cuco::legacy {
 
 /**
  * @brief Public linear probing scheme class.
@@ -73,4 +73,4 @@ class double_hashing : public detail::probe_sequence_base<CGSize> {
   using impl = detail::double_hashing_impl<Key, Value, Scope, vector_width(), CGSize, Hash1, Hash2>;
 };
 
-}  // namespace cuco
+}  // namespace cuco::legacy

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -122,15 +122,15 @@ namespace cuco {
  * @tparam Value Type of the mapped values. Requires `cuco::is_bitwise_comparable_v<Value>`
  * @tparam Scope The scope in which multimap operations will be performed by
  * individual threads
- * @tparam ProbeSequence Probe sequence chosen between `cuco::detail::linear_probing`
- * and `cuco::detail::double_hashing`. (see `detail/probe_sequences.cuh`)
+ * @tparam ProbeSequence Probe sequence chosen between `cuco::legacy::linear_probing`
+ * and `cuco::legacy::double_hashing`. (see `probe_sequences.cuh`)
  * @tparam Allocator Type of allocator used for device storage
  */
 template <typename Key,
           typename Value,
           cuda::thread_scope Scope = cuda::thread_scope_device,
           typename Allocator       = cuco::cuda_allocator<char>,
-          class ProbeSequence      = cuco::double_hashing<8, cuco::default_hash_function<Key>>>
+          class ProbeSequence = cuco::legacy::double_hashing<8, cuco::default_hash_function<Key>>>
 class static_multimap {
   static_assert(
     cuco::is_bitwise_comparable_v<Key>,
@@ -142,10 +142,10 @@ class static_multimap {
     "Value type must have unique object representations or have been explicitly declared as safe "
     "for bitwise comparison via specialization of cuco::is_bitwise_comparable_v<Value>.");
 
-  static_assert(
-    std::is_base_of_v<cuco::detail::probe_sequence_base<ProbeSequence::cg_size>, ProbeSequence>,
-    "ProbeSequence must be a specialization of either cuco::double_hashing or "
-    "cuco::linear_probing.");
+  static_assert(std::is_base_of_v<cuco::legacy::detail::probe_sequence_base<ProbeSequence::cg_size>,
+                                  ProbeSequence>,
+                "ProbeSequence must be a specialization of either cuco::legacy::double_hashing or "
+                "cuco::legacy::linear_probing.");
 
  public:
   using value_type         = cuco::pair<Key, Value>;            ///< Type of key/value pairs
@@ -163,7 +163,7 @@ class static_multimap {
   using counter_allocator_type = typename std::allocator_traits<Allocator>::rebind_alloc<
     atomic_ctr_type>;  ///< Type of the allocator to (de)allocate atomic counters
   using probe_sequence_type =
-    detail::probe_sequence<ProbeSequence, Key, Value, Scope>;  ///< Probe scheme type
+    cuco::legacy::detail::probe_sequence<ProbeSequence, Key, Value, Scope>;  ///< Probe scheme type
 
   static_multimap(static_multimap const&) = delete;
   static_multimap& operator=(static_multimap const&) = delete;

--- a/tests/static_multimap/custom_pair_retrieve_test.cu
+++ b/tests/static_multimap/custom_pair_retrieve_test.cu
@@ -203,9 +203,10 @@ TEMPLATE_TEST_CASE_SIG(
 {
   constexpr std::size_t num_pairs{200};
 
-  using probe = std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
-                                   cuco::linear_probing<1, cuco::default_hash_function<Key>>,
-                                   cuco::double_hashing<8, cuco::default_hash_function<Key>>>;
+  using probe =
+    std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
+                       cuco::legacy::linear_probing<1, cuco::default_hash_function<Key>>,
+                       cuco::legacy::double_hashing<8, cuco::default_hash_function<Key>>>;
 
   cuco::static_multimap<Key, Value, cuda::thread_scope_device, cuco::cuda_allocator<char>, probe>
     map{num_pairs * 2, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};

--- a/tests/static_multimap/custom_type_test.cu
+++ b/tests/static_multimap/custom_type_test.cu
@@ -234,8 +234,8 @@ TEMPLATE_TEST_CASE_SIG("User defined key and value type",
   constexpr std::size_t capacity  = num_pairs * 2;
 
   using probe = std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
-                                   cuco::linear_probing<1, hash_key_pair>,
-                                   cuco::double_hashing<8, hash_key_pair, hash_key_pair>>;
+                                   cuco::legacy::linear_probing<1, hash_key_pair>,
+                                   cuco::legacy::double_hashing<8, hash_key_pair, hash_key_pair>>;
 
   cuco::static_multimap<Key, Value, cuda::thread_scope_device, cuco::cuda_allocator<char>, probe>
     map{capacity, cuco::empty_key{sentinel_key}, cuco::empty_value{sentinel_value}};

--- a/tests/static_multimap/heterogeneous_lookup_test.cu
+++ b/tests/static_multimap/heterogeneous_lookup_test.cu
@@ -102,7 +102,7 @@ TEMPLATE_TEST_CASE("Heterogeneous lookup",
                         Value,
                         cuda::thread_scope_device,
                         cuco::cuda_allocator<char>,
-                        cuco::linear_probing<1, custom_hasher>>
+                        cuco::legacy::linear_probing<1, custom_hasher>>
     map{capacity, cuco::empty_key<Key>{sentinel_key}, cuco::empty_value<Value>{sentinel_value}};
 
   auto insert_pairs = thrust::make_transform_iterator(

--- a/tests/static_multimap/insert_if_test.cu
+++ b/tests/static_multimap/insert_if_test.cu
@@ -67,9 +67,10 @@ TEMPLATE_TEST_CASE_SIG(
                       return cuco::pair<Key, Value>{i, i};
                     });
 
-  using probe = std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
-                                   cuco::linear_probing<1, cuco::default_hash_function<Key>>,
-                                   cuco::double_hashing<8, cuco::default_hash_function<Key>>>;
+  using probe =
+    std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
+                       cuco::legacy::linear_probing<1, cuco::default_hash_function<Key>>,
+                       cuco::legacy::double_hashing<8, cuco::default_hash_function<Key>>>;
 
   cuco::static_multimap<Key, Value, cuda::thread_scope_device, cuco::cuda_allocator<char>, probe>
     map{num_keys * 2, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};

--- a/tests/static_multimap/multiplicity_test.cu
+++ b/tests/static_multimap/multiplicity_test.cu
@@ -161,9 +161,10 @@ TEMPLATE_TEST_CASE_SIG(
 {
   constexpr std::size_t num_items{4};
 
-  using probe = std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
-                                   cuco::linear_probing<1, cuco::default_hash_function<Key>>,
-                                   cuco::double_hashing<8, cuco::default_hash_function<Key>>>;
+  using probe =
+    std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
+                       cuco::legacy::linear_probing<1, cuco::default_hash_function<Key>>,
+                       cuco::legacy::double_hashing<8, cuco::default_hash_function<Key>>>;
 
   cuco::static_multimap<Key, Value, cuda::thread_scope_device, cuco::cuda_allocator<char>, probe>
     map{5, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};

--- a/tests/static_multimap/non_match_test.cu
+++ b/tests/static_multimap/non_match_test.cu
@@ -139,15 +139,16 @@ TEMPLATE_TEST_CASE_SIG(
                       return cuco::pair<Key, Value>{i / 2, i};
                     });
 
-  using probe = std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
-                                   cuco::linear_probing<1, cuco::default_hash_function<Key>>,
-                                   cuco::double_hashing<8, cuco::default_hash_function<Key>>>;
+  using probe =
+    std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
+                       cuco::legacy::linear_probing<1, cuco::default_hash_function<Key>>,
+                       cuco::legacy::double_hashing<8, cuco::default_hash_function<Key>>>;
 
   cuco::static_multimap<Key,
                         Value,
                         cuda::thread_scope_device,
                         cuco::cuda_allocator<char>,
-                        cuco::linear_probing<1, cuco::default_hash_function<Key>>>
+                        cuco::legacy::linear_probing<1, cuco::default_hash_function<Key>>>
     map{num_keys * 2, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};
   test_non_matches<Key, Value>(map, d_pairs.begin(), d_keys.begin(), num_keys);
 }

--- a/tests/static_multimap/pair_function_test.cu
+++ b/tests/static_multimap/pair_function_test.cu
@@ -132,9 +132,10 @@ TEMPLATE_TEST_CASE_SIG(
                       return cuco::pair<Key, Value>{i / 2, i};
                     });
 
-  using probe = std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
-                                   cuco::linear_probing<1, cuco::default_hash_function<Key>>,
-                                   cuco::double_hashing<8, cuco::default_hash_function<Key>>>;
+  using probe =
+    std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
+                       cuco::legacy::linear_probing<1, cuco::default_hash_function<Key>>,
+                       cuco::legacy::double_hashing<8, cuco::default_hash_function<Key>>>;
 
   cuco::static_multimap<Key, Value, cuda::thread_scope_device, cuco::cuda_allocator<char>, probe>
     map{num_pairs * 2, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};


### PR DESCRIPTION
Similar to #414, this is a preparation for inlining `experimental` namespace. It moves the old probe sequences which are only used by the current multimap old into `cuco::legacy` namespace. 