### PR TITLE
Bump clang format version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,11 +10,10 @@ ci:
 
 repos:
       - repo: https://github.com/pre-commit/mirrors-clang-format
-        rev: v13.0.0
+        rev: v16.0.6
         hooks:
               - id: clang-format
-                files: \.(cu|cuh|h|hpp|cpp|inl)$
-                'types_or': [file]
+                types_or: [c, c++, cuda]
                 args: ['-fallback-style=none', '-style=file', '-i']
       - repo: local
         hooks:

--- a/include/cuco/aow_storage.cuh
+++ b/include/cuco/aow_storage.cuh
@@ -92,7 +92,7 @@ class aow_storage : public detail::aow_storage_base<T, WindowSize, Extent> {
   aow_storage& operator=(aow_storage&&) = default;
   ~aow_storage()                        = default;  ///< Destructor
 
-  aow_storage(aow_storage const&) = delete;
+  aow_storage(aow_storage const&)            = delete;
   aow_storage& operator=(aow_storage const&) = delete;
 
   /**

--- a/include/cuco/detail/extent/extent.inl
+++ b/include/cuco/detail/extent/extent.inl
@@ -117,12 +117,10 @@ template <int32_t CGSize, int32_t WindowSize, typename SizeType>
 namespace detail {
 
 template <typename...>
-struct is_window_extent : std::false_type {
-};
+struct is_window_extent : std::false_type {};
 
 template <typename SizeType, std::size_t N>
-struct is_window_extent<window_extent<SizeType, N>> : std::true_type {
-};
+struct is_window_extent<window_extent<SizeType, N>> : std::true_type {};
 
 template <typename T>
 inline constexpr bool is_window_extent_v = is_window_extent<T>::value;

--- a/include/cuco/detail/pair/tuple_helpers.inl
+++ b/include/cuco/detail/pair/tuple_helpers.inl
@@ -15,20 +15,16 @@
  */
 
 template <typename T1, typename T2>
-struct tuple_size<cuco::pair<T1, T2>> : integral_constant<size_t, 2> {
-};
+struct tuple_size<cuco::pair<T1, T2>> : integral_constant<size_t, 2> {};
 
 template <typename T1, typename T2>
-struct tuple_size<const cuco::pair<T1, T2>> : tuple_size<cuco::pair<T1, T2>> {
-};
+struct tuple_size<const cuco::pair<T1, T2>> : tuple_size<cuco::pair<T1, T2>> {};
 
 template <typename T1, typename T2>
-struct tuple_size<volatile cuco::pair<T1, T2>> : tuple_size<cuco::pair<T1, T2>> {
-};
+struct tuple_size<volatile cuco::pair<T1, T2>> : tuple_size<cuco::pair<T1, T2>> {};
 
 template <typename T1, typename T2>
-struct tuple_size<const volatile cuco::pair<T1, T2>> : tuple_size<cuco::pair<T1, T2>> {
-};
+struct tuple_size<const volatile cuco::pair<T1, T2>> : tuple_size<cuco::pair<T1, T2>> {};
 
 template <std::size_t I, typename T1, typename T2>
 struct tuple_element<I, cuco::pair<T1, T2>> {
@@ -46,20 +42,16 @@ struct tuple_element<1, cuco::pair<T1, T2>> {
 };
 
 template <typename T1, typename T2>
-struct tuple_element<0, const cuco::pair<T1, T2>> : tuple_element<0, cuco::pair<T1, T2>> {
-};
+struct tuple_element<0, const cuco::pair<T1, T2>> : tuple_element<0, cuco::pair<T1, T2>> {};
 
 template <typename T1, typename T2>
-struct tuple_element<1, const cuco::pair<T1, T2>> : tuple_element<1, cuco::pair<T1, T2>> {
-};
+struct tuple_element<1, const cuco::pair<T1, T2>> : tuple_element<1, cuco::pair<T1, T2>> {};
 
 template <typename T1, typename T2>
-struct tuple_element<0, volatile cuco::pair<T1, T2>> : tuple_element<0, cuco::pair<T1, T2>> {
-};
+struct tuple_element<0, volatile cuco::pair<T1, T2>> : tuple_element<0, cuco::pair<T1, T2>> {};
 
 template <typename T1, typename T2>
-struct tuple_element<1, volatile cuco::pair<T1, T2>> : tuple_element<1, cuco::pair<T1, T2>> {
-};
+struct tuple_element<1, volatile cuco::pair<T1, T2>> : tuple_element<1, cuco::pair<T1, T2>> {};
 
 template <typename T1, typename T2>
 struct tuple_element<0, const volatile cuco::pair<T1, T2>> : tuple_element<0, cuco::pair<T1, T2>> {

--- a/include/cuco/detail/traits.hpp
+++ b/include/cuco/detail/traits.hpp
@@ -25,20 +25,17 @@
 namespace cuco::detail {
 
 template <typename T, typename = void>
-struct is_std_pair_like : cuda::std::false_type {
-};
+struct is_std_pair_like : cuda::std::false_type {};
 
 template <typename T>
 struct is_std_pair_like<T,
                         cuda::std::void_t<decltype(std::get<0>(cuda::std::declval<T>())),
                                           decltype(std::get<1>(cuda::std::declval<T>()))>>
   : cuda::std::
-      conditional_t<std::tuple_size<T>::value == 2, cuda::std::true_type, cuda::std::false_type> {
-};
+      conditional_t<std::tuple_size<T>::value == 2, cuda::std::true_type, cuda::std::false_type> {};
 
 template <typename T, typename = void>
-struct is_cuda_std_pair_like : cuda::std::false_type {
-};
+struct is_cuda_std_pair_like : cuda::std::false_type {};
 
 template <typename T>
 struct is_cuda_std_pair_like<
@@ -47,12 +44,10 @@ struct is_cuda_std_pair_like<
                     decltype(cuda::std::get<1>(cuda::std::declval<T>()))>>
   : cuda::std::conditional_t<cuda::std::tuple_size<T>::value == 2,
                              cuda::std::true_type,
-                             cuda::std::false_type> {
-};
+                             cuda::std::false_type> {};
 
 template <typename T, typename = void>
-struct is_thrust_pair_like_impl : cuda::std::false_type {
-};
+struct is_thrust_pair_like_impl : cuda::std::false_type {};
 
 template <typename T>
 struct is_thrust_pair_like_impl<
@@ -61,13 +56,11 @@ struct is_thrust_pair_like_impl<
                     decltype(thrust::get<1>(cuda::std::declval<T>()))>>
   : cuda::std::conditional_t<thrust::tuple_size<T>::value == 2,
                              cuda::std::true_type,
-                             cuda::std::false_type> {
-};
+                             cuda::std::false_type> {};
 
 template <typename T>
 struct is_thrust_pair_like
   : is_thrust_pair_like_impl<cuda::std::remove_reference_t<decltype(thrust::raw_reference_cast(
-      cuda::std::declval<T>()))>> {
-};
+      cuda::std::declval<T>()))>> {};
 
 }  // namespace cuco::detail

--- a/include/cuco/dynamic_map.cuh
+++ b/include/cuco/dynamic_map.cuh
@@ -117,7 +117,7 @@ class dynamic_map {
   dynamic_map(dynamic_map&&)      = delete;
 
   dynamic_map& operator=(dynamic_map const&) = delete;
-  dynamic_map& operator=(dynamic_map&&) = delete;
+  dynamic_map& operator=(dynamic_map&&)      = delete;
 
   /**
    * @brief Constructs a dynamically-sized map with the specified initial capacity, growth factor

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -138,7 +138,7 @@ class static_map {
                                         storage_ref_type,
                                         Operators...>;  ///< Non-owning container ref type
 
-  static_map(static_map const&) = delete;
+  static_map(static_map const&)            = delete;
   static_map& operator=(static_map const&) = delete;
 
   static_map(static_map&&) = default;  ///< Move constructor
@@ -866,7 +866,7 @@ class static_map {
   static_map(static_map&&)      = delete;
 
   static_map& operator=(static_map const&) = delete;
-  static_map& operator=(static_map&&) = delete;
+  static_map& operator=(static_map&&)      = delete;
 
   /**
    * @brief Indicates if concurrent insert/find is supported for the key/value types.

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -165,7 +165,7 @@ class static_multimap {
   using probe_sequence_type =
     cuco::legacy::detail::probe_sequence<ProbeSequence, Key, Value, Scope>;  ///< Probe scheme type
 
-  static_multimap(static_multimap const&) = delete;
+  static_multimap(static_multimap const&)            = delete;
   static_multimap& operator=(static_multimap const&) = delete;
 
   static_multimap(static_multimap&&) = default;  ///< Move constructor

--- a/include/cuco/static_set.cuh
+++ b/include/cuco/static_set.cuh
@@ -114,7 +114,7 @@ class static_set {
                                         storage_ref_type,
                                         Operators...>;  ///< Non-owning container ref type
 
-  static_set(static_set const&) = delete;
+  static_set(static_set const&)            = delete;
   static_set& operator=(static_set const&) = delete;
 
   static_set(static_set&&) = default;  ///< Move constructor

--- a/include/cuco/utility/key_generator.cuh
+++ b/include/cuco/utility/key_generator.cuh
@@ -41,8 +41,7 @@ namespace distribution {
 /**
  * @brief Tag struct representing a random distribution of unique keys.
  */
-struct unique {
-};
+struct unique {};
 
 /**
  * @brief Tag struct representing a uniform distribution.

--- a/include/cuco/utility/traits.hpp
+++ b/include/cuco/utility/traits.hpp
@@ -38,14 +38,12 @@ namespace cuco {
  *
  */
 template <typename T, typename = void>
-struct is_bitwise_comparable : std::false_type {
-};
+struct is_bitwise_comparable : std::false_type {};
 
 /// By default, only types with unique object representations are allowed
 template <typename T>
 struct is_bitwise_comparable<T, std::enable_if_t<std::has_unique_object_representations_v<T>>>
-  : std::true_type {
-};
+  : std::true_type {};
 
 template <typename T>
 inline constexpr bool is_bitwise_comparable_v = is_bitwise_comparable<T>::value;
@@ -54,11 +52,10 @@ inline constexpr bool is_bitwise_comparable_v = is_bitwise_comparable<T>::value;
  * @brief Declares that a type `Type` is bitwise comparable.
  *
  */
-#define CUCO_DECLARE_BITWISE_COMPARABLE(Type)           \
-  namespace cuco {                                      \
-  template <>                                           \
-  struct is_bitwise_comparable<Type> : std::true_type { \
-  };                                                    \
+#define CUCO_DECLARE_BITWISE_COMPARABLE(Type)             \
+  namespace cuco {                                        \
+  template <>                                             \
+  struct is_bitwise_comparable<Type> : std::true_type {}; \
   }
 
 template <bool value, typename... Args>


### PR DESCRIPTION
Similar to https://github.com/rapidsai/cudf/pull/14120

This PR bumps the `clang-format` version to 16.0.6 for better formatting.