### PR TITLE
Fix a build warning with ARM

### DIFF
--- a/include/cuco/detail/static_map_kernels.cuh
+++ b/include/cuco/detail/static_map_kernels.cuh
@@ -445,6 +445,7 @@ CUCO_KERNEL void find(
   int64_t idx               = (block_size * blockIdx.x + threadIdx.x) / tile_size;
 #pragma nv_diagnostic push
 #pragma nv_diag_suppress static_var_with_dynamic_init
+// Get rid of a false-positive build warning with ARM
   __shared__ Value writeBuffer[block_size / tile_size];
 #pragma nv_diagnostic pop
 

--- a/include/cuco/detail/static_map_kernels.cuh
+++ b/include/cuco/detail/static_map_kernels.cuh
@@ -443,7 +443,10 @@ CUCO_KERNEL void find(
   auto tile                 = cg::tiled_partition<tile_size>(cg::this_thread_block());
   int64_t const loop_stride = gridDim.x * block_size / tile_size;
   int64_t idx               = (block_size * blockIdx.x + threadIdx.x) / tile_size;
+#pragma nv_diagnostic push
+#pragma nv_diag_suppress static_var_with_dynamic_init
   __shared__ Value writeBuffer[block_size / tile_size];
+#pragma nv_diagnostic pop
 
   while (idx < n) {
     auto key   = *(first + idx);

--- a/include/cuco/detail/static_map_kernels.cuh
+++ b/include/cuco/detail/static_map_kernels.cuh
@@ -445,7 +445,7 @@ CUCO_KERNEL void find(
   int64_t idx               = (block_size * blockIdx.x + threadIdx.x) / tile_size;
 #pragma nv_diagnostic push
 #pragma nv_diag_suppress static_var_with_dynamic_init
-// Get rid of a false-positive build warning with ARM
+  // Get rid of a false-positive build warning with ARM
   __shared__ Value writeBuffer[block_size / tile_size];
 #pragma nv_diagnostic pop
 


### PR DESCRIPTION
Fixes a build warning with ARM
```bash
/home/coder/cuCollections/include/cuco/detail/static_map_kernels.cuh(446): warning #20054-D: dynamic initialization is not supported for a function-scope static __shared__ variable within a __device__/__global__ function
395
              Value writeBuffer[block_size / tile_size];