### PR TITLE
Fix misuses of the `CUCO_HAS_CUDA_BARRIER` marco

### DIFF
--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -26,6 +26,9 @@
 #include <thrust/tuple.h>
 
 #include <cuda/atomic>
+#if defined(CUCO_HAS_CUDA_BARRIER)
+#include <cuda/barrier>
+#endif
 
 #include <cooperative_groups.h>
 
@@ -295,10 +298,10 @@ class open_addressing_ref_impl {
    * the ownership of the memory
    */
   template <typename CG>
-  __device__ constexpr void make_copy(CG const& g, window_type* const memory_to_use) const noexcept
+  __device__ void make_copy(CG const& g, window_type* const memory_to_use) const noexcept
   {
     auto const num_windows = static_cast<size_type>(this->window_extent());
-#if defined(CUDA_HAS_CUDA_BARRIER)
+#if defined(CUCO_HAS_CUDA_BARRIER)
     __shared__ cuda::barrier<cuda::thread_scope::thread_scope_block> barrier;
     if (g.thread_rank() == 0) { init(&barrier, g.size()); }
     g.sync();

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -1853,7 +1853,7 @@ class static_map {
                                             pair_atomic_type* const memory_to_use,
                                             device_view source_device_view) noexcept
     {
-#if defined(CUDA_HAS_CUDA_BARRIER)
+#if defined(CUCO_HAS_CUDA_BARRIER)
       __shared__ cuda::barrier<cuda::thread_scope::thread_scope_block> barrier;
       if (g.thread_rank() == 0) { init(&barrier, g.size()); }
       g.sync();


### PR DESCRIPTION
Replace the `CUDA_HAS_CUDA_BARRIER` typo with `CUCO_HAS_CUDA_BARRIER`.