### PR TITLE
Mark all cuco kernels as static so they have hidden visibility

### DIFF
--- a/examples/static_set/device_subsets_example.cu
+++ b/examples/static_set/device_subsets_example.cu
@@ -102,7 +102,7 @@ __global__ void insert(ref_type* set_refs)
  *
  * @param set_refs Pointer to the array of subset objects
  */
-static __global__ void find(ref_type* set_refs)
+__global__ void find(ref_type* set_refs)
 {
   namespace cg = cooperative_groups;
 

--- a/examples/static_set/device_subsets_example.cu
+++ b/examples/static_set/device_subsets_example.cu
@@ -77,7 +77,7 @@ key_type constexpr empty_key_sentinel = -1;
  *
  * @param set_refs Pointer to the array of subset objects
  */
-static __global__ void insert(ref_type* set_refs)
+__global__ void insert(ref_type* set_refs)
 {
   namespace cg = cooperative_groups;
 

--- a/examples/static_set/device_subsets_example.cu
+++ b/examples/static_set/device_subsets_example.cu
@@ -77,7 +77,7 @@ key_type constexpr empty_key_sentinel = -1;
  *
  * @param set_refs Pointer to the array of subset objects
  */
-__global__ void insert(ref_type* set_refs)
+static __global__ void insert(ref_type* set_refs)
 {
   namespace cg = cooperative_groups;
 
@@ -102,7 +102,7 @@ __global__ void insert(ref_type* set_refs)
  *
  * @param set_refs Pointer to the array of subset objects
  */
-__global__ void find(ref_type* set_refs)
+static __global__ void find(ref_type* set_refs)
 {
   namespace cg = cooperative_groups;
 

--- a/include/cuco/detail/dynamic_map_kernels.cuh
+++ b/include/cuco/detail/dynamic_map_kernels.cuh
@@ -66,14 +66,14 @@ template <uint32_t block_size,
           typename Hash,
           typename KeyEqual>
 CUCO_KERNEL void insert(InputIt first,
-                       InputIt last,
-                       viewT* submap_views,
-                       mutableViewT* submap_mutable_views,
-                       atomicT* num_successes,
-                       uint32_t insert_idx,
-                       uint32_t num_submaps,
-                       Hash hash,
-                       KeyEqual key_equal)
+                        InputIt last,
+                        viewT* submap_views,
+                        mutableViewT* submap_mutable_views,
+                        atomicT* num_successes,
+                        uint32_t insert_idx,
+                        uint32_t num_submaps,
+                        Hash hash,
+                        KeyEqual key_equal)
 {
   using BlockReduce = cub::BlockReduce<std::size_t, block_size>;
   __shared__ typename BlockReduce::TempStorage temp_storage;
@@ -151,14 +151,14 @@ template <uint32_t block_size,
           typename Hash,
           typename KeyEqual>
 CUCO_KERNEL void insert(InputIt first,
-                       InputIt last,
-                       viewT* submap_views,
-                       mutableViewT* submap_mutable_views,
-                       atomicT** submap_num_successes,
-                       uint32_t insert_idx,
-                       uint32_t num_submaps,
-                       Hash hash,
-                       KeyEqual key_equal)
+                        InputIt last,
+                        viewT* submap_views,
+                        mutableViewT* submap_mutable_views,
+                        atomicT** submap_num_successes,
+                        uint32_t insert_idx,
+                        uint32_t num_submaps,
+                        Hash hash,
+                        KeyEqual key_equal)
 {
   using BlockReduce = cub::BlockReduce<std::size_t, block_size>;
   __shared__ typename BlockReduce::TempStorage temp_storage;
@@ -229,12 +229,12 @@ template <uint32_t block_size,
           typename Hash,
           typename KeyEqual>
 CUCO_KERNEL void erase(InputIt first,
-                      InputIt last,
-                      mutableViewT* submap_mutable_views,
-                      atomicT** submap_num_successes,
-                      uint32_t num_submaps,
-                      Hash hash,
-                      KeyEqual key_equal)
+                       InputIt last,
+                       mutableViewT* submap_mutable_views,
+                       atomicT** submap_num_successes,
+                       uint32_t num_submaps,
+                       Hash hash,
+                       KeyEqual key_equal)
 {
   extern __shared__ unsigned long long submap_block_num_successes[];
 
@@ -300,12 +300,12 @@ template <uint32_t block_size,
           typename Hash,
           typename KeyEqual>
 CUCO_KERNEL void erase(InputIt first,
-                      InputIt last,
-                      mutableViewT* submap_mutable_views,
-                      atomicT** submap_num_successes,
-                      uint32_t num_submaps,
-                      Hash hash,
-                      KeyEqual key_equal)
+                       InputIt last,
+                       mutableViewT* submap_mutable_views,
+                       atomicT** submap_num_successes,
+                       uint32_t num_submaps,
+                       Hash hash,
+                       KeyEqual key_equal)
 {
   extern __shared__ unsigned long long submap_block_num_successes[];
 
@@ -372,12 +372,12 @@ template <uint32_t block_size,
           typename Hash,
           typename KeyEqual>
 CUCO_KERNEL void find(InputIt first,
-                     InputIt last,
-                     OutputIt output_begin,
-                     viewT* submap_views,
-                     uint32_t num_submaps,
-                     Hash hash,
-                     KeyEqual key_equal)
+                      InputIt last,
+                      OutputIt output_begin,
+                      viewT* submap_views,
+                      uint32_t num_submaps,
+                      Hash hash,
+                      KeyEqual key_equal)
 {
   auto tid                  = blockDim.x * blockIdx.x + threadIdx.x;
   auto empty_value_sentinel = submap_views[0].get_empty_value_sentinel();
@@ -447,12 +447,12 @@ template <uint32_t block_size,
           typename Hash,
           typename KeyEqual>
 CUCO_KERNEL void find(InputIt first,
-                     InputIt last,
-                     OutputIt output_begin,
-                     viewT* submap_views,
-                     uint32_t num_submaps,
-                     Hash hash,
-                     KeyEqual key_equal)
+                      InputIt last,
+                      OutputIt output_begin,
+                      viewT* submap_views,
+                      uint32_t num_submaps,
+                      Hash hash,
+                      KeyEqual key_equal)
 {
   auto tile                 = cg::tiled_partition<tile_size>(cg::this_thread_block());
   auto tid                  = blockDim.x * blockIdx.x + threadIdx.x;
@@ -518,12 +518,12 @@ template <uint32_t block_size,
           typename Hash,
           typename KeyEqual>
 CUCO_KERNEL void contains(InputIt first,
-                         InputIt last,
-                         OutputIt output_begin,
-                         viewT* submap_views,
-                         uint32_t num_submaps,
-                         Hash hash,
-                         KeyEqual key_equal)
+                          InputIt last,
+                          OutputIt output_begin,
+                          viewT* submap_views,
+                          uint32_t num_submaps,
+                          Hash hash,
+                          KeyEqual key_equal)
 {
   auto tid = blockDim.x * blockIdx.x + threadIdx.x;
   __shared__ bool writeBuffer[block_size];
@@ -586,12 +586,12 @@ template <uint32_t block_size,
           typename Hash,
           typename KeyEqual>
 CUCO_KERNEL void contains(InputIt first,
-                         InputIt last,
-                         OutputIt output_begin,
-                         viewT* submap_views,
-                         uint32_t num_submaps,
-                         Hash hash,
-                         KeyEqual key_equal)
+                          InputIt last,
+                          OutputIt output_begin,
+                          viewT* submap_views,
+                          uint32_t num_submaps,
+                          Hash hash,
+                          KeyEqual key_equal)
 {
   auto tile    = cg::tiled_partition<tile_size>(cg::this_thread_block());
   auto tid     = blockDim.x * blockIdx.x + threadIdx.x;

--- a/include/cuco/detail/dynamic_map_kernels.cuh
+++ b/include/cuco/detail/dynamic_map_kernels.cuh
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #pragma once
+#include <cuco/detail/utility/cuda.cuh>
 
 #include <cub/block/block_reduce.cuh>
 
@@ -24,6 +25,8 @@
 namespace cuco {
 namespace detail {
 namespace cg = cooperative_groups;
+
+CUCO_SUPPRESS_KERNEL_WARNINGS
 
 /**
  * @brief Inserts all key/value pairs in the range `[first, last)`.
@@ -62,7 +65,7 @@ template <uint32_t block_size,
           typename atomicT,
           typename Hash,
           typename KeyEqual>
-__global__ void insert(InputIt first,
+CUCO_KERNEL void insert(InputIt first,
                        InputIt last,
                        viewT* submap_views,
                        mutableViewT* submap_mutable_views,
@@ -147,7 +150,7 @@ template <uint32_t block_size,
           typename atomicT,
           typename Hash,
           typename KeyEqual>
-__global__ void insert(InputIt first,
+CUCO_KERNEL void insert(InputIt first,
                        InputIt last,
                        viewT* submap_views,
                        mutableViewT* submap_mutable_views,
@@ -225,7 +228,7 @@ template <uint32_t block_size,
           typename atomicT,
           typename Hash,
           typename KeyEqual>
-__global__ void erase(InputIt first,
+CUCO_KERNEL void erase(InputIt first,
                       InputIt last,
                       mutableViewT* submap_mutable_views,
                       atomicT** submap_num_successes,
@@ -296,7 +299,7 @@ template <uint32_t block_size,
           typename atomicT,
           typename Hash,
           typename KeyEqual>
-__global__ void erase(InputIt first,
+CUCO_KERNEL void erase(InputIt first,
                       InputIt last,
                       mutableViewT* submap_mutable_views,
                       atomicT** submap_num_successes,
@@ -368,7 +371,7 @@ template <uint32_t block_size,
           typename viewT,
           typename Hash,
           typename KeyEqual>
-__global__ void find(InputIt first,
+CUCO_KERNEL void find(InputIt first,
                      InputIt last,
                      OutputIt output_begin,
                      viewT* submap_views,
@@ -443,7 +446,7 @@ template <uint32_t block_size,
           typename viewT,
           typename Hash,
           typename KeyEqual>
-__global__ void find(InputIt first,
+CUCO_KERNEL void find(InputIt first,
                      InputIt last,
                      OutputIt output_begin,
                      viewT* submap_views,
@@ -514,7 +517,7 @@ template <uint32_t block_size,
           typename viewT,
           typename Hash,
           typename KeyEqual>
-__global__ void contains(InputIt first,
+CUCO_KERNEL void contains(InputIt first,
                          InputIt last,
                          OutputIt output_begin,
                          viewT* submap_views,
@@ -582,7 +585,7 @@ template <uint32_t block_size,
           typename viewT,
           typename Hash,
           typename KeyEqual>
-__global__ void contains(InputIt first,
+CUCO_KERNEL void contains(InputIt first,
                          InputIt last,
                          OutputIt output_begin,
                          viewT* submap_views,

--- a/include/cuco/detail/open_addressing/kernels.cuh
+++ b/include/cuco/detail/open_addressing/kernels.cuh
@@ -63,11 +63,11 @@ template <int32_t CGSize,
           typename AtomicT,
           typename Ref>
 CUCO_KERNEL void insert_if_n(InputIt first,
-                            cuco::detail::index_type n,
-                            StencilIt stencil,
-                            Predicate pred,
-                            AtomicT* num_successes,
-                            Ref ref)
+                             cuco::detail::index_type n,
+                             StencilIt stencil,
+                             Predicate pred,
+                             AtomicT* num_successes,
+                             Ref ref)
 {
   using BlockReduce = cub::BlockReduce<typename Ref::size_type, BlockSize>;
   __shared__ typename BlockReduce::TempStorage temp_storage;
@@ -214,11 +214,11 @@ template <int32_t CGSize,
           typename OutputIt,
           typename Ref>
 CUCO_KERNEL void contains_if_n(InputIt first,
-                              cuco::detail::index_type n,
-                              StencilIt stencil,
-                              Predicate pred,
-                              OutputIt output_begin,
-                              Ref ref)
+                               cuco::detail::index_type n,
+                               StencilIt stencil,
+                               Predicate pred,
+                               OutputIt output_begin,
+                               Ref ref)
 {
   namespace cg = cooperative_groups;
 
@@ -295,8 +295,8 @@ CUCO_KERNEL void size(StorageRef storage, Predicate is_filled, AtomicT* count)
 
 template <int32_t BlockSize, typename ContainerRef, typename Predicate>
 CUCO_KERNEL void rehash(typename ContainerRef::storage_ref_type storage_ref,
-                       ContainerRef container_ref,
-                       Predicate is_filled)
+                        ContainerRef container_ref,
+                        Predicate is_filled)
 {
   namespace cg = cooperative_groups;
 

--- a/include/cuco/detail/open_addressing/kernels.cuh
+++ b/include/cuco/detail/open_addressing/kernels.cuh
@@ -27,6 +27,7 @@
 
 namespace cuco {
 namespace detail {
+CUCO_SUPPRESS_KERNEL_WARNINGS
 
 /**
  * @brief Inserts all elements in the range `[first, first + n)` and returns the number of
@@ -61,7 +62,7 @@ template <int32_t CGSize,
           typename Predicate,
           typename AtomicT,
           typename Ref>
-__global__ void insert_if_n(InputIt first,
+CUCO_KERNEL void insert_if_n(InputIt first,
                             cuco::detail::index_type n,
                             StencilIt stencil,
                             Predicate pred,
@@ -127,7 +128,7 @@ template <int32_t CGSize,
           typename StencilIt,
           typename Predicate,
           typename Ref>
-__global__ void insert_if_n(
+CUCO_KERNEL void insert_if_n(
   InputIt first, cuco::detail::index_type n, StencilIt stencil, Predicate pred, Ref ref)
 {
   auto const loop_stride = cuco::detail::grid_stride() / CGSize;
@@ -162,7 +163,7 @@ __global__ void insert_if_n(
  * @param ref Non-owning container device ref used to access the slot storage
  */
 template <int32_t CGSize, int32_t BlockSize, typename InputIt, typename Ref>
-__global__ void erase(InputIt first, cuco::detail::index_type n, Ref ref)
+CUCO_KERNEL void erase(InputIt first, cuco::detail::index_type n, Ref ref)
 {
   auto const loop_stride = cuco::detail::grid_stride() / CGSize;
   auto idx               = cuco::detail::global_thread_id() / CGSize;
@@ -212,7 +213,7 @@ template <int32_t CGSize,
           typename Predicate,
           typename OutputIt,
           typename Ref>
-__global__ void contains_if_n(InputIt first,
+CUCO_KERNEL void contains_if_n(InputIt first,
                               cuco::detail::index_type n,
                               StencilIt stencil,
                               Predicate pred,
@@ -267,7 +268,7 @@ __global__ void contains_if_n(InputIt first,
  * @param count Number of filled slots
  */
 template <int32_t BlockSize, typename StorageRef, typename Predicate, typename AtomicT>
-__global__ void size(StorageRef storage, Predicate is_filled, AtomicT* count)
+CUCO_KERNEL void size(StorageRef storage, Predicate is_filled, AtomicT* count)
 {
   using size_type = typename StorageRef::size_type;
 
@@ -293,7 +294,7 @@ __global__ void size(StorageRef storage, Predicate is_filled, AtomicT* count)
 }
 
 template <int32_t BlockSize, typename ContainerRef, typename Predicate>
-__global__ void rehash(typename ContainerRef::storage_ref_type storage_ref,
+CUCO_KERNEL void rehash(typename ContainerRef::storage_ref_type storage_ref,
                        ContainerRef container_ref,
                        Predicate is_filled)
 {

--- a/include/cuco/detail/static_map/kernels.cuh
+++ b/include/cuco/detail/static_map/kernels.cuh
@@ -28,6 +28,7 @@
 namespace cuco {
 namespace static_map_ns {
 namespace detail {
+CUCO_SUPPRESS_KERNEL_WARNINGS
 
 /**
  * @brief For any key-value pair `{k, v}` in the range `[first, first + n)`, if a key equivalent to
@@ -48,7 +49,7 @@ namespace detail {
  * @param ref Non-owning container device ref used to access the slot storage
  */
 template <int32_t CGSize, int32_t BlockSize, typename InputIt, typename Ref>
-__global__ void insert_or_assign(InputIt first, cuco::detail::index_type n, Ref ref)
+CUCO_KERNEL void insert_or_assign(InputIt first, cuco::detail::index_type n, Ref ref)
 {
   auto const loop_stride = cuco::detail::grid_stride() / CGSize;
   auto idx               = cuco::detail::global_thread_id() / CGSize;
@@ -87,7 +88,7 @@ __global__ void insert_or_assign(InputIt first, cuco::detail::index_type n, Ref 
  * @param ref Non-owning map device ref used to access the slot storage
  */
 template <int32_t CGSize, int32_t BlockSize, typename InputIt, typename OutputIt, typename Ref>
-__global__ void find(InputIt first, cuco::detail::index_type n, OutputIt output_begin, Ref ref)
+CUCO_KERNEL void find(InputIt first, cuco::detail::index_type n, OutputIt output_begin, Ref ref)
 {
   namespace cg = cooperative_groups;
 

--- a/include/cuco/detail/static_map_kernels.cuh
+++ b/include/cuco/detail/static_map_kernels.cuh
@@ -313,13 +313,13 @@ template <std::size_t block_size,
           typename Hash,
           typename KeyEqual>
 CUCO_KERNEL void insert_if_n(InputIt first,
-                            int64_t n,
-                            atomicT* num_successes,
-                            viewT view,
-                            StencilIt stencil,
-                            Predicate pred,
-                            Hash hash,
-                            KeyEqual key_equal)
+                             int64_t n,
+                             atomicT* num_successes,
+                             viewT view,
+                             StencilIt stencil,
+                             Predicate pred,
+                             Hash hash,
+                             KeyEqual key_equal)
 {
   typedef cub::BlockReduce<std::size_t, block_size> BlockReduce;
   __shared__ typename BlockReduce::TempStorage temp_storage;

--- a/include/cuco/detail/static_map_kernels.cuh
+++ b/include/cuco/detail/static_map_kernels.cuh
@@ -24,6 +24,7 @@
 namespace cuco::legacy::detail {
 namespace cg = cooperative_groups;
 
+CUCO_SUPPRESS_KERNEL_WARNINGS
 /**
  * @brief Initializes each slot in the flat `slots` storage to contain `k` and `v`.
  *
@@ -47,7 +48,7 @@ template <std::size_t block_size,
           typename Key,
           typename Value,
           typename pair_atomic_type>
-__global__ void initialize(pair_atomic_type* const slots, Key k, Value v, int64_t size)
+CUCO_KERNEL void initialize(pair_atomic_type* const slots, Key k, Value v, int64_t size)
 {
   int64_t const loop_stride = gridDim.x * block_size;
   int64_t idx               = block_size * blockIdx.x + threadIdx.x;
@@ -85,7 +86,7 @@ template <std::size_t block_size,
           typename viewT,
           typename Hash,
           typename KeyEqual>
-__global__ void insert(
+CUCO_KERNEL void insert(
   InputIt first, int64_t n, atomicT* num_successes, viewT view, Hash hash, KeyEqual key_equal)
 {
   typedef cub::BlockReduce<std::size_t, block_size> BlockReduce;
@@ -140,7 +141,7 @@ template <std::size_t block_size,
           typename viewT,
           typename Hash,
           typename KeyEqual>
-__global__ void insert(
+CUCO_KERNEL void insert(
   InputIt first, int64_t n, atomicT* num_successes, viewT view, Hash hash, KeyEqual key_equal)
 {
   typedef cub::BlockReduce<std::size_t, block_size> BlockReduce;
@@ -194,7 +195,7 @@ template <std::size_t block_size,
           typename viewT,
           typename Hash,
           typename KeyEqual>
-__global__ void erase(
+CUCO_KERNEL void erase(
   InputIt first, int64_t n, atomicT* num_successes, viewT view, Hash hash, KeyEqual key_equal)
 {
   using BlockReduce = cub::BlockReduce<std::size_t, block_size>;
@@ -247,7 +248,7 @@ template <std::size_t block_size,
           typename viewT,
           typename Hash,
           typename KeyEqual>
-__global__ void erase(
+CUCO_KERNEL void erase(
   InputIt first, int64_t n, atomicT* num_successes, viewT view, Hash hash, KeyEqual key_equal)
 {
   typedef cub::BlockReduce<std::size_t, block_size> BlockReduce;
@@ -311,7 +312,7 @@ template <std::size_t block_size,
           typename Predicate,
           typename Hash,
           typename KeyEqual>
-__global__ void insert_if_n(InputIt first,
+CUCO_KERNEL void insert_if_n(InputIt first,
                             int64_t n,
                             atomicT* num_successes,
                             viewT view,
@@ -375,7 +376,7 @@ template <std::size_t block_size,
           typename viewT,
           typename Hash,
           typename KeyEqual>
-__global__ void find(
+CUCO_KERNEL void find(
   InputIt first, int64_t n, OutputIt output_begin, viewT view, Hash hash, KeyEqual key_equal)
 {
   int64_t const loop_stride = gridDim.x * block_size;
@@ -437,7 +438,7 @@ template <std::size_t block_size,
           typename viewT,
           typename Hash,
           typename KeyEqual>
-__global__ void find(
+CUCO_KERNEL void find(
   InputIt first, int64_t n, OutputIt output_begin, viewT view, Hash hash, KeyEqual key_equal)
 {
   auto tile                 = cg::tiled_partition<tile_size>(cg::this_thread_block());
@@ -494,7 +495,7 @@ template <std::size_t block_size,
           typename viewT,
           typename Hash,
           typename KeyEqual>
-__global__ void contains(
+CUCO_KERNEL void contains(
   InputIt first, int64_t n, OutputIt output_begin, viewT view, Hash hash, KeyEqual key_equal)
 {
   int64_t const loop_stride = gridDim.x * block_size;
@@ -551,7 +552,7 @@ template <std::size_t block_size,
           typename viewT,
           typename Hash,
           typename KeyEqual>
-__global__ void contains(
+CUCO_KERNEL void contains(
   InputIt first, int64_t n, OutputIt output_begin, viewT view, Hash hash, KeyEqual key_equal)
 {
   auto tile                 = cg::tiled_partition<tile_size>(cg::this_thread_block());

--- a/include/cuco/detail/static_multimap/kernels.cuh
+++ b/include/cuco/detail/static_multimap/kernels.cuh
@@ -366,11 +366,11 @@ template <uint32_t block_size,
           typename viewT,
           typename KeyEqual>
 CUCO_KERNEL void retrieve(InputIt first,
-                         int64_t n,
-                         OutputIt output_begin,
-                         atomicT* num_matches,
-                         viewT view,
-                         KeyEqual key_equal)
+                          int64_t n,
+                          OutputIt output_begin,
+                          atomicT* num_matches,
+                          viewT view,
+                          KeyEqual key_equal)
 {
   using pair_type = typename viewT::value_type;
 
@@ -479,12 +479,12 @@ template <uint32_t block_size,
           typename viewT,
           typename PairEqual>
 CUCO_KERNEL void pair_retrieve(InputIt first,
-                              int64_t n,
-                              OutputIt1 probe_output_begin,
-                              OutputIt2 contained_output_begin,
-                              atomicT* num_matches,
-                              viewT view,
-                              PairEqual pair_equal)
+                               int64_t n,
+                               OutputIt1 probe_output_begin,
+                               OutputIt2 contained_output_begin,
+                               atomicT* num_matches,
+                               viewT view,
+                               PairEqual pair_equal)
 {
   using pair_type = typename viewT::value_type;
 

--- a/include/cuco/detail/static_set/kernels.cuh
+++ b/include/cuco/detail/static_set/kernels.cuh
@@ -30,6 +30,7 @@ namespace cuco {
 namespace static_set_ns {
 namespace detail {
 
+CUCO_SUPPRESS_KERNEL_WARNINGS
 /**
  * @brief Finds the equivalent set elements of all keys in the range `[first, last)`.
  *
@@ -50,7 +51,7 @@ namespace detail {
  * @param ref Non-owning set device ref used to access the slot storage
  */
 template <int32_t CGSize, int32_t BlockSize, typename InputIt, typename OutputIt, typename Ref>
-__global__ void find(InputIt first, cuco::detail::index_type n, OutputIt output_begin, Ref ref)
+CUCO_KERNEL void find(InputIt first, cuco::detail::index_type n, OutputIt output_begin, Ref ref)
 {
   namespace cg = cooperative_groups;
 

--- a/include/cuco/detail/storage/kernels.cuh
+++ b/include/cuco/detail/storage/kernels.cuh
@@ -35,8 +35,8 @@ CUCO_SUPPRESS_KERNEL_WARNINGS
  */
 template <typename WindowT>
 CUCO_KERNEL void initialize(WindowT* windows,
-                           cuco::detail::index_type n,
-                           typename WindowT::value_type value)
+                            cuco::detail::index_type n,
+                            typename WindowT::value_type value)
 {
   auto const loop_stride = cuco::detail::grid_stride();
   auto idx               = cuco::detail::global_thread_id();

--- a/include/cuco/detail/storage/kernels.cuh
+++ b/include/cuco/detail/storage/kernels.cuh
@@ -22,6 +22,8 @@
 namespace cuco {
 namespace detail {
 
+CUCO_SUPPRESS_KERNEL_WARNINGS
+
 /**
  * @brief Initializes each slot in the window storage to contain `value`.
  *
@@ -32,7 +34,7 @@ namespace detail {
  * @param value Value to which all values in `slots` are initialized
  */
 template <typename WindowT>
-__global__ void initialize(WindowT* windows,
+CUCO_KERNEL void initialize(WindowT* windows,
                            cuco::detail::index_type n,
                            typename WindowT::value_type value)
 {

--- a/include/cuco/detail/trie/dynamic_bitset/kernels.cuh
+++ b/include/cuco/detail/trie/dynamic_bitset/kernels.cuh
@@ -72,9 +72,9 @@ CUCO_KERNEL void bitset_test_kernel(BitsetRef ref,
  */
 template <typename BitsetRef, typename KeyIt, typename OutputIt>
 CUCO_KERNEL void bitset_rank_kernel(BitsetRef ref,
-                                   KeyIt keys,
-                                   OutputIt outputs,
-                                   cuco::detail::index_type num_keys)
+                                    KeyIt keys,
+                                    OutputIt outputs,
+                                    cuco::detail::index_type num_keys)
 {
   auto key_id       = cuco::detail::global_thread_id();
   auto const stride = cuco::detail::grid_stride();
@@ -101,9 +101,9 @@ CUCO_KERNEL void bitset_rank_kernel(BitsetRef ref,
  */
 template <typename BitsetRef, typename KeyIt, typename OutputIt>
 CUCO_KERNEL void bitset_select_kernel(BitsetRef ref,
-                                     KeyIt keys,
-                                     OutputIt outputs,
-                                     cuco::detail::index_type num_keys)
+                                      KeyIt keys,
+                                      OutputIt outputs,
+                                      cuco::detail::index_type num_keys)
 {
   auto key_id       = cuco::detail::global_thread_id();
   auto const stride = cuco::detail::grid_stride();
@@ -127,9 +127,9 @@ CUCO_KERNEL void bitset_select_kernel(BitsetRef ref,
  */
 template <typename WordType, typename SizeType>
 CUCO_KERNEL void bit_counts_kernel(WordType const* words,
-                                  SizeType* bit_counts,
-                                  cuco::detail::index_type num_words,
-                                  bool flip_bits)
+                                   SizeType* bit_counts,
+                                   cuco::detail::index_type num_words,
+                                   bool flip_bits)
 {
   auto word_id      = cuco::detail::global_thread_id();
   auto const stride = cuco::detail::grid_stride();
@@ -159,10 +159,10 @@ CUCO_KERNEL void bit_counts_kernel(WordType const* words,
  */
 template <typename SizeType>
 CUCO_KERNEL void encode_ranks_from_prefix_bit_counts(const SizeType* prefix_bit_counts,
-                                                    rank* ranks,
-                                                    SizeType num_words,
-                                                    SizeType num_blocks,
-                                                    SizeType words_per_block)
+                                                     rank* ranks,
+                                                     SizeType num_words,
+                                                     SizeType num_blocks,
+                                                     SizeType words_per_block)
 {
   auto rank_id      = cuco::detail::global_thread_id();
   auto const stride = cuco::detail::grid_stride();
@@ -202,10 +202,10 @@ CUCO_KERNEL void encode_ranks_from_prefix_bit_counts(const SizeType* prefix_bit_
  */
 template <typename SizeType>
 CUCO_KERNEL void mark_blocks_with_select_entries(SizeType const* prefix_bit_counts,
-                                                SizeType* select_markers,
-                                                SizeType num_blocks,
-                                                SizeType words_per_block,
-                                                SizeType bits_per_block)
+                                                 SizeType* select_markers,
+                                                 SizeType num_blocks,
+                                                 SizeType words_per_block,
+                                                 SizeType bits_per_block)
 {
   auto block_id     = cuco::detail::global_thread_id();
   auto const stride = cuco::detail::grid_stride();

--- a/include/cuco/detail/trie/dynamic_bitset/kernels.cuh
+++ b/include/cuco/detail/trie/dynamic_bitset/kernels.cuh
@@ -26,6 +26,7 @@ namespace cuco {
 namespace experimental {
 namespace detail {
 
+CUCO_SUPPRESS_KERNEL_WARNINGS
 /*
  * @brief Test bits for a range of keys
  *
@@ -41,10 +42,10 @@ namespace detail {
  * @param num_keys Number of input keys
  */
 template <typename BitsetRef, typename KeyIt, typename OutputIt>
-__global__ void bitset_test_kernel(BitsetRef ref,
-                                   KeyIt keys,
-                                   OutputIt outputs,
-                                   cuco::detail::index_type num_keys)
+CUCO_KERNEL void bitset_test_kernel(BitsetRef ref,
+                                    KeyIt keys,
+                                    OutputIt outputs,
+                                    cuco::detail::index_type num_keys)
 {
   auto key_id       = cuco::detail::global_thread_id();
   auto const stride = cuco::detail::grid_stride();
@@ -70,7 +71,7 @@ __global__ void bitset_test_kernel(BitsetRef ref,
  * @param num_keys Number of input keys
  */
 template <typename BitsetRef, typename KeyIt, typename OutputIt>
-__global__ void bitset_rank_kernel(BitsetRef ref,
+CUCO_KERNEL void bitset_rank_kernel(BitsetRef ref,
                                    KeyIt keys,
                                    OutputIt outputs,
                                    cuco::detail::index_type num_keys)
@@ -99,7 +100,7 @@ __global__ void bitset_rank_kernel(BitsetRef ref,
  * @param num_keys Number of input keys
  */
 template <typename BitsetRef, typename KeyIt, typename OutputIt>
-__global__ void bitset_select_kernel(BitsetRef ref,
+CUCO_KERNEL void bitset_select_kernel(BitsetRef ref,
                                      KeyIt keys,
                                      OutputIt outputs,
                                      cuco::detail::index_type num_keys)
@@ -125,7 +126,7 @@ __global__ void bitset_select_kernel(BitsetRef ref,
  * @param flip_bits Boolean to request negation of words before counting bits
  */
 template <typename WordType, typename SizeType>
-__global__ void bit_counts_kernel(WordType const* words,
+CUCO_KERNEL void bit_counts_kernel(WordType const* words,
                                   SizeType* bit_counts,
                                   cuco::detail::index_type num_words,
                                   bool flip_bits)
@@ -157,7 +158,7 @@ __global__ void bit_counts_kernel(WordType const* words,
  * @param words_per_block Number of words in each block
  */
 template <typename SizeType>
-__global__ void encode_ranks_from_prefix_bit_counts(const SizeType* prefix_bit_counts,
+CUCO_KERNEL void encode_ranks_from_prefix_bit_counts(const SizeType* prefix_bit_counts,
                                                     rank* ranks,
                                                     SizeType num_words,
                                                     SizeType num_blocks,
@@ -200,7 +201,7 @@ __global__ void encode_ranks_from_prefix_bit_counts(const SizeType* prefix_bit_c
  * @param bits_per_block Number of bits in each block
  */
 template <typename SizeType>
-__global__ void mark_blocks_with_select_entries(SizeType const* prefix_bit_counts,
+CUCO_KERNEL void mark_blocks_with_select_entries(SizeType const* prefix_bit_counts,
                                                 SizeType* select_markers,
                                                 SizeType num_blocks,
                                                 SizeType words_per_block,

--- a/include/cuco/detail/utility/cuda.cuh
+++ b/include/cuco/detail/utility/cuda.cuh
@@ -17,6 +17,25 @@
 
 #include <cuco/detail/utility/cuda.hpp>
 
+#if defined(CUCO_DISABLE_KERNEL_VISIBILITY_WARNING_SUPPRESSION)
+# define CUCO_SUPPRESS_KERNEL_WARNINGS
+#elif defined(__NVCC__) && (defined(__GNUC__) || defined(__clang__))
+// handle when nvcc is the CUDA compiler and gcc or clang is host
+# define CUCO_SUPPRESS_KERNEL_WARNINGS \
+    _Pragma("nv_diag_suppress 1407")
+    _Pragma("GCC diagnostic ignored \"-Wattributes\"")
+#elif defined(__clang__)
+// handle when clang is the CUDA compiler
+# define CUCO_SUPPRESS_KERNEL_WARNINGS \
+    _Pragma("clang diagnostic ignored \"-Wattributes\"")
+#elif defined(__NVCOMPILER)
+# define CUCO_SUPPRESS_KERNEL_WARNINGS \
+#   pragma diag_suppress attribute_requires_external_linkage
+#endif
+
+#ifndef CUCO_KERNEL
+# define CUCO_KERNEL __attribute__ ((visibility ("hidden"))) __global__
+#endif
 namespace cuco {
 namespace detail {
 

--- a/include/cuco/detail/utility/cuda.cuh
+++ b/include/cuco/detail/utility/cuda.cuh
@@ -18,23 +18,20 @@
 #include <cuco/detail/utility/cuda.hpp>
 
 #if defined(CUCO_DISABLE_KERNEL_VISIBILITY_WARNING_SUPPRESSION)
-# define CUCO_SUPPRESS_KERNEL_WARNINGS
+#define CUCO_SUPPRESS_KERNEL_WARNINGS
 #elif defined(__NVCC__) && (defined(__GNUC__) || defined(__clang__))
 // handle when nvcc is the CUDA compiler and gcc or clang is host
-# define CUCO_SUPPRESS_KERNEL_WARNINGS \
-    _Pragma("nv_diag_suppress 1407")
-    _Pragma("GCC diagnostic ignored \"-Wattributes\"")
+#define CUCO_SUPPRESS_KERNEL_WARNINGS _Pragma("nv_diag_suppress 1407")
+_Pragma("GCC diagnostic ignored \"-Wattributes\"")
 #elif defined(__clang__)
 // handle when clang is the CUDA compiler
-# define CUCO_SUPPRESS_KERNEL_WARNINGS \
-    _Pragma("clang diagnostic ignored \"-Wattributes\"")
+#define CUCO_SUPPRESS_KERNEL_WARNINGS _Pragma("clang diagnostic ignored \"-Wattributes\"")
 #elif defined(__NVCOMPILER)
-# define CUCO_SUPPRESS_KERNEL_WARNINGS \
-#   pragma diag_suppress attribute_requires_external_linkage
+#define CUCO_SUPPRESS_KERNEL_WARNINGS #pragma diag_suppress attribute_requires_external_linkage
 #endif
 
 #ifndef CUCO_KERNEL
-# define CUCO_KERNEL __attribute__ ((visibility ("hidden"))) __global__
+#define CUCO_KERNEL __attribute__((visibility("hidden"))) __global__
 #endif
 namespace cuco {
 namespace detail {


### PR DESCRIPTION
This marks all kernels in CUCO as `static` so that they have internal linkage and won't conflict when used by multiple DSOs.

I didn't see a single shared/common header in cuco where I could place a `CUCO_KERNEL` macro so I modified each instance instead.
While `cccl` went with a `__attribute__ ((visibility ("hidden")))` approach to help reduce RDC size, this approach seemed very invasive for cuco. This is due to the fact that we would need to pragma push and pop both gcc warnings and nvcc warnings in each cuco header so that we don't introduce any warnings. This is needed as the compiler incorrectly state that the `__attribute__ ((visibility ("hidden")))` has no side-effect.

Context:
https://github.com/rapidsai/cudf/pull/14726
https://github.com/NVIDIA/cccl/issues/166
https://github.com/rapidsai/raft/issues/1722