### PR TITLE
Fix dynamic init warning for cuda barrier

### DIFF
--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -302,9 +302,11 @@ class open_addressing_ref_impl {
   {
     auto const num_windows = static_cast<size_type>(this->window_extent());
 #if defined(CUCO_HAS_CUDA_BARRIER)
+#pragma nv_diagnostic push
 // Disables `barrier` initialization warning.
 #pragma nv_diag_suppress static_var_with_dynamic_init
     __shared__ cuda::barrier<cuda::thread_scope::thread_scope_block> barrier;
+#pragma nv_diagnostic pop
     if (g.thread_rank() == 0) { init(&barrier, g.size()); }
     g.sync();
 

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -285,7 +285,7 @@ class open_addressing_ref_impl {
    */
   [[nodiscard]] __host__ __device__ constexpr iterator end() noexcept { return storage_ref_.end(); }
 
-  // Disables `barrier` initialization warning.
+// Disables `barrier` initialization warning.
 #pragma nv_diag_suppress static_var_with_dynamic_init
 
   /**

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -285,11 +285,6 @@ class open_addressing_ref_impl {
    */
   [[nodiscard]] __host__ __device__ constexpr iterator end() noexcept { return storage_ref_.end(); }
 
-#if defined(CUCO_HAS_CUDA_BARRIER)
-// Disables `barrier` initialization warning.
-#pragma nv_diag_suppress static_var_with_dynamic_init
-#endif
-
   /**
    * @brief Makes a copy of the current device reference using non-owned memory.
    *
@@ -307,6 +302,8 @@ class open_addressing_ref_impl {
   {
     auto const num_windows = static_cast<size_type>(this->window_extent());
 #if defined(CUCO_HAS_CUDA_BARRIER)
+// Disables `barrier` initialization warning.
+#pragma nv_diag_suppress static_var_with_dynamic_init
     __shared__ cuda::barrier<cuda::thread_scope::thread_scope_block> barrier;
     if (g.thread_rank() == 0) { init(&barrier, g.size()); }
     g.sync();

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -285,6 +285,9 @@ class open_addressing_ref_impl {
    */
   [[nodiscard]] __host__ __device__ constexpr iterator end() noexcept { return storage_ref_.end(); }
 
+  // Disables `barrier` initialization warning.
+#pragma nv_diag_suppress static_var_with_dynamic_init
+
   /**
    * @brief Makes a copy of the current device reference using non-owned memory.
    *

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -285,8 +285,10 @@ class open_addressing_ref_impl {
    */
   [[nodiscard]] __host__ __device__ constexpr iterator end() noexcept { return storage_ref_.end(); }
 
+#if defined(CUCO_HAS_CUDA_BARRIER)
 // Disables `barrier` initialization warning.
 #pragma nv_diag_suppress static_var_with_dynamic_init
+#endif
 
   /**
    * @brief Makes a copy of the current device reference using non-owned memory.


### PR DESCRIPTION
This PR silences the cuda barrier dynamic initialization warning by using the proper pragma.

The warning comes up when building with nvcc 12.4 but not seen with 12.3 or earlier.