### PR TITLE
Fix flaky memcpy optimization in xxhash

### DIFF
--- a/include/cuco/detail/hash_functions/xxhash.cuh
+++ b/include/cuco/detail/hash_functions/xxhash.cuh
@@ -89,8 +89,14 @@ struct XXHash_32 {
    */
   constexpr result_type __host__ __device__ operator()(Key const& key) const noexcept
   {
-    return compute_hash(reinterpret_cast<std::byte const*>(&key),
-                        cuco::extent<std::size_t, sizeof(Key)>{});
+    if constexpr (sizeof(Key) <= 16) {
+      Key const key_copy = key;
+      return compute_hash(reinterpret_cast<std::byte const*>(&key_copy),
+                          cuco::extent<std::size_t, sizeof(Key)>{});
+    } else {
+      return compute_hash(reinterpret_cast<std::byte const*>(&key),
+                          cuco::extent<std::size_t, sizeof(Key)>{});
+    }
   }
 
   /**
@@ -251,8 +257,14 @@ struct XXHash_64 {
    */
   constexpr result_type __host__ __device__ operator()(Key const& key) const noexcept
   {
-    return compute_hash(reinterpret_cast<std::byte const*>(&key),
-                        cuco::extent<std::size_t, sizeof(Key)>{});
+    if constexpr (sizeof(Key) <= 16) {
+      Key const key_copy = key;
+      return compute_hash(reinterpret_cast<std::byte const*>(&key_copy),
+                          cuco::extent<std::size_t, sizeof(Key)>{});
+    } else {
+      return compute_hash(reinterpret_cast<std::byte const*>(&key),
+                          cuco::extent<std::size_t, sizeof(Key)>{});
+    }
   }
 
   /**


### PR DESCRIPTION
Our xxhash implementation uses a `memcpy` approach to extract chunks from the input key ([link](https://github.com/NVIDIA/cuCollections/blob/791a637d1787fb52f8855a52c400ce97cdca1ede/include/cuco/detail/hash_functions/utils.cuh#L21-L28)). This hasn't been a problem so far, since the compiler was able to emit optimized `LDG` instructions, i.e. `.32, .64, .128` in all of the tested scenarios.

However, I stumbled over a scenario where this optimization is not applied: https://godbolt.org/z/61fqxKG8j
The only difference between the two kernels is that the kernel on left takes the input array as an iterator `ÌnputIt` while the kernel on the right takes a proper pointer to the array.
We can see that the left kernel correctly emits `LDG.32` while the kernel on the right emits 4x`LDG.u8`.

My proposed solution is to enforce a local copy of the key before it is passed to the `compute_hash` function.