### PR TITLE
Get rid of CUDA __inline__ specifier in test functions

### DIFF
--- a/tests/static_map/insert_or_assign_test.cu
+++ b/tests/static_map/insert_or_assign_test.cu
@@ -32,7 +32,7 @@
 using size_type = std::size_t;
 
 template <typename Map>
-__inline__ void test_insert_or_assign(Map& map, size_type num_keys)
+void test_insert_or_assign(Map& map, size_type num_keys)
 {
   using Key   = typename Map::key_type;
   using Value = typename Map::mapped_type;

--- a/tests/static_map/unique_sequence_test.cu
+++ b/tests/static_map/unique_sequence_test.cu
@@ -36,7 +36,7 @@
 using size_type = int32_t;
 
 template <typename Map>
-__inline__ void test_unique_sequence(Map& map, size_type num_keys)
+void test_unique_sequence(Map& map, size_type num_keys)
 {
   using Key   = typename Map::key_type;
   using Value = typename Map::mapped_type;

--- a/tests/static_multimap/custom_type_test.cu
+++ b/tests/static_multimap/custom_type_test.cu
@@ -58,7 +58,7 @@ struct value_pair {
 };
 
 template <typename Map>
-__inline__ void test_custom_key_value_type(Map& map, std::size_t num_pairs)
+void test_custom_key_value_type(Map& map, std::size_t num_pairs)
 {
   using Key   = key_pair;
   using Value = value_pair;

--- a/tests/static_multimap/insert_if_test.cu
+++ b/tests/static_multimap/insert_if_test.cu
@@ -27,7 +27,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 
 template <typename Key, typename Map, typename PairIt, typename KeyIt>
-__inline__ void test_insert_if(Map& map, PairIt pair_begin, KeyIt key_begin, std::size_t size)
+void test_insert_if(Map& map, PairIt pair_begin, KeyIt key_begin, std::size_t size)
 {
   // 50% insertion
   auto pred_lambda = [] __device__(Key k) { return k % 2 == 0; };

--- a/tests/static_multimap/multiplicity_test.cu
+++ b/tests/static_multimap/multiplicity_test.cu
@@ -30,7 +30,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 
 template <typename Map>
-__inline__ void test_multiplicity_two(Map& map, std::size_t num_items)
+void test_multiplicity_two(Map& map, std::size_t num_items)
 {
   using Key   = typename Map::key_type;
   using Value = typename Map::mapped_type;

--- a/tests/static_multimap/non_match_test.cu
+++ b/tests/static_multimap/non_match_test.cu
@@ -29,7 +29,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 
 template <typename Key, typename Value, typename Map, typename PairIt, typename KeyIt>
-__inline__ void test_non_matches(Map& map, PairIt pair_begin, KeyIt key_begin, std::size_t num_keys)
+void test_non_matches(Map& map, PairIt pair_begin, KeyIt key_begin, std::size_t num_keys)
 {
   map.insert(pair_begin, pair_begin + num_keys);
 

--- a/tests/static_multimap/pair_function_test.cu
+++ b/tests/static_multimap/pair_function_test.cu
@@ -40,7 +40,7 @@ struct pair_equal {
 };
 
 template <typename Key, typename Value, typename Map, typename PairIt>
-__inline__ void test_pair_functions(Map& map, PairIt pair_begin, std::size_t num_pairs)
+void test_pair_functions(Map& map, PairIt pair_begin, std::size_t num_pairs)
 {
   map.insert(pair_begin, pair_begin + num_pairs);
   CUCO_CUDA_TRY(cudaStreamSynchronize(0));

--- a/tests/static_multiset/insert_test.cu
+++ b/tests/static_multiset/insert_test.cu
@@ -30,7 +30,7 @@
 using size_type = int32_t;
 
 template <typename Set>
-__inline__ void test_insert(Set& set)
+void test_insert(Set& set)
 {
   using Key = typename Set::key_type;
 

--- a/tests/static_set/insert_and_find_test.cu
+++ b/tests/static_set/insert_and_find_test.cu
@@ -27,7 +27,7 @@
 #include <cuda/functional>
 
 template <typename Set>
-__inline__ void test_insert_and_find(Set& set, std::size_t num_keys)
+void test_insert_and_find(Set& set, std::size_t num_keys)
 {
   using Key                     = typename Set::key_type;
   static auto constexpr cg_size = Set::cg_size;

--- a/tests/static_set/large_input_test.cu
+++ b/tests/static_set/large_input_test.cu
@@ -30,7 +30,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 
 template <typename Set>
-__inline__ void test_unique_sequence(Set& set, bool* res_begin, std::size_t num_keys)
+void test_unique_sequence(Set& set, bool* res_begin, std::size_t num_keys)
 {
   using Key = typename Set::key_type;
 

--- a/tests/static_set/retrieve_all_test.cu
+++ b/tests/static_set/retrieve_all_test.cu
@@ -28,7 +28,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 
 template <typename Set>
-__inline__ void test_unique_sequence(Set& set, std::size_t num_keys)
+void test_unique_sequence(Set& set, std::size_t num_keys)
 {
   using Key = typename Set::key_type;
 

--- a/tests/static_set/retrieve_test.cu
+++ b/tests/static_set/retrieve_test.cu
@@ -32,7 +32,7 @@
 static constexpr int key_sentinel = -1;
 
 template <typename Set>
-__inline__ void test_unique_sequence(Set& set, std::size_t num_keys)
+void test_unique_sequence(Set& set, std::size_t num_keys)
 {
   using Key = typename Set::key_type;
 

--- a/tests/static_set/unique_sequence_test.cu
+++ b/tests/static_set/unique_sequence_test.cu
@@ -34,7 +34,7 @@
 using size_type = int32_t;
 
 template <typename Set>
-__inline__ void test_unique_sequence(Set& set, size_type num_keys)
+void test_unique_sequence(Set& set, size_type num_keys)
 {
   using Key = typename Set::key_type;
 


### PR DESCRIPTION
This PR removes the `__inline__` specifier for host test functions.
