### PR TITLE
Fix ODR violation where end() might be defined by multiple mixin operators

### DIFF
--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -129,6 +129,45 @@ template <typename Key,
           typename ProbingScheme,
           typename StorageRef,
           typename... Operators>
+__host__ __device__ constexpr static_map_ref<Key,
+                                             T,
+                                             Scope,
+                                             KeyEqual,
+                                             ProbingScheme,
+                                             StorageRef,
+                                             Operators...>::const_iterator
+static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::end()
+  const noexcept
+{
+  return this->impl_.end();
+}
+
+template <typename Key,
+          typename T,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
+__host__ __device__ constexpr static_map_ref<Key,
+                                             T,
+                                             Scope,
+                                             KeyEqual,
+                                             ProbingScheme,
+                                             StorageRef,
+                                             Operators...>::iterator
+static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::end() noexcept
+{
+  return this->impl_.end();
+}
+
+template <typename Key,
+          typename T,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
 __host__ __device__ constexpr auto
 static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::capacity()
   const noexcept
@@ -518,32 +557,6 @@ class operator_impl<
 
  public:
   /**
-   * @brief Returns a const_iterator to one past the last slot.
-   *
-   * @note This API is available only when `find_tag` or `insert_and_find_tag` is present.
-   *
-   * @return A const_iterator to one past the last slot
-   */
-  [[nodiscard]] __host__ __device__ constexpr const_iterator end() const noexcept
-  {
-    auto const& ref_ = static_cast<ref_type const&>(*this);
-    return ref_.impl_.end();
-  }
-
-  /**
-   * @brief Returns an iterator to one past the last slot.
-   *
-   * @note This API is available only when `find_tag` or `insert_and_find_tag` is present.
-   *
-   * @return An iterator to one past the last slot
-   */
-  [[nodiscard]] __host__ __device__ constexpr iterator end() noexcept
-  {
-    auto const& ref_ = static_cast<ref_type const&>(*this);
-    return ref_.impl_.end();
-  }
-
-  /**
    * @brief Inserts the given element into the map.
    *
    * @note This API returns a pair consisting of an iterator to the inserted element (or to the
@@ -724,32 +737,6 @@ class operator_impl<
   static constexpr auto window_size = base_type::window_size;
 
  public:
-  /**
-   * @brief Returns a const_iterator to one past the last slot.
-   *
-   * @note This API is available only when `find_tag` or `insert_and_find_tag` is present.
-   *
-   * @return A const_iterator to one past the last slot
-   */
-  [[nodiscard]] __host__ __device__ constexpr const_iterator end() const noexcept
-  {
-    auto const& ref_ = static_cast<ref_type const&>(*this);
-    return ref_.impl_.end();
-  }
-
-  /**
-   * @brief Returns an iterator to one past the last slot.
-   *
-   * @note This API is available only when `find_tag` or `insert_and_find_tag` is present.
-   *
-   * @return An iterator to one past the last slot
-   */
-  [[nodiscard]] __host__ __device__ constexpr iterator end() noexcept
-  {
-    auto const& ref_ = static_cast<ref_type const&>(*this);
-    return ref_.impl_.end();
-  }
-
   /**
    * @brief Finds an element in the map with key equivalent to the probe key.
    *

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -111,6 +111,40 @@ template <typename Key,
           typename ProbingScheme,
           typename StorageRef,
           typename... Operators>
+__host__ __device__ constexpr static_set_ref<Key,
+                                             Scope,
+                                             KeyEqual,
+                                             ProbingScheme,
+                                             StorageRef,
+                                             Operators...>::const_iterator
+static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::end() const noexcept
+{
+  return this->impl_.end();
+}
+
+template <typename Key,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
+__host__ __device__ constexpr static_set_ref<Key,
+                                             Scope,
+                                             KeyEqual,
+                                             ProbingScheme,
+                                             StorageRef,
+                                             Operators...>::iterator
+static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::end() noexcept
+{
+  return this->impl_.end();
+}
+
+template <typename Key,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
 __host__ __device__ constexpr auto
 static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::capacity()
   const noexcept
@@ -287,32 +321,6 @@ class operator_impl<op::insert_and_find_tag,
 
  public:
   /**
-   * @brief Returns a const_iterator to one past the last slot.
-   *
-   * @note This API is available only when `find_tag` or `insert_and_find_tag` is present.
-   *
-   * @return A const_iterator to one past the last slot
-   */
-  [[nodiscard]] __host__ __device__ constexpr const_iterator end() const noexcept
-  {
-    auto const& ref_ = static_cast<ref_type const&>(*this);
-    return ref_.impl_.end();
-  }
-
-  /**
-   * @brief Returns an iterator to one past the last slot.
-   *
-   * @note This API is available only when `find_tag` or `insert_and_find_tag` is present.
-   *
-   * @return An iterator to one past the last slot
-   */
-  [[nodiscard]] __host__ __device__ constexpr iterator end() noexcept
-  {
-    auto const& ref_ = static_cast<ref_type const&>(*this);
-    return ref_.impl_.end();
-  }
-
-  /**
    * @brief Inserts the given element into the set.
    *
    * @note This API returns a pair consisting of an iterator to the inserted element (or to the
@@ -486,32 +494,6 @@ class operator_impl<op::find_tag,
   static constexpr auto window_size = base_type::window_size;
 
  public:
-  /**
-   * @brief Returns a const_iterator to one past the last slot.
-   *
-   * @note This API is available only when `find_tag` or `insert_and_find_tag` is present.
-   *
-   * @return A const_iterator to one past the last slot
-   */
-  [[nodiscard]] __host__ __device__ constexpr const_iterator end() const noexcept
-  {
-    auto const& ref_ = static_cast<ref_type const&>(*this);
-    return ref_.impl_.end();
-  }
-
-  /**
-   * @brief Returns an iterator to one past the last slot.
-   *
-   * @note This API is available only when `find_tag` or `insert_and_find_tag` is present.
-   *
-   * @return An iterator to one past the last slot
-   */
-  [[nodiscard]] __host__ __device__ constexpr iterator end() noexcept
-  {
-    auto const& ref_ = static_cast<ref_type const&>(*this);
-    return ref_.impl_.end();
-  }
-
   /**
    * @brief Finds an element in the set with key equivalent to the probe key.
    *

--- a/include/cuco/static_map_ref.cuh
+++ b/include/cuco/static_map_ref.cuh
@@ -186,6 +186,20 @@ class static_map_ref
   [[nodiscard]] __host__ __device__ constexpr key_equal key_eq() const noexcept;
 
   /**
+   * @brief Returns a const_iterator to one past the last slot.
+   *
+   * @return A const_iterator to one past the last slot
+   */
+  [[nodiscard]] __host__ __device__ constexpr const_iterator end() const noexcept;
+
+  /**
+   * @brief Returns an iterator to one past the last slot.
+   *
+   * @return An iterator to one past the last slot
+   */
+  [[nodiscard]] __host__ __device__ constexpr iterator end() noexcept;
+
+  /**
    * @brief Creates a reference with new operators from the current object.
    *
    * Note that this function uses move semantics and thus invalidates the current object.

--- a/include/cuco/static_set_ref.cuh
+++ b/include/cuco/static_set_ref.cuh
@@ -164,6 +164,20 @@ class static_set_ref
   [[nodiscard]] __host__ __device__ constexpr key_equal key_eq() const noexcept;
 
   /**
+   * @brief Returns a const_iterator to one past the last slot.
+   *
+   * @return A const_iterator to one past the last slot
+   */
+  [[nodiscard]] __host__ __device__ constexpr const_iterator end() const noexcept;
+
+  /**
+   * @brief Returns an iterator to one past the last slot.
+   *
+   * @return An iterator to one past the last slot
+   */
+  [[nodiscard]] __host__ __device__ constexpr iterator end() noexcept;
+
+  /**
    * @brief Creates a reference with new operators from the current object.
    *
    * Note that this function uses move semantics and thus invalidates the current object.


### PR DESCRIPTION
This PR fixes an ODR violation that occurs when mixing multiple operators that define `end()` in their body, e.g., `find()` and `insert_and_find().`

Solution: Move definition of `end()` to the `_ref` class instead of defining it in the operators.