### PR TITLE
Fix typos in the `static_set` documentation

### DIFF
--- a/include/cuco/static_set.cuh
+++ b/include/cuco/static_set.cuh
@@ -122,7 +122,7 @@ class static_set {
   /**
    * @brief Replaces the contents of the container with another container.
    *
-   * @return Reference of the current map object
+   * @return Reference of the current set object
    */
   static_set& operator=(static_set&&) = default;
   ~static_set()                       = default;
@@ -133,7 +133,7 @@ class static_set {
    *
    * The actual set capacity depends on the given `capacity`, the probing scheme, CG size, and the
    * window size and it is computed via the `make_window_extent` factory. Insert operations will not
-   * automatically grow the set. Attempting to insert more unique keys than the capacity of the map
+   * automatically grow the set. Attempting to insert more unique keys than the capacity of the set
    * results in undefined behavior.
    *
    * @note Any `*_sentinel`s are reserved and behavior is undefined when attempting to insert
@@ -159,7 +159,7 @@ class static_set {
                        cuda_stream_ref stream              = {});
 
   /**
-   * @brief Constructs a statically-sized map with the number of elements to insert `n`, the desired
+   * @brief Constructs a statically-sized set with the number of elements to insert `n`, the desired
    * load factor, etc
    *
    * @note This constructor helps users create a set based on the number of elements to insert and
@@ -206,7 +206,7 @@ class static_set {
    *
    * The actual set capacity depends on the given `capacity`, the probing scheme, CG size, and the
    * window size and it is computed via the `make_window_extent` factory. Insert operations will not
-   * automatically grow the set. Attempting to insert more unique keys than the capacity of the map
+   * automatically grow the set. Attempting to insert more unique keys than the capacity of the set
    * results in undefined behavior.
    *
    * @note Any `*_sentinel`s are reserved and behavior is undefined when attempting to insert
@@ -619,9 +619,9 @@ class static_set {
   [[nodiscard]] size_type size(cuda_stream_ref stream = {}) const noexcept;
 
   /**
-   * @brief Gets the maximum number of elements the hash map can hold.
+   * @brief Gets the maximum number of elements the hash set can hold.
    *
-   * @return The maximum number of elements the hash map can hold
+   * @return The maximum number of elements the hash set can hold
    */
   [[nodiscard]] constexpr auto capacity() const noexcept;
 


### PR DESCRIPTION
There are several occurrences of "map" in the `static_set` documentation. This PR replaces all of them with "set".