### PR TITLE
Clean up strong type utility

### DIFF
--- a/include/cuco/detail/utility/strong_type.cuh
+++ b/include/cuco/detail/utility/strong_type.cuh
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+
+#pragma once
+
+namespace cuco::detail {
+
+/**
+ * @brief A strong type wrapper
+ *
+ * @tparam T Type of the value
+ */
+template <typename T>
+struct strong_type {
+  /**
+   * @brief Constructs a strong type
+   *
+   * @param v Value to be wrapped as a strong type
+   */
+  __host__ __device__ explicit constexpr strong_type(T v) : value{v} {}
+
+  /**
+   * @brief Implicit conversion operator to the underlying value.
+   *
+   * @return Underlying value
+   */
+  __host__ __device__ constexpr operator T() const noexcept { return value; }
+
+  T value;  ///< Underlying data value
+};
+
+}  // namespace cuco::detail

--- a/include/cuco/detail/utils.cuh
+++ b/include/cuco/detail/utils.cuh
@@ -83,30 +83,6 @@ struct slot_is_filled {
 };
 
 /**
- * @brief A strong type wrapper.
- *
- * @tparam T Type of the mapped values
- */
-template <typename T>
-struct strong_type {
-  /**
-   * @brief Constructs a strong type.
-   *
-   * @param v Value to be wrapped as a strong type
-   */
-  __host__ __device__ explicit constexpr strong_type(T v) : value{v} {}
-
-  /**
-   * @brief Implicit conversion operator to the underlying value.
-   *
-   * @return Underlying value
-   */
-  __host__ __device__ constexpr operator T() const noexcept { return value; }
-
-  T value;  ///< Underlying value
-};
-
-/**
  * @brief Converts a given hash value into a valid (positive) size type.
  *
  * @tparam SizeType The target type

--- a/include/cuco/sentinel.cuh
+++ b/include/cuco/sentinel.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,9 @@
 
 #pragma once
 
-#include <cuco/detail/utils.cuh>
+#include <cuco/detail/utility/strong_type.cuh>
 
 namespace cuco {
-inline namespace sentinel {
-
 /**
  * @brief A strong type wrapper used to denote the empty key sentinel.
  *
@@ -65,6 +63,4 @@ struct erased_key : public cuco::detail::strong_type<T> {
    */
   __host__ __device__ explicit constexpr erased_key(T v) : cuco::detail::strong_type<T>(v) {}
 };
-
-}  // namespace sentinel
 }  // namespace cuco

--- a/include/cuco/utility/key_generator.cuh
+++ b/include/cuco/utility/key_generator.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <cuco/detail/error.hpp>
-#include <cuco/detail/utils.cuh>
+#include <cuco/detail/utility/strong_type.cuh>
 
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/counting_iterator.h>


### PR DESCRIPTION
This PR removes the inline sentinel namespace and moves the strong type definition to its own header file.

It's the first step to clean up multiple unrelated definitions in the same `detail/utils.hpp/cuh` file.