### PR TITLE
Fix set ref example: global index should take CG size into consideration

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ We plan to add many GPU-accelerated, concurrent data structures to `cuCollection
 
 #### Examples:
 - [Host-bulk APIs](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_set/host_bulk_example.cu) (see [live example in godbolt](https://godbolt.org/z/fczxbM1h6))
-- [Device-ref APIs for individual operations](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_set/device_ref_example.cu) (see [live example in godbolt](https://godbolt.org/z/aKT1sbcns))
+- [Device-ref APIs for individual operations](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_set/device_ref_example.cu) (see [live example in godbolt](https://godbolt.org/z/zcnGqfdMW))
 - [One single storage for multiple sets](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_set/device_subsets_example.cu) (see [live example in godbolt](https://godbolt.org/z/rYbfxhf73))
 
 ### `static_map`

--- a/examples/static_set/device_ref_example.cu
+++ b/examples/static_set/device_ref_example.cu
@@ -67,7 +67,7 @@ __global__ void custom_contains(SetRef set, InputIterator keys, std::size_t n, O
 
   while (idx < n) {
     bool const is_contained = set.contains(tile, *(keys + idx));
-    if (tile.thread_rank == 0) { found[idx] = is_contained; }
+    if (tile.thread_rank() == 0) { found[idx] = is_contained; }
     idx += loop_stride;
   }
 }


### PR DESCRIPTION
This PR fixes an issue in the set ref example where the global index should be calculated based on CG size.

Closes #423 