### PR TITLE
Fix illegal memory issues in multimap benchmarks

### DIFF
--- a/benchmarks/hash_table/static_multimap/query_bench.cu
+++ b/benchmarks/hash_table/static_multimap/query_bench.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/hash_table/static_multimap/query_bench.cu
+++ b/benchmarks/hash_table/static_multimap/query_bench.cu
@@ -61,9 +61,12 @@ std::enable_if_t<(sizeof(Key) == sizeof(Value)), void> static_multimap_query(
     size, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};
   map.insert(pairs.begin(), pairs.end());
 
+  auto const output_size = map.count_outer(keys.begin(), keys.end());
+  thrust::device_vector<pair_type> output(output_size);
+
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    auto count = map.count_outer(keys.begin(), keys.end(), launch.get_stream());
-    map.retrieve_outer(keys.begin(), keys.end(), pairs.begin(), launch.get_stream());
+    auto const count = map.count_outer(keys.begin(), keys.end(), launch.get_stream());
+    map.retrieve_outer(keys.begin(), keys.end(), output.begin(), launch.get_stream());
   });
 }
 

--- a/benchmarks/hash_table/static_multimap/retrieve_bench.cu
+++ b/benchmarks/hash_table/static_multimap/retrieve_bench.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/hash_table/static_multimap/retrieve_bench.cu
+++ b/benchmarks/hash_table/static_multimap/retrieve_bench.cu
@@ -61,8 +61,11 @@ std::enable_if_t<(sizeof(Key) == sizeof(Value)), void> static_multimap_retrieve(
     size, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};
   map.insert(pairs.begin(), pairs.end());
 
+  auto const output_size = map.count_outer(keys.begin(), keys.end());
+  thrust::device_vector<pair_type> output(output_size);
+
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    map.retrieve_outer(keys.begin(), keys.end(), pairs.begin(), launch.get_stream());
+    map.retrieve_outer(keys.begin(), keys.end(), output.begin(), launch.get_stream());
   });
 }
 


### PR DESCRIPTION
This PR fixes bugs in the multimap benchmarks where the corresponding count operation should have determined the output size.