### PR TITLE
Ensure that `tuple_size` is defined

### DIFF
--- a/include/cuco/detail/pair/traits.hpp
+++ b/include/cuco/detail/pair/traits.hpp
@@ -41,7 +41,8 @@ template <typename T>
 struct is_cuda_std_pair_like<
   T,
   cuda::std::void_t<decltype(cuda::std::get<0>(cuda::std::declval<T>())),
-                    decltype(cuda::std::get<1>(cuda::std::declval<T>()))>>
+                    decltype(cuda::std::get<1>(cuda::std::declval<T>())),
+                    decltype(cuda::std::tuple_size<T>::value)>>
   : cuda::std::conditional_t<cuda::std::tuple_size<T>::value == 2,
                              cuda::std::true_type,
                              cuda::std::false_type> {};
@@ -53,7 +54,8 @@ template <typename T>
 struct is_thrust_pair_like_impl<
   T,
   cuda::std::void_t<decltype(thrust::get<0>(cuda::std::declval<T>())),
-                    decltype(thrust::get<1>(cuda::std::declval<T>()))>>
+                    decltype(thrust::get<1>(cuda::std::declval<T>())),
+                    decltype(thrust::tuple_size<T>::value)>>
   : cuda::std::conditional_t<thrust::tuple_size<T>::value == 2,
                              cuda::std::true_type,
                              cuda::std::false_type> {};

--- a/include/cuco/detail/pair/traits.hpp
+++ b/include/cuco/detail/pair/traits.hpp
@@ -38,11 +38,10 @@ template <typename T, typename = void>
 struct is_cuda_std_pair_like : cuda::std::false_type {};
 
 template <typename T>
-struct is_cuda_std_pair_like<
-  T,
-  cuda::std::void_t<decltype(cuda::std::get<0>(cuda::std::declval<T>())),
-                    decltype(cuda::std::get<1>(cuda::std::declval<T>())),
-                    decltype(cuda::std::tuple_size<T>::value)>>
+struct is_cuda_std_pair_like<T,
+                             cuda::std::void_t<decltype(cuda::std::get<0>(cuda::std::declval<T>())),
+                                               decltype(cuda::std::get<1>(cuda::std::declval<T>())),
+                                               decltype(cuda::std::tuple_size<T>::value)>>
   : cuda::std::conditional_t<cuda::std::tuple_size<T>::value == 2,
                              cuda::std::true_type,
                              cuda::std::false_type> {};
@@ -51,11 +50,10 @@ template <typename T, typename = void>
 struct is_thrust_pair_like_impl : cuda::std::false_type {};
 
 template <typename T>
-struct is_thrust_pair_like_impl<
-  T,
-  cuda::std::void_t<decltype(thrust::get<0>(cuda::std::declval<T>())),
-                    decltype(thrust::get<1>(cuda::std::declval<T>())),
-                    decltype(thrust::tuple_size<T>::value)>>
+struct is_thrust_pair_like_impl<T,
+                                cuda::std::void_t<decltype(thrust::get<0>(cuda::std::declval<T>())),
+                                                  decltype(thrust::get<1>(cuda::std::declval<T>())),
+                                                  decltype(thrust::tuple_size<T>::value)>>
   : cuda::std::conditional_t<thrust::tuple_size<T>::value == 2,
                              cuda::std::true_type,
                              cuda::std::false_type> {};


### PR DESCRIPTION
Some compilers have issues trying to instantiate it too early. We can work around this by adding another SFINAE condition.
