### PR TITLE
Remove asynchronous set retrieve APIs

### DIFF
--- a/include/cuco/detail/static_set/static_set.inl
+++ b/include/cuco/detail/static_set/static_set.inl
@@ -323,27 +323,6 @@ static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::ret
   OutputIt2 output_match,
   cuda_stream_ref stream) const
 {
-  auto res = this->retrieve_async(first, last, output_probe, output_match, stream);
-  stream.synchronize();
-  return res;
-}
-
-template <class Key,
-          class Extent,
-          cuda::thread_scope Scope,
-          class KeyEqual,
-          class ProbingScheme,
-          class Allocator,
-          class Storage>
-template <typename InputIt, typename OutputIt1, typename OutputIt2>
-cuda::std::pair<OutputIt1, OutputIt2>
-static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::retrieve_async(
-  InputIt first,
-  InputIt last,
-  OutputIt1 output_probe,
-  OutputIt2 output_match,
-  cuda_stream_ref stream) const
-{
   auto const num_keys = cuco::detail::distance(first, last);
   if (num_keys == 0) { return {output_probe, output_match}; }
 
@@ -369,8 +348,7 @@ template <class Key,
           class Allocator,
           class Storage>
 template <typename InputIt, typename OutputIt, typename ProbeEqual, typename ProbeHash>
-OutputIt
-static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::retrieve_async(
+OutputIt static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::retrieve(
   InputIt first,
   InputIt last,
   OutputIt output_begin,
@@ -378,7 +356,7 @@ static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::ret
   ProbeHash const& probe_hash,
   cuda_stream_ref stream) const
 {
-  CUCO_FAIL("Unsupported code path: retrieve_async with custom hash/equal");
+  CUCO_FAIL("Unsupported code path: retrieve with custom hash/equal");
 }
 
 template <class Key,

--- a/include/cuco/static_set.cuh
+++ b/include/cuco/static_set.cuh
@@ -541,8 +541,7 @@ class static_set {
    * If key `k = *(first + i)` has a match `m` in the set, copies a `cuco::pair{k, m}` to
    * unspecified locations in `[output_begin, output_end)`. Else, does nothing.
    *
-   * @note This function synchronizes the given stream. For asynchronous execution use
-   * `retrieve_async`.
+   * @note This function synchronizes the given stream.
    * @note Behavior is undefined if the size of the output range exceeds
    * `std::distance(output_begin, output_end)`.
    * @note Behavior is undefined if the given key has multiple matches in the set.
@@ -579,38 +578,6 @@ class static_set {
    * `std::distance(output_begin, output_end)`.
    * @note Behavior is undefined if the given key has multiple matches in the set.
    *
-   * @tparam InputIt Device accessible input iterator
-   * @tparam OutputIt1 Device accessible output iterator whose `value_type` can be constructed from
-   * `ProbeKey`
-   * @tparam OutputIt2 Device accessible output iterator whose `value_type` can be constructed from
-   * `Key`
-   *
-   * @param first Beginning of the sequence of probe keys
-   * @param last End of the sequence of probe keys
-   * @param output_probe Beginning of the sequence of the probe keys that have a match
-   * @param output_match Beginning of the sequence of the matched keys
-   * @param stream CUDA stream used for retrieve
-   *
-   * @return The iterator indicating the last valid pair in the output
-   */
-  template <typename InputIt, typename OutputIt1, typename OutputIt2>
-  cuda::std::pair<OutputIt1, OutputIt2> retrieve_async(InputIt first,
-                                                       InputIt last,
-                                                       OutputIt1 output_probe,
-                                                       OutputIt2 output_match,
-                                                       cuda_stream_ref stream = {}) const;
-
-  /**
-   * @brief Asynchronously retrieves the matched key in the set corresponding to all probe keys in
-   * the range `[first, last)`
-   *
-   * If key `k = *(first + i)` has a match `m` in the set, copies a `cuco::pair{k, m}` to
-   * unspecified locations in `[output_begin, output_end)`. Else, does nothing.
-   *
-   * @note Behavior is undefined if the size of the output range exceeds
-   * `std::distance(output_begin, output_end)`.
-   * @note Behavior is undefined if the given key has multiple matches in the set.
-   *
    * @throw This API will always throw since it's not implemented.
    *
    * @tparam InputIt Device accessible input iterator
@@ -631,12 +598,12 @@ class static_set {
    * @return The iterator indicating the last valid pair in the output
    */
   template <typename InputIt, typename OutputIt, typename ProbeEqual, typename ProbeHash>
-  OutputIt retrieve_async(InputIt first,
-                          InputIt last,
-                          OutputIt output_begin,
-                          ProbeEqual const& probe_equal = ProbeEqual{},
-                          ProbeHash const& probe_hash   = ProbeHash{},
-                          cuda_stream_ref stream        = {}) const;
+  OutputIt retrieve(InputIt first,
+                    InputIt last,
+                    OutputIt output_begin,
+                    ProbeEqual const& probe_equal = ProbeEqual{},
+                    ProbeHash const& probe_hash   = ProbeHash{},
+                    cuda_stream_ref stream        = {}) const;
 
   /**
    * @brief Retrieves all keys contained in the set.


### PR DESCRIPTION
Set retrieve APIs synchronize before return to determine the end of the output iterator thus `retrieve_async` doesn't really make sense.

This PR removes them.