### PR TITLE
Use invoke_one when possible

### DIFF
--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -300,7 +300,12 @@ class open_addressing_ref_impl {
     auto const num_windows = static_cast<size_type>(this->window_extent());
 #if defined(CUDA_HAS_CUDA_BARRIER)
     __shared__ cuda::barrier<cuda::thread_scope::thread_scope_block> barrier;
+
+#if defined(CUCO_HAS_CG_INVOKE_ONE)
+    cooperative_groups::invoke_one(g, [&]() { init(&barrier, g.size()); });
+#else
     if (g.thread_rank() == 0) { init(&barrier, g.size()); }
+#endif
     g.sync();
 
     cuda::memcpy_async(

--- a/include/cuco/detail/static_map/kernels.cuh
+++ b/include/cuco/detail/static_map/kernels.cuh
@@ -118,9 +118,15 @@ CUCO_KERNEL void find(InputIt first, cuco::detail::index_type n, OutputIt output
         auto const tile  = cg::tiled_partition<CGSize>(block);
         auto const found = ref.find(tile, key);
 
+#if defined(CUCO_HAS_CG_INVOKE_ONE)
+        cg::invoke_one(tile, [&]() {
+          *(output_begin + idx) = found == ref.end() ? ref.empty_value_sentinel() : (*found).second;
+        });
+#else
         if (tile.thread_rank() == 0) {
           *(output_begin + idx) = found == ref.end() ? ref.empty_value_sentinel() : (*found).second;
         }
+#endif
       }
     }
     idx += loop_stride;

--- a/include/cuco/detail/static_set/kernels.cuh
+++ b/include/cuco/detail/static_set/kernels.cuh
@@ -81,9 +81,15 @@ CUCO_KERNEL void find(InputIt first, cuco::detail::index_type n, OutputIt output
         auto const tile  = cg::tiled_partition<CGSize>(block);
         auto const found = ref.find(tile, key);
 
+#if defined(CUCO_HAS_CG_INVOKE_ONE)
+        cg::invoke_one(tile, [&]() {
+          *(output_begin + idx) = found == ref.end() ? ref.empty_key_sentinel() : *found;
+        });
+#else
         if (tile.thread_rank() == 0) {
           *(output_begin + idx) = found == ref.end() ? ref.empty_key_sentinel() : *found;
         }
+#endif
       }
     }
     idx += loop_stride;


### PR DESCRIPTION
This PR updates new open addressing implementations to use `cg::invoke_one` when possible.

It doesn't change legacy implementations like multimap or dynamic map, etc.