### PR TITLE
Add ref with_operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ We plan to add many GPU-accelerated, concurrent data structures to `cuCollection
 - [Host-bulk APIs](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_set/host_bulk_example.cu) (see [live example in godbolt](https://godbolt.org/z/fczxbM1h6))
 - [Device-ref APIs for individual operations](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_set/device_ref_example.cu) (see [live example in godbolt](https://godbolt.org/z/zcnGqfdMW))
 - [One single storage for multiple sets](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_set/device_subsets_example.cu) (see [live example in godbolt](https://godbolt.org/z/P9s4fKscj))
-- [Using shared memory as storage](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_set/shared_memory_example.cu) (see [live example in godbolt](https://godbolt.org/z/sTsq7fbjv))
+- [Using shared memory as storage](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_set/shared_memory_example.cu) (see [live example in godbolt](https://godbolt.org/z/4dq58efc8))
 - [Using set as mapping table to handle large keys or indeterministic sentinels](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_set/mapping_table_example.cu) (see [live example in godbolt](https://godbolt.org/z/E1e3j86E4))
 
 ### `static_map`

--- a/README.md
+++ b/README.md
@@ -206,8 +206,8 @@ We plan to add many GPU-accelerated, concurrent data structures to `cuCollection
 #### Examples:
 - [Host-bulk APIs](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_set/host_bulk_example.cu) (see [live example in godbolt](https://godbolt.org/z/fczxbM1h6))
 - [Device-ref APIs for individual operations](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_set/device_ref_example.cu) (see [live example in godbolt](https://godbolt.org/z/zcnGqfdMW))
-- [One single storage for multiple sets](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_set/device_subsets_example.cu) (see [live example in godbolt](https://godbolt.org/z/rYbfxhf73))
-- [Using shared memory as storage](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_set/shared_memory_example.cu) (see [live example in godbolt](https://godbolt.org/z/q5GaW3qYY))
+- [One single storage for multiple sets](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_set/device_subsets_example.cu) (see [live example in godbolt](https://godbolt.org/z/P9s4fKscj))
+- [Using shared memory as storage](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_set/shared_memory_example.cu) (see [live example in godbolt](https://godbolt.org/z/sTsq7fbjv))
 - [Using set as mapping table to handle large keys or indeterministic sentinels](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_set/mapping_table_example.cu) (see [live example in godbolt](https://godbolt.org/z/E1e3j86E4))
 
 ### `static_map`

--- a/examples/static_set/device_subsets_example.cu
+++ b/examples/static_set/device_subsets_example.cu
@@ -86,7 +86,7 @@ __global__ void insert(ref_type* set_refs)
   auto const idx = (blockDim.x * blockIdx.x + threadIdx.x) / cg_size;
 
   auto raw_set_ref    = *(set_refs + idx);
-  auto insert_set_ref = std::move(raw_set_ref).with(cuco::insert);
+  auto insert_set_ref = raw_set_ref.with_operators(cuco::insert);
 
   // Insert `N` elemtns into the set with CG insert
   for (int i = 0; i < N; i++) {
@@ -110,7 +110,7 @@ __global__ void find(ref_type* set_refs)
   auto const idx  = (blockDim.x * blockIdx.x + threadIdx.x) / cg_size;
 
   auto raw_set_ref  = *(set_refs + idx);
-  auto find_set_ref = std::move(raw_set_ref).with(cuco::find);
+  auto find_set_ref = raw_set_ref.with_operators(cuco::find);
 
   // Result denoting if any of the inserted data is not found
   __shared__ int result;

--- a/examples/static_set/shared_memory_example.cu
+++ b/examples/static_set/shared_memory_example.cu
@@ -60,6 +60,7 @@ __global__ void shmem_set_kernel(typename SetRef::extent_type window_extent,
   // Next, we want to check if the keys can be found again using the `contains` function. We create
   // a new non-owning object based on the `insert_ref` that supports `contains` but no longer
   // supports `insert`.
+  // CAVEAT: concurrent use of `insert_ref` and `contains_ref` is undefined behavior.
   auto const contains_ref = insert_ref.with_operators(cuco::contains);
 
   // Check if all keys can be found

--- a/examples/static_set/shared_memory_example.cu
+++ b/examples/static_set/shared_memory_example.cu
@@ -45,11 +45,8 @@ __global__ void shmem_set_kernel(typename SetRef::extent_type window_extent,
   // Synchronize the block to make sure initialization has finished.
   block.sync();
 
-  // The `set` object does not come with any functionality.
-  // We first have to transform it into an object that supports the function we need
-  // (in this case `insert`). This invalidates the old `set` object (move semantics).
-  // With this guard we can make sure that users don't mix operations that are not
-  // safe to use in a concurrent setup.
+  // The `set` object does not come with any functionality. We first have to transform it into an
+  // object that supports the function we need (in this case `insert`).
   auto insert_ref = set.with_operators(cuco::insert);
 
   // Each thread inserts its thread id into the set.
@@ -60,9 +57,9 @@ __global__ void shmem_set_kernel(typename SetRef::extent_type window_extent,
 
   // Synchronize the cta to make sure all insert operations have finished.
   block.sync();
-  // Next, we want to check if the keys can be found again using the `contains` function.
-  // We move the `insert_ref` to a new object that supports `contains` but no longer supports
-  // `insert`.
+  // Next, we want to check if the keys can be found again using the `contains` function. We create
+  // a new non-owning object based on the `insert_ref` that supports `contains` but no longer
+  // supports `insert`.
   auto const contains_ref = insert_ref.with_operators(cuco::contains);
 
   // Check if all keys can be found

--- a/examples/static_set/shared_memory_example.cu
+++ b/examples/static_set/shared_memory_example.cu
@@ -50,7 +50,7 @@ __global__ void shmem_set_kernel(typename SetRef::extent_type window_extent,
   // (in this case `insert`). This invalidates the old `set` object (move semantics).
   // With this guard we can make sure that users don't mix operations that are not
   // safe to use in a concurrent setup.
-  auto insert_ref = std::move(set).with(cuco::insert);
+  auto insert_ref = set.with_operators(cuco::insert);
 
   // Each thread inserts its thread id into the set.
   typename SetRef::key_type const key = block.thread_rank();
@@ -63,7 +63,7 @@ __global__ void shmem_set_kernel(typename SetRef::extent_type window_extent,
   // Next, we want to check if the keys can be found again using the `contains` function.
   // We move the `insert_ref` to a new object that supports `contains` but no longer supports
   // `insert`.
-  auto const contains_ref = std::move(insert_ref).with(cuco::contains);
+  auto const contains_ref = insert_ref.with_operators(cuco::contains);
 
   // Check if all keys can be found
   if (not contains_ref.contains(key)) { printf("ERROR: Key %d not found\n", key); }

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -259,6 +259,32 @@ template <typename Key,
           typename ProbingScheme,
           typename StorageRef,
           typename... Operators>
+template <typename... NewOperators>
+__host__ __device__ auto constexpr static_map_ref<Key,
+                                                  T,
+                                                  Scope,
+                                                  KeyEqual,
+                                                  ProbingScheme,
+                                                  StorageRef,
+                                                  Operators...>::with_operators(NewOperators...)
+  const noexcept
+{
+  return static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, NewOperators...>{
+    cuco::empty_key<Key>{this->empty_key_sentinel()},
+    cuco::empty_value<T>{this->empty_value_sentinel()},
+    this->key_eq(),
+    this->impl_.probing_scheme(),
+    {},
+    this->impl_.storage_ref()};
+}
+
+template <typename Key,
+          typename T,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
 template <typename CG, cuda::thread_scope NewScope>
 __device__ constexpr auto
 static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::make_copy(

--- a/include/cuco/detail/static_multiset/static_multiset_ref.inl
+++ b/include/cuco/detail/static_multiset/static_multiset_ref.inl
@@ -217,6 +217,25 @@ template <typename Key,
           typename ProbingScheme,
           typename StorageRef,
           typename... Operators>
+template <typename... NewOperators>
+__host__ __device__ constexpr auto
+static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::with_operators(
+  NewOperators...) const noexcept
+{
+  return static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, NewOperators...>{
+    cuco::empty_key<Key>{this->empty_key_sentinel()},
+    this->key_eq(),
+    this->impl_.probing_scheme(),
+    {},
+    this->impl_.storage_ref()};
+}
+
+template <typename Key,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
 template <typename NewKeyEqual>
 __host__ __device__ constexpr auto
 static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::with_key_eq(

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -216,6 +216,25 @@ template <typename Key,
           typename ProbingScheme,
           typename StorageRef,
           typename... Operators>
+template <typename... NewOperators>
+__host__ __device__ constexpr auto
+static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::with_operators(
+  NewOperators...) const noexcept
+{
+  return static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, NewOperators...>{
+    cuco::empty_key<Key>{this->empty_key_sentinel()},
+    this->key_eq(),
+    this->impl_.probing_scheme(),
+    {},
+    this->impl_.storage_ref()};
+}
+
+template <typename Key,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
 template <typename NewKeyEqual>
 __host__ __device__ constexpr auto
 static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::with_key_eq(

--- a/include/cuco/static_map_ref.cuh
+++ b/include/cuco/static_map_ref.cuh
@@ -221,6 +221,22 @@ class static_map_ref
   [[nodiscard]] __host__ __device__ auto with(NewOperators... ops) && noexcept;
 
   /**
+   * @brief Creates a reference with new operators from the current object
+   *
+   * @warning Using two or more reference objects to the same container but with
+   * a different operator set at the same time results in undefined behavior.
+   *
+   * @tparam NewOperators List of `cuco::op::*_tag` types
+   *
+   * @param ops List of operators, e.g., `cuco::insert`
+   *
+   * @return `*this` with `NewOperators...`
+   */
+  template <typename... NewOperators>
+  [[nodiscard]] __host__ __device__ constexpr auto with_operators(
+    NewOperators... ops) const noexcept;
+
+  /**
    * @brief Makes a copy of the current device reference using non-owned memory
    *
    * This function is intended to be used to create shared memory copies of small static maps,

--- a/include/cuco/static_map_ref.cuh
+++ b/include/cuco/static_map_ref.cuh
@@ -206,6 +206,8 @@ class static_map_ref
   /**
    * @brief Creates a reference with new operators from the current object.
    *
+   * @deprecated This function is deprecated. Use the new `with_operators` instead.
+   *
    * Note that this function uses move semantics and thus invalidates the current object.
    *
    * @warning Using two or more reference objects to the same container but with

--- a/include/cuco/static_multiset_ref.cuh
+++ b/include/cuco/static_multiset_ref.cuh
@@ -186,6 +186,8 @@ class static_multiset_ref
   /**
    * @brief Creates a reference with new operators from the current object.
    *
+   * @deprecated This function is deprecated. Use the new `with_operators` instead.
+   *
    * Note that this function uses move semantics and thus invalidates the current object.
    *
    * @warning Using two or more reference objects to the same container but with

--- a/include/cuco/static_multiset_ref.cuh
+++ b/include/cuco/static_multiset_ref.cuh
@@ -201,6 +201,22 @@ class static_multiset_ref
   [[nodiscard]] __host__ __device__ auto with(NewOperators... ops) && noexcept;
 
   /**
+   * @brief Creates a reference with new operators from the current object
+   *
+   * @warning Using two or more reference objects to the same container but with
+   * a different operator set at the same time results in undefined behavior.
+   *
+   * @tparam NewOperators List of `cuco::op::*_tag` types
+   *
+   * @param ops List of operators, e.g., `cuco::insert`
+   *
+   * @return `*this` with `NewOperators...`
+   */
+  template <typename... NewOperators>
+  [[nodiscard]] __host__ __device__ constexpr auto with_operators(
+    NewOperators... ops) const noexcept;
+
+  /**
    * @brief Makes a copy of the current device reference with given key comparator
    *
    * @tparam NewKeyEqual The new key equal type

--- a/include/cuco/static_set_ref.cuh
+++ b/include/cuco/static_set_ref.cuh
@@ -184,6 +184,8 @@ class static_set_ref
   /**
    * @brief Creates a reference with new operators from the current object.
    *
+   * @deprecated This function is deprecated. Use the new `with_operators` instead.
+   *
    * Note that this function uses move semantics and thus invalidates the current object.
    *
    * @warning Using two or more reference objects to the same container but with

--- a/include/cuco/static_set_ref.cuh
+++ b/include/cuco/static_set_ref.cuh
@@ -199,6 +199,22 @@ class static_set_ref
   [[nodiscard]] __host__ __device__ auto with(NewOperators... ops) && noexcept;
 
   /**
+   * @brief Creates a reference with new operators from the current object
+   *
+   * @warning Using two or more reference objects to the same container but with
+   * a different operator set at the same time results in undefined behavior.
+   *
+   * @tparam NewOperators List of `cuco::op::*_tag` types
+   *
+   * @param ops List of operators, e.g., `cuco::insert`
+   *
+   * @return `*this` with `NewOperators...`
+   */
+  template <typename... NewOperators>
+  [[nodiscard]] __host__ __device__ constexpr auto with_operators(
+    NewOperators... ops) const noexcept;
+
+  /**
    * @brief Makes a copy of the current device reference with given key comparator
    *
    * @tparam NewKeyEqual The new key equal type

--- a/tests/static_map/shared_memory_test.cu
+++ b/tests/static_map/shared_memory_test.cu
@@ -47,7 +47,7 @@ __global__ void shared_memory_test_kernel(Ref* maps,
 
   auto g          = cuco::test::cg::this_thread_block();
   auto insert_ref = maps[map_id].make_copy(g, sm_buffer, cuco::thread_scope_block);
-  auto find_ref   = std::move(insert_ref).with(cuco::op::find);
+  auto find_ref   = insert_ref.with_operators(cuco::op::find);
 
   for (int i = g.thread_rank(); i < number_of_elements; i += g.size()) {
     auto found_pair_it = find_ref.find(insterted_keys[offset + i]);
@@ -197,11 +197,11 @@ __global__ void shared_memory_hash_table_kernel(bool* key_found)
   auto const rank  = block.thread_rank();
 
   // insert {thread_rank, thread_rank} for each thread in thread-block
-  auto insert_ref = std::move(raw_ref).with(cuco::op::insert);
+  auto insert_ref = raw_ref.with_operators(cuco::op::insert);
   insert_ref.insert(slot_type{rank, rank});
   block.sync();
 
-  auto find_ref             = std::move(insert_ref).with(cuco::op::find);
+  auto find_ref             = insert_ref.with_operators(cuco::op::find);
   auto const retrieved_pair = find_ref.find(rank);
   block.sync();
 

--- a/tests/static_set/shared_memory_test.cu
+++ b/tests/static_set/shared_memory_test.cu
@@ -46,7 +46,7 @@ __global__ void shared_memory_test_kernel(Ref* sets,
 
   auto g          = cuco::test::cg::this_thread_block();
   auto insert_ref = sets[set_id].make_copy(g, sm_buffer, cuco::thread_scope_block);
-  auto find_ref   = std::move(insert_ref).with(cuco::op::find);
+  auto find_ref   = insert_ref.with_operators(cuco::op::find);
 
   for (int i = g.thread_rank(); i < number_of_elements; i += g.size()) {
     auto found_it = find_ref.find(insterted_keys[offset + i]);
@@ -177,11 +177,11 @@ __global__ void shared_memory_hash_set_kernel(bool* key_found)
   auto const rank  = block.thread_rank();
 
   // insert {thread_rank, thread_rank} for each thread in thread-block
-  auto insert_ref = std::move(raw_ref).with(cuco::op::insert);
+  auto insert_ref = raw_ref.with_operators(cuco::op::insert);
   insert_ref.insert(rank);
   block.sync();
 
-  auto find_ref           = std::move(insert_ref).with(cuco::op::find);
+  auto find_ref           = insert_ref.with_operators(cuco::op::find);
   auto const retrieved_it = find_ref.find(rank);
   block.sync();
 


### PR DESCRIPTION
Address https://github.com/NVIDIA/cuCollections/pull/467#discussion_r1580274993

This PR adds new `with_operators` ref APIs. They replace the legacy `with` APIs without moving the old ref object. The legacy APIs will be deprecated once all RAPIDS projects use the new APIs.