### PR TITLE
Add convenience macro for defining strong types (correctly)

### DIFF
--- a/include/cuco/detail/utility/strong_type.cuh
+++ b/include/cuco/detail/utility/strong_type.cuh
@@ -21,8 +21,9 @@ namespace cuco::detail {
  * @brief A strong type wrapper
  *
  * @tparam T Type of the value
+ *
  */
-template <typename T>
+template <class T>
 struct strong_type {
   /**
    * @brief Constructs a strong type
@@ -42,3 +43,23 @@ struct strong_type {
 };
 
 }  // namespace cuco::detail
+
+/**
+ * @brief Convenience wrapper for defining a strong type
+ */
+#define CUCO_DEFINE_STRONG_TYPE(Name, Type)                 \
+  struct Name : public cuco::detail::strong_type<Type> {    \
+    __host__ __device__ explicit constexpr Name(Type value) \
+      : cuco::detail::strong_type<Type>(value)              \
+    {                                                       \
+    }                                                       \
+  };
+
+/**
+ * @brief Convenience wrapper for defining a templated strong type
+ */
+#define CUCO_DEFINE_TEMPLATE_STRONG_TYPE(Name)                                                    \
+  template <typename T>                                                                           \
+  struct Name : public cuco::detail::strong_type<T> {                                             \
+    __host__ __device__ explicit constexpr Name(T value) : cuco::detail::strong_type<T>(value) {} \
+  };

--- a/include/cuco/sentinel.cuh
+++ b/include/cuco/sentinel.cuh
@@ -20,17 +20,17 @@
 
 namespace cuco {
 /**
- * @brief A strong type wrapper used to denote the empty key sentinel.
+ * @brief A strong type wrapper `cuco::empty_key<Key>` used to denote the empty key sentinel.
  */
 CUCO_DEFINE_TEMPLATE_STRONG_TYPE(empty_key);
 
 /**
- * @brief A strong type wrapper used to denote the empty value sentinel.
+ * @brief A strong type wrapper `cuco::empty_value<T>` used to denote the empty value sentinel.
  */
 CUCO_DEFINE_TEMPLATE_STRONG_TYPE(empty_value);
 
 /**
- * @brief A strong type wrapper used to denote the erased key sentinel.
+ * @brief A strong type wrapper `cuco::erased_key<Key>` used to denote the erased key sentinel.
  */
 CUCO_DEFINE_TEMPLATE_STRONG_TYPE(erased_key);
 }  // namespace cuco

--- a/include/cuco/sentinel.cuh
+++ b/include/cuco/sentinel.cuh
@@ -21,46 +21,16 @@
 namespace cuco {
 /**
  * @brief A strong type wrapper used to denote the empty key sentinel.
- *
- * @tparam T Type of the key values
  */
-template <typename T>
-struct empty_key : public cuco::detail::strong_type<T> {
-  /**
-   * @brief Constructs an empty key sentinel with the given `v`.
-   *
-   * @param v The empty key sentinel value
-   */
-  __host__ __device__ explicit constexpr empty_key(T v) : cuco::detail::strong_type<T>(v) {}
-};
+CUCO_DEFINE_TEMPLATE_STRONG_TYPE(empty_key);
 
 /**
  * @brief A strong type wrapper used to denote the empty value sentinel.
- *
- * @tparam T Type of the mapped values
  */
-template <typename T>
-struct empty_value : public cuco::detail::strong_type<T> {
-  /**
-   * @brief Constructs an empty value sentinel with the given `v`.
-   *
-   * @param v The empty value sentinel value
-   */
-  __host__ __device__ explicit constexpr empty_value(T v) : cuco::detail::strong_type<T>(v) {}
-};
+CUCO_DEFINE_TEMPLATE_STRONG_TYPE(empty_value);
 
 /**
  * @brief A strong type wrapper used to denote the erased key sentinel.
- *
- * @tparam T Type of the key values
  */
-template <typename T>
-struct erased_key : public cuco::detail::strong_type<T> {
-  /**
-   * @brief Constructs an erased key sentinel with the given `v`.
-   *
-   * @param v The erased key sentinel value
-   */
-  __host__ __device__ explicit constexpr erased_key(T v) : cuco::detail::strong_type<T>(v) {}
-};
+CUCO_DEFINE_TEMPLATE_STRONG_TYPE(erased_key);
 }  // namespace cuco


### PR DESCRIPTION
This PR adds some convenience macros for defining strong types.
Background: https://github.com/NVIDIA/cuCollections/pull/429#discussion_r1541340467

tl;dr We want to avoid defining strong types as type aliases of `cuco::detail::strong_type` as this leads to a situation where all strong types with the same underlying value type are indistinguishable: 

```cpp
using foo = cuco::detail::strong_type<float>;
using bar = cuco::detail::strong_type<float>;

void expects_foo(foo f) {
  ...
}

int main() {
  expects_foo(foo{0.1});
  expects_foo(bar{0.2}); // doesn't throw an error since foo and bar are aliases of the same type
}
```