### PR TITLE
Add launch bounds to kernels

### DIFF
--- a/include/cuco/detail/open_addressing/kernels.cuh
+++ b/include/cuco/detail/open_addressing/kernels.cuh
@@ -61,12 +61,12 @@ template <int32_t CGSize,
           typename Predicate,
           typename AtomicT,
           typename Ref>
-CUCO_KERNEL void insert_if_n(InputIt first,
-                             cuco::detail::index_type n,
-                             StencilIt stencil,
-                             Predicate pred,
-                             AtomicT* num_successes,
-                             Ref ref)
+CUCO_KERNEL __launch_bounds__(BlockSize) void insert_if_n(InputIt first,
+                                                          cuco::detail::index_type n,
+                                                          StencilIt stencil,
+                                                          Predicate pred,
+                                                          AtomicT* num_successes,
+                                                          Ref ref)
 {
   using BlockReduce = cub::BlockReduce<typename Ref::size_type, BlockSize>;
   __shared__ typename BlockReduce::TempStorage temp_storage;
@@ -127,7 +127,7 @@ template <int32_t CGSize,
           typename StencilIt,
           typename Predicate,
           typename Ref>
-CUCO_KERNEL void insert_if_n(
+CUCO_KERNEL __launch_bounds__(BlockSize) void insert_if_n(
   InputIt first, cuco::detail::index_type n, StencilIt stencil, Predicate pred, Ref ref)
 {
   auto const loop_stride = cuco::detail::grid_stride() / CGSize;
@@ -162,7 +162,9 @@ CUCO_KERNEL void insert_if_n(
  * @param ref Non-owning container device ref used to access the slot storage
  */
 template <int32_t CGSize, int32_t BlockSize, typename InputIt, typename Ref>
-CUCO_KERNEL void erase(InputIt first, cuco::detail::index_type n, Ref ref)
+CUCO_KERNEL __launch_bounds__(BlockSize) void erase(InputIt first,
+                                                    cuco::detail::index_type n,
+                                                    Ref ref)
 {
   auto const loop_stride = cuco::detail::grid_stride() / CGSize;
   auto idx               = cuco::detail::global_thread_id() / CGSize;
@@ -212,12 +214,12 @@ template <int32_t CGSize,
           typename Predicate,
           typename OutputIt,
           typename Ref>
-CUCO_KERNEL void contains_if_n(InputIt first,
-                               cuco::detail::index_type n,
-                               StencilIt stencil,
-                               Predicate pred,
-                               OutputIt output_begin,
-                               Ref ref)
+CUCO_KERNEL __launch_bounds__(BlockSize) void contains_if_n(InputIt first,
+                                                            cuco::detail::index_type n,
+                                                            StencilIt stencil,
+                                                            Predicate pred,
+                                                            OutputIt output_begin,
+                                                            Ref ref)
 {
   namespace cg = cooperative_groups;
 
@@ -274,7 +276,10 @@ CUCO_KERNEL void contains_if_n(InputIt first,
  * @param ref Non-owning container device ref used to access the slot storage
  */
 template <int32_t CGSize, int32_t BlockSize, typename InputIt, typename OutputIt, typename Ref>
-CUCO_KERNEL void find(InputIt first, cuco::detail::index_type n, OutputIt output_begin, Ref ref)
+CUCO_KERNEL __launch_bounds__(BlockSize) void find(InputIt first,
+                                                   cuco::detail::index_type n,
+                                                   OutputIt output_begin,
+                                                   Ref ref)
 {
   namespace cg = cooperative_groups;
 
@@ -342,7 +347,9 @@ CUCO_KERNEL void find(InputIt first, cuco::detail::index_type n, OutputIt output
  * @param count Number of filled slots
  */
 template <int32_t BlockSize, typename StorageRef, typename Predicate, typename AtomicT>
-CUCO_KERNEL void size(StorageRef storage, Predicate is_filled, AtomicT* count)
+CUCO_KERNEL __launch_bounds__(BlockSize) void size(StorageRef storage,
+                                                   Predicate is_filled,
+                                                   AtomicT* count)
 {
   using size_type = typename StorageRef::size_type;
 
@@ -368,9 +375,10 @@ CUCO_KERNEL void size(StorageRef storage, Predicate is_filled, AtomicT* count)
 }
 
 template <int32_t BlockSize, typename ContainerRef, typename Predicate>
-CUCO_KERNEL void rehash(typename ContainerRef::storage_ref_type storage_ref,
-                        ContainerRef container_ref,
-                        Predicate is_filled)
+CUCO_KERNEL __launch_bounds__(BlockSize) void rehash(
+  typename ContainerRef::storage_ref_type storage_ref,
+  ContainerRef container_ref,
+  Predicate is_filled)
 {
   namespace cg = cooperative_groups;
 

--- a/include/cuco/detail/static_map/kernels.cuh
+++ b/include/cuco/detail/static_map/kernels.cuh
@@ -47,7 +47,9 @@ CUCO_SUPPRESS_KERNEL_WARNINGS
  * @param ref Non-owning container device ref used to access the slot storage
  */
 template <int32_t CGSize, int32_t BlockSize, typename InputIt, typename Ref>
-CUCO_KERNEL void insert_or_assign(InputIt first, cuco::detail::index_type n, Ref ref)
+CUCO_KERNEL __launch_bounds__(BlockSize) void insert_or_assign(InputIt first,
+                                                               cuco::detail::index_type n,
+                                                               Ref ref)
 {
   auto const loop_stride = cuco::detail::grid_stride() / CGSize;
   auto idx               = cuco::detail::global_thread_id() / CGSize;

--- a/include/cuco/detail/static_set/kernels.cuh
+++ b/include/cuco/detail/static_set/kernels.cuh
@@ -267,12 +267,12 @@ template <int32_t BlockSize,
           typename OutputIt2,
           typename AtomicT,
           typename Ref>
-CUCO_KERNEL void retrieve(InputIt first,
-                          cuco::detail::index_type n,
-                          OutputIt1 output_probe,
-                          OutputIt2 output_match,
-                          AtomicT* counter,
-                          Ref ref)
+CUCO_KERNEL __launch_bounds__(BlockSize) void retrieve(InputIt first,
+                                                       cuco::detail::index_type n,
+                                                       OutputIt1 output_probe,
+                                                       OutputIt2 output_match,
+                                                       AtomicT* counter,
+                                                       Ref ref)
 {
   // Scalar retrieve without using CG
   if constexpr (Ref::cg_size == 1) {


### PR DESCRIPTION
What the description says.

I wasn't able to observe any performance differences after adding this annotation.
However, it is best-practice since it passes more information to the compiler that can be potentially used for (future) optimizations.