### PR TITLE
Add ref `with_hash_function` and `with_key_eq` APIs for set and multiset

### DIFF
--- a/include/cuco/detail/probing_scheme_impl.inl
+++ b/include/cuco/detail/probing_scheme_impl.inl
@@ -94,7 +94,7 @@ __host__ __device__ constexpr linear_probing<CGSize, Hash>::linear_probing(Hash 
 
 template <int32_t CGSize, typename Hash>
 template <typename NewHash>
-__host__ __device__ constexpr auto linear_probing<CGSize, Hash>::make_copy(
+__host__ __device__ constexpr auto linear_probing<CGSize, Hash>::with_hash_function(
   NewHash const& hash) const noexcept
 {
   return linear_probing<cg_size, NewHash>{hash};
@@ -135,7 +135,7 @@ __host__ __device__ constexpr double_hashing<CGSize, Hash1, Hash2>::double_hashi
 
 template <int32_t CGSize, typename Hash1, typename Hash2>
 template <typename NewHash1, typename NewHash2>
-__host__ __device__ constexpr auto double_hashing<CGSize, Hash1, Hash2>::make_copy(
+__host__ __device__ constexpr auto double_hashing<CGSize, Hash1, Hash2>::with_hash_function(
   NewHash1 const& hash1, NewHash2 const& hash2) const noexcept
 {
   return double_hashing<cg_size, NewHash1, NewHash2>{hash1, hash2};

--- a/include/cuco/detail/probing_scheme_impl.inl
+++ b/include/cuco/detail/probing_scheme_impl.inl
@@ -93,6 +93,14 @@ __host__ __device__ constexpr linear_probing<CGSize, Hash>::linear_probing(Hash 
 }
 
 template <int32_t CGSize, typename Hash>
+template <typename NewHash>
+__host__ __device__ constexpr auto linear_probing<CGSize, Hash>::make_copy(
+  NewHash const& hash) const noexcept
+{
+  return linear_probing<cg_size, NewHash>{hash};
+}
+
+template <int32_t CGSize, typename Hash>
 template <typename ProbeKey, typename Extent>
 __host__ __device__ constexpr auto linear_probing<CGSize, Hash>::operator()(
   ProbeKey const& probe_key, Extent upper_bound) const noexcept
@@ -123,6 +131,14 @@ __host__ __device__ constexpr double_hashing<CGSize, Hash1, Hash2>::double_hashi
   Hash1 const& hash1, Hash2 const& hash2)
   : hash1_{hash1}, hash2_{hash2}
 {
+}
+
+template <int32_t CGSize, typename Hash1, typename Hash2>
+template <typename NewHash1, typename NewHash2>
+__host__ __device__ constexpr auto double_hashing<CGSize, Hash1, Hash2>::make_copy(
+  NewHash1 const& hash1, NewHash2 const& hash2) const noexcept
+{
+  return double_hashing<cg_size, NewHash1, NewHash2>{hash1, hash2};
 }
 
 template <int32_t CGSize, typename Hash1, typename Hash2>

--- a/include/cuco/detail/static_multiset/static_multiset_ref.inl
+++ b/include/cuco/detail/static_multiset/static_multiset_ref.inl
@@ -211,6 +211,31 @@ auto static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operat
     std::move(*this)};
 }
 
+template <typename Key,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
+template <typename NewKeyEqual, typename NewHash>
+__host__ __device__ constexpr auto
+static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::make_copy(
+  NewKeyEqual const& key_equal, NewHash const& hash) const noexcept
+{
+  auto probing_scheme = this->impl_.probing_scheme().make_copy(hash);
+  return static_multiset_ref<Key,
+                             Scope,
+                             NewKeyEqual,
+                             decltype(probing_scheme),
+                             StorageRef,
+                             Operators...>{cuco::empty_key<Key>{this->empty_key_sentinel()},
+                                           // cuco::erased_key<Key>{this->erased_key_sentinel()},
+                                           key_equal,
+                                           probing_scheme,
+                                           {},
+                                           this->impl_.storage_ref()};
+}
+
 namespace detail {
 
 template <typename Key,

--- a/include/cuco/detail/static_multiset/static_multiset_ref.inl
+++ b/include/cuco/detail/static_multiset/static_multiset_ref.inl
@@ -217,20 +217,38 @@ template <typename Key,
           typename ProbingScheme,
           typename StorageRef,
           typename... Operators>
-template <typename NewKeyEqual, typename NewHash>
+template <typename NewKeyEqual>
 __host__ __device__ constexpr auto
-static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::make_copy(
-  NewKeyEqual const& key_equal, NewHash const& hash) const noexcept
+static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::with_key_eq(
+  NewKeyEqual const& key_equal) const noexcept
 {
-  auto probing_scheme = this->impl_.probing_scheme().make_copy(hash);
+  return static_multiset_ref<Key, Scope, NewKeyEqual, ProbingScheme, StorageRef, Operators...>{
+    cuco::empty_key<Key>{this->empty_key_sentinel()},
+    key_equal,
+    this->impl_.probing_scheme(),
+    {},
+    this->impl_.storage_ref()};
+}
+
+template <typename Key,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
+template <typename NewHash>
+__host__ __device__ constexpr auto
+static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::
+  with_hash_function(NewHash const& hash) const noexcept
+{
+  auto const probing_scheme = this->impl_.probing_scheme().make_copy(hash);
   return static_multiset_ref<Key,
                              Scope,
-                             NewKeyEqual,
+                             KeyEqual,
                              decltype(probing_scheme),
                              StorageRef,
                              Operators...>{cuco::empty_key<Key>{this->empty_key_sentinel()},
-                                           // cuco::erased_key<Key>{this->erased_key_sentinel()},
-                                           key_equal,
+                                           this->impl_.key_eq(),
                                            probing_scheme,
                                            {},
                                            this->impl_.storage_ref()};

--- a/include/cuco/detail/static_multiset/static_multiset_ref.inl
+++ b/include/cuco/detail/static_multiset/static_multiset_ref.inl
@@ -241,7 +241,7 @@ __host__ __device__ constexpr auto
 static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::
   with_hash_function(NewHash const& hash) const noexcept
 {
-  auto const probing_scheme = this->impl_.probing_scheme().make_copy(hash);
+  auto const probing_scheme = this->impl_.probing_scheme().with_hash_function(hash);
   return static_multiset_ref<Key,
                              Scope,
                              KeyEqual,

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -239,6 +239,31 @@ template <typename Key,
           typename ProbingScheme,
           typename StorageRef,
           typename... Operators>
+template <typename NewKeyEqual, typename NewHash>
+__host__ __device__ constexpr auto
+static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::make_copy(
+  NewKeyEqual const& key_equal, NewHash const& hash) const noexcept
+{
+  auto probing_scheme = this->impl_.probing_scheme().make_copy(hash);
+  return static_set_ref<Key,
+                        Scope,
+                        NewKeyEqual,
+                        decltype(probing_scheme),
+                        StorageRef,
+                        Operators...>{cuco::empty_key<Key>{this->empty_key_sentinel()},
+                                      // cuco::erased_key<Key>{this->erased_key_sentinel()},
+                                      key_equal,
+                                      probing_scheme,
+                                      {},
+                                      this->impl_.storage_ref()};
+}
+
+template <typename Key,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
 template <typename CG>
 __device__ constexpr void
 static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::initialize(

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -240,7 +240,7 @@ __host__ __device__ constexpr auto
 static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::with_hash_function(
   NewHash const& hash) const noexcept
 {
-  auto const probing_scheme = this->impl_.probing_scheme().make_copy(hash);
+  auto const probing_scheme = this->impl_.probing_scheme().with_hash_function(hash);
   return static_set_ref<Key, Scope, KeyEqual, decltype(probing_scheme), StorageRef, Operators...>{
     cuco::empty_key<Key>{this->empty_key_sentinel()},
     this->impl_.key_eq(),

--- a/include/cuco/probing_scheme.cuh
+++ b/include/cuco/probing_scheme.cuh
@@ -47,6 +47,18 @@ class linear_probing : private detail::probing_scheme_base<CGSize> {
   __host__ __device__ constexpr linear_probing(Hash const& hash = {});
 
   /**
+   *@brief Makes a copy of the current probing method with the given hasher
+   *
+   * @tparam NewHash New hasher type
+   *
+   * @param hash Hasher
+   *
+   * @return Copy of the current probing method
+   */
+  template <typename NewHash>
+  __host__ __device__ constexpr auto make_copy(NewHash const& hash) const noexcept;
+
+  /**
    * @brief Operator to return a probing iterator
    *
    * @tparam ProbeKey Type of probing key
@@ -109,6 +121,21 @@ class double_hashing : private detail::probing_scheme_base<CGSize> {
    * @param hash2 Second hasher
    */
   __host__ __device__ constexpr double_hashing(Hash1 const& hash1 = {}, Hash2 const& hash2 = {1});
+
+  /**
+   *@brief Makes a copy of the current probing method with the given hasher
+   *
+   * @tparam NewHash1 First new hasher type
+   * @tparam NewHash2 Second new hasher type
+   *
+   * @param hash1 First hasher
+   * @param hash2 second hasher
+   *
+   * @return Copy of the current probing method
+   */
+  template <typename NewHash1, typename NewHash2 = NewHash1>
+  __host__ __device__ constexpr auto make_copy(NewHash1 const& hash1,
+                                               NewHash2 const& hash2 = {1}) const noexcept;
 
   /**
    * @brief Operator to return a probing iterator

--- a/include/cuco/probing_scheme.cuh
+++ b/include/cuco/probing_scheme.cuh
@@ -56,7 +56,8 @@ class linear_probing : private detail::probing_scheme_base<CGSize> {
    * @return Copy of the current probing method
    */
   template <typename NewHash>
-  [[nodiscard]] __host__ __device__ constexpr auto make_copy(NewHash const& hash) const noexcept;
+  [[nodiscard]] __host__ __device__ constexpr auto with_hash_function(
+    NewHash const& hash) const noexcept;
 
   /**
    * @brief Operator to return a probing iterator
@@ -134,9 +135,9 @@ class double_hashing : private detail::probing_scheme_base<CGSize> {
    * @return Copy of the current probing method
    */
   template <typename NewHash1, typename NewHash2 = NewHash1>
-  [[nodiscard]] __host__ __device__ constexpr auto make_copy(NewHash1 const& hash1,
-                                                             NewHash2 const& hash2 = {
-                                                               1}) const noexcept;
+  [[nodiscard]] __host__ __device__ constexpr auto with_hash_function(NewHash1 const& hash1,
+                                                                      NewHash2 const& hash2 = {
+                                                                        1}) const noexcept;
 
   /**
    * @brief Operator to return a probing iterator

--- a/include/cuco/probing_scheme.cuh
+++ b/include/cuco/probing_scheme.cuh
@@ -56,7 +56,7 @@ class linear_probing : private detail::probing_scheme_base<CGSize> {
    * @return Copy of the current probing method
    */
   template <typename NewHash>
-  __host__ __device__ constexpr auto make_copy(NewHash const& hash) const noexcept;
+  [[nodiscard]] __host__ __device__ constexpr auto make_copy(NewHash const& hash) const noexcept;
 
   /**
    * @brief Operator to return a probing iterator
@@ -134,8 +134,9 @@ class double_hashing : private detail::probing_scheme_base<CGSize> {
    * @return Copy of the current probing method
    */
   template <typename NewHash1, typename NewHash2 = NewHash1>
-  __host__ __device__ constexpr auto make_copy(NewHash1 const& hash1,
-                                               NewHash2 const& hash2 = {1}) const noexcept;
+  [[nodiscard]] __host__ __device__ constexpr auto make_copy(NewHash1 const& hash1,
+                                                             NewHash2 const& hash2 = {
+                                                               1}) const noexcept;
 
   /**
    * @brief Operator to return a probing iterator

--- a/include/cuco/static_multiset_ref.cuh
+++ b/include/cuco/static_multiset_ref.cuh
@@ -201,19 +201,30 @@ class static_multiset_ref
   [[nodiscard]] __host__ __device__ auto with(NewOperators... ops) && noexcept;
 
   /**
-   * @brief Makes a copy of the current device reference with given hash and key comparator
+   * @brief Makes a copy of the current device reference with given key comparator
    *
    * @tparam NewKeyEqual The new key equal type
-   * @tparam NewHash The new hasher type
    *
    * @param key_equal New key comparator
+   *
+   * @return Copy of the current device ref
+   */
+  template <typename NewKeyEqual>
+  [[nodiscard]] __host__ __device__ constexpr auto with_key_eq(
+    NewKeyEqual const& key_equal) const noexcept;
+
+  /**
+   * @brief Makes a copy of the current device reference with given hasher
+   *
+   * @tparam NewHash The new hasher type
+   *
    * @param hash New hasher
    *
    * @return Copy of the current device ref
    */
-  template <typename NewKeyEqual, typename NewHash>
-  [[nodiscard]] __host__ __device__ constexpr auto make_copy(NewKeyEqual const& key_equal,
-                                                             NewHash const& hash) const noexcept;
+  template <typename NewHash>
+  [[nodiscard]] __host__ __device__ constexpr auto with_hash_function(
+    NewHash const& hash) const noexcept;
 
  private:
   impl_type impl_;

--- a/include/cuco/static_multiset_ref.cuh
+++ b/include/cuco/static_multiset_ref.cuh
@@ -200,6 +200,21 @@ class static_multiset_ref
   template <typename... NewOperators>
   [[nodiscard]] __host__ __device__ auto with(NewOperators... ops) && noexcept;
 
+  /**
+   * @brief Makes a copy of the current device reference with given hash and key comparator
+   *
+   * @tparam NewKeyEqual The new key equal type
+   * @tparam NewHash The new hasher type
+   *
+   * @param key_equal New key comparator
+   * @param hash New hasher
+   *
+   * @return Copy of the current device ref
+   */
+  template <typename NewKeyEqual, typename NewHash>
+  [[nodiscard]] __host__ __device__ constexpr auto make_copy(NewKeyEqual const& key_equal,
+                                                             NewHash const& hash) const noexcept;
+
  private:
   impl_type impl_;
 

--- a/include/cuco/static_set_ref.cuh
+++ b/include/cuco/static_set_ref.cuh
@@ -224,6 +224,21 @@ class static_set_ref
     cuda_thread_scope<NewScope> scope = {}) const noexcept;
 
   /**
+   * @brief Makes a copy of the current device reference with given hash and key comparator
+   *
+   * @tparam NewKeyEqual The new key equal type
+   * @tparam NewHash The new hasher type
+   *
+   * @param key_equal New key comparator
+   * @param hash New hasher
+   *
+   * @return Copy of the current device ref
+   */
+  template <typename NewKeyEqual, typename NewHash>
+  [[nodiscard]] __host__ __device__ constexpr auto make_copy(NewKeyEqual const& key_equal,
+                                                             NewHash const& hash) const noexcept;
+
+  /**
    * @brief Initializes the set storage using the threads in the group `tile`.
    *
    * @note This function synchronizes the group `tile`.

--- a/include/cuco/static_set_ref.cuh
+++ b/include/cuco/static_set_ref.cuh
@@ -199,6 +199,32 @@ class static_set_ref
   [[nodiscard]] __host__ __device__ auto with(NewOperators... ops) && noexcept;
 
   /**
+   * @brief Makes a copy of the current device reference with given key comparator
+   *
+   * @tparam NewKeyEqual The new key equal type
+   *
+   * @param key_equal New key comparator
+   *
+   * @return Copy of the current device ref
+   */
+  template <typename NewKeyEqual>
+  [[nodiscard]] __host__ __device__ constexpr auto with_key_eq(
+    NewKeyEqual const& key_equal) const noexcept;
+
+  /**
+   * @brief Makes a copy of the current device reference with given hasher
+   *
+   * @tparam NewHash The new hasher type
+   *
+   * @param hash New hasher
+   *
+   * @return Copy of the current device ref
+   */
+  template <typename NewHash>
+  [[nodiscard]] __host__ __device__ constexpr auto with_hash_function(
+    NewHash const& hash) const noexcept;
+
+  /**
    * @brief Makes a copy of the current device reference using non-owned memory
    *
    * This function is intended to be used to create shared memory copies of small static sets,
@@ -222,21 +248,6 @@ class static_set_ref
     CG const& tile,
     window_type* const memory_to_use,
     cuda_thread_scope<NewScope> scope = {}) const noexcept;
-
-  /**
-   * @brief Makes a copy of the current device reference with given hash and key comparator
-   *
-   * @tparam NewKeyEqual The new key equal type
-   * @tparam NewHash The new hasher type
-   *
-   * @param key_equal New key comparator
-   * @param hash New hasher
-   *
-   * @return Copy of the current device ref
-   */
-  template <typename NewKeyEqual, typename NewHash>
-  [[nodiscard]] __host__ __device__ constexpr auto make_copy(NewKeyEqual const& key_equal,
-                                                             NewHash const& hash) const noexcept;
 
   /**
    * @brief Initializes the set storage using the threads in the group `tile`.


### PR DESCRIPTION
Closes #457

This PR adds `with_hash_function` and `with_key_eq` to allow making copies of an existing ref with new hasher and comparator. This is required to enable custom build and key equal for hash table queries.