### PR TITLE
Fix the default erase sentinel bug in the base open addressing ctor

### DIFF
--- a/include/cuco/detail/open_addressing/open_addressing_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_impl.cuh
@@ -186,7 +186,7 @@ class open_addressing_impl {
                alloc}
   {
     CUCO_EXPECTS(desired_load_factor > 0., "Desired occupancy must be larger than zero");
-    CUCO_EXPECTS(desired_load_factor < 1., "Desired occupancy must be smaller than one");
+    CUCO_EXPECTS(desired_load_factor <= 1., "Desired occupancy must be no larger than one");
 
     this->clear_async(stream);
   }

--- a/include/cuco/detail/open_addressing/open_addressing_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_impl.cuh
@@ -178,6 +178,7 @@ class open_addressing_impl {
                                  cuda_stream_ref stream)
     : empty_key_sentinel_{empty_key_sentinel},
       empty_slot_sentinel_{empty_slot_sentinel},
+      erased_key_sentinel_{empty_key_sentinel},
       predicate_{pred},
       probing_scheme_{probing_scheme},
       storage_{make_window_extent<open_addressing_impl>(

--- a/tests/static_set/insert_and_find_test.cu
+++ b/tests/static_set/insert_and_find_test.cu
@@ -100,7 +100,8 @@ TEMPLATE_TEST_CASE_SIG(
                                    cuco::linear_probing<CGSize, cuco::default_hash_function<Key>>,
                                    cuco::double_hashing<CGSize, cuco::default_hash_function<Key>>>;
 
-  auto set = cuco::static_set{num_keys, cuco::empty_key<Key>{-1}, {}, {}, {}, cuco::storage<2>{}};
+  auto set =
+    cuco::static_set{num_keys, cuco::empty_key<Key>{-1}, {}, probe{}, {}, cuco::storage<2>{}};
 
   test_insert_and_find(set, num_keys);
 }

--- a/tests/static_set/retrieve_all_test.cu
+++ b/tests/static_set/retrieve_all_test.cu
@@ -71,7 +71,7 @@ TEMPLATE_TEST_CASE_SIG(
   (int64_t, cuco::test::probe_sequence::linear_probing, 2))
 {
   constexpr std::size_t num_keys{400};
-  constexpr double desired_load_factor = 0.5;
+  constexpr double desired_load_factor = 1.;
   auto constexpr gold_capacity         = CGSize == 1 ? 409  // 409 x 1 x 1
                                                      : 422  // 211 x 2 x 1
     ;

--- a/tests/static_set/retrieve_all_test.cu
+++ b/tests/static_set/retrieve_all_test.cu
@@ -71,15 +71,16 @@ TEMPLATE_TEST_CASE_SIG(
   (int64_t, cuco::test::probe_sequence::linear_probing, 2))
 {
   constexpr std::size_t num_keys{400};
-  auto constexpr gold_capacity = CGSize == 1 ? 409  // 409 x 1 x 1
-                                             : 422  // 211 x 2 x 1
+  constexpr double desired_load_factor = 0.5;
+  auto constexpr gold_capacity         = CGSize == 1 ? 409  // 409 x 1 x 1
+                                                     : 422  // 211 x 2 x 1
     ;
 
   using probe = std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
                                    cuco::linear_probing<CGSize, cuco::default_hash_function<Key>>,
                                    cuco::double_hashing<CGSize, cuco::default_hash_function<Key>>>;
 
-  auto set = cuco::static_set{num_keys, cuco::empty_key<Key>{-1}, {}, probe{}};
+  auto set = cuco::static_set{num_keys, desired_load_factor, cuco::empty_key<Key>{-1}, {}, probe{}};
 
   REQUIRE(set.capacity() == gold_capacity);
 


### PR DESCRIPTION
This PR fixes a bug in the OA base class where the erased key sentinel value should have been initialized by the empty key sentinel if not specified.

Tests are updated to exercise this issue.

Needed by https://github.com/rapidsai/cudf/pull/14813