### PR TITLE
Add murmurhash3_x86_128 hash 

### DIFF
--- a/benchmarks/hash_bench.cu
+++ b/benchmarks/hash_bench.cu
@@ -52,6 +52,16 @@ constexpr __host__ __device__ void hash_result_aggregate(cuda::std::array<uint64
   agg[1] += hash_val[1];
 }
 
+template <>
+constexpr __host__ __device__ void hash_result_aggregate(cuda::std::array<uint32_t, 4>& agg,
+                                                         cuda::std::array<uint32_t, 4> hash_val)
+{
+  agg[0] += hash_val[0];
+  agg[1] += hash_val[1];
+  agg[2] += hash_val[2];
+  agg[3] += hash_val[3];
+}
+
 template <int32_t BlockSize, typename Hasher, typename OutputIt>
 __global__ void hash_bench_kernel(Hasher hash,
                                   cuco::detail::index_type n,
@@ -109,6 +119,9 @@ NVBENCH_BENCH_TYPES(
                                        cuco::xxhash_64<large_key<32>>,
                                        cuco::murmurhash3_fmix_32<nvbench::int32_t>,
                                        cuco::murmurhash3_fmix_64<nvbench::int64_t>,
+                                       cuco::murmurhash3_x86_128<nvbench::int32_t>,
+                                       cuco::murmurhash3_x86_128<nvbench::int64_t>,
+                                       cuco::murmurhash3_x86_128<large_key<32>>,
                                        cuco::murmurhash3_x64_128<nvbench::int32_t>,
                                        cuco::murmurhash3_x64_128<nvbench::int64_t>,
                                        cuco::murmurhash3_x64_128<large_key<32>>>))

--- a/include/cuco/detail/hash_functions/murmurhash3.cuh
+++ b/include/cuco/detail/hash_functions/murmurhash3.cuh
@@ -348,11 +348,6 @@ struct MurmurHash3_x64_128 {
   }
 
  private:
-  constexpr __host__ __device__ std::uint64_t rotl64(std::uint64_t x, std::int8_t r) const noexcept
-  {
-    return (x << r) | (x >> (64 - r));
-  }
-
   MurmurHash3_fmix64<std::uint64_t> fmix64_;
   std::uint64_t seed_;
 };
@@ -550,11 +545,6 @@ struct MurmurHash3_x86_128 {
   }
 
  private:
-  constexpr __host__ __device__ std::uint32_t rotl32(std::uint32_t x, std::int8_t r) const noexcept
-  {
-    return (x << r) | (x >> (32 - r));
-  }
-
   MurmurHash3_fmix32<std::uint32_t> fmix32_;
   std::uint32_t seed_;
 };

--- a/include/cuco/detail/hash_functions/murmurhash3.cuh
+++ b/include/cuco/detail/hash_functions/murmurhash3.cuh
@@ -20,10 +20,10 @@
 #include <cuco/extent.cuh>
 
 #include <cuda/std/array>
+#include <cuda/std/type_traits>
 
 #include <cstddef>
 #include <cstdint>
-#include <type_traits>
 
 namespace cuco::detail {
 
@@ -170,7 +170,7 @@ struct MurmurHash3_32 {
     constexpr std::uint32_t c2 = 0x1b873593;
     //----------
     // body
-    for (std::remove_const_t<decltype(nblocks)> i = 0; size >= 4 && i < nblocks; i++) {
+    for (cuda::std::remove_const_t<decltype(nblocks)> i = 0; size >= 4 && i < nblocks; i++) {
       std::uint32_t k1 = load_chunk<std::uint32_t>(bytes, i);
       k1 *= c1;
       k1 = rotl32(k1, 15);
@@ -273,7 +273,8 @@ struct MurmurHash3_x64_128 {
     constexpr std::uint64_t c2 = 0x4cf5ad432745937full;
     //----------
     // body
-    for (std::remove_const_t<decltype(nblocks)> i = 0; size >= block_size && i < nblocks; i++) {
+    for (cuda::std::remove_const_t<decltype(nblocks)> i = 0; size >= block_size && i < nblocks;
+         i++) {
       std::uint64_t k1 = load_chunk<std::uint64_t>(bytes, 2 * i);
       std::uint64_t k2 = load_chunk<std::uint64_t>(bytes, 2 * i + 1);
 
@@ -425,7 +426,8 @@ struct MurmurHash3_x86_128 {
     constexpr std::uint32_t c4 = 0xa1e38b93;
     //----------
     // body
-    for (std::remove_const_t<decltype(nblocks)> i = 0; size >= block_size && i < nblocks; i++) {
+    for (cuda::std::remove_const_t<decltype(nblocks)> i = 0; size >= block_size && i < nblocks;
+         i++) {
       std::uint32_t k1 = load_chunk<std::uint32_t>(bytes, 4 * i);
       std::uint32_t k2 = load_chunk<std::uint32_t>(bytes, 4 * i + 1);
       std::uint32_t k3 = load_chunk<std::uint32_t>(bytes, 4 * i + 2);

--- a/include/cuco/detail/hash_functions/utils.cuh
+++ b/include/cuco/detail/hash_functions/utils.cuh
@@ -27,4 +27,14 @@ constexpr __host__ __device__ T load_chunk(U const* const data, Extent index) no
   return chunk;
 }
 
+constexpr __host__ __device__ std::uint32_t rotl32(std::uint32_t x, std::int8_t r) noexcept
+{
+  return (x << r) | (x >> (32 - r));
+}
+
+constexpr __host__ __device__ std::uint64_t rotl64(std::uint64_t x, std::int8_t r) noexcept
+{
+  return (x << r) | (x >> (64 - r));
+}
+
 };  // namespace cuco::detail

--- a/include/cuco/detail/hash_functions/xxhash.cuh
+++ b/include/cuco/detail/hash_functions/xxhash.cuh
@@ -127,21 +127,21 @@ struct XXHash_32 {
         // pipeline 4*4byte computations
         auto const pipeline_offset = offset / 4;
         v1 += load_chunk<std::uint32_t>(bytes, pipeline_offset + 0) * prime2;
-        v1 = rotl(v1, 13);
+        v1 = rotl32(v1, 13);
         v1 *= prime1;
         v2 += load_chunk<std::uint32_t>(bytes, pipeline_offset + 1) * prime2;
-        v2 = rotl(v2, 13);
+        v2 = rotl32(v2, 13);
         v2 *= prime1;
         v3 += load_chunk<std::uint32_t>(bytes, pipeline_offset + 2) * prime2;
-        v3 = rotl(v3, 13);
+        v3 = rotl32(v3, 13);
         v3 *= prime1;
         v4 += load_chunk<std::uint32_t>(bytes, pipeline_offset + 3) * prime2;
-        v4 = rotl(v4, 13);
+        v4 = rotl32(v4, 13);
         v4 *= prime1;
         offset += 16;
       } while (offset <= limit);
 
-      h32 = rotl(v1, 1) + rotl(v2, 7) + rotl(v3, 12) + rotl(v4, 18);
+      h32 = rotl32(v1, 1) + rotl32(v2, 7) + rotl32(v3, 12) + rotl32(v4, 18);
     } else {
       h32 = seed_ + prime5;
     }
@@ -152,7 +152,7 @@ struct XXHash_32 {
     if ((size % 16) >= 4) {
       for (; offset <= size - 4; offset += 4) {
         h32 += load_chunk<std::uint32_t>(bytes, offset / 4) * prime3;
-        h32 = rotl(h32, 17) * prime4;
+        h32 = rotl32(h32, 17) * prime4;
       }
     }
 
@@ -160,7 +160,7 @@ struct XXHash_32 {
     if (size % 4) {
       while (offset < size) {
         h32 += (std::to_integer<std::uint32_t>(bytes[offset]) & 255) * prime5;
-        h32 = rotl(h32, 11) * prime1;
+        h32 = rotl32(h32, 11) * prime1;
         ++offset;
       }
     }
@@ -169,11 +169,6 @@ struct XXHash_32 {
   }
 
  private:
-  constexpr __host__ __device__ std::uint32_t rotl(std::uint32_t h, std::int8_t r) const noexcept
-  {
-    return ((h << r) | (h >> (32 - r)));
-  }
-
   // avalanche helper
   constexpr __host__ __device__ std::uint32_t finalize(std::uint32_t h) const noexcept
   {
@@ -295,42 +290,42 @@ struct XXHash_64 {
         // pipeline 4*8byte computations
         auto const pipeline_offset = offset / 8;
         v1 += load_chunk<std::uint64_t>(bytes, pipeline_offset + 0) * prime2;
-        v1 = rotl(v1, 31);
+        v1 = rotl64(v1, 31);
         v1 *= prime1;
         v2 += load_chunk<std::uint64_t>(bytes, pipeline_offset + 1) * prime2;
-        v2 = rotl(v2, 31);
+        v2 = rotl64(v2, 31);
         v2 *= prime1;
         v3 += load_chunk<std::uint64_t>(bytes, pipeline_offset + 2) * prime2;
-        v3 = rotl(v3, 31);
+        v3 = rotl64(v3, 31);
         v3 *= prime1;
         v4 += load_chunk<std::uint64_t>(bytes, pipeline_offset + 3) * prime2;
-        v4 = rotl(v4, 31);
+        v4 = rotl64(v4, 31);
         v4 *= prime1;
         offset += 32;
       } while (offset <= limit);
 
-      h64 = rotl(v1, 1) + rotl(v2, 7) + rotl(v3, 12) + rotl(v4, 18);
+      h64 = rotl64(v1, 1) + rotl64(v2, 7) + rotl64(v3, 12) + rotl64(v4, 18);
 
       v1 *= prime2;
-      v1 = rotl(v1, 31);
+      v1 = rotl64(v1, 31);
       v1 *= prime1;
       h64 ^= v1;
       h64 = h64 * prime1 + prime4;
 
       v2 *= prime2;
-      v2 = rotl(v2, 31);
+      v2 = rotl64(v2, 31);
       v2 *= prime1;
       h64 ^= v2;
       h64 = h64 * prime1 + prime4;
 
       v3 *= prime2;
-      v3 = rotl(v3, 31);
+      v3 = rotl64(v3, 31);
       v3 *= prime1;
       h64 ^= v3;
       h64 = h64 * prime1 + prime4;
 
       v4 *= prime2;
-      v4 = rotl(v4, 31);
+      v4 = rotl64(v4, 31);
       v4 *= prime1;
       h64 ^= v4;
       h64 = h64 * prime1 + prime4;
@@ -344,9 +339,9 @@ struct XXHash_64 {
     if ((size % 32) >= 8) {
       for (; offset <= size - 8; offset += 8) {
         std::uint64_t k1 = load_chunk<std::uint64_t>(bytes, offset / 8) * prime2;
-        k1               = rotl(k1, 31) * prime1;
+        k1               = rotl64(k1, 31) * prime1;
         h64 ^= k1;
-        h64 = rotl(h64, 27) * prime1 + prime4;
+        h64 = rotl64(h64, 27) * prime1 + prime4;
       }
     }
 
@@ -354,7 +349,7 @@ struct XXHash_64 {
     if ((size % 8) >= 4) {
       for (; offset <= size - 4; offset += 4) {
         h64 ^= (load_chunk<std::uint32_t>(bytes, offset / 4) & 0xffffffffull) * prime1;
-        h64 = rotl(h64, 23) * prime2 + prime3;
+        h64 = rotl64(h64, 23) * prime2 + prime3;
       }
     }
 
@@ -363,7 +358,7 @@ struct XXHash_64 {
     if (size % 4) {
       while (offset < size) {
         h64 ^= (std::to_integer<std::uint32_t>(bytes[offset]) & 0xff) * prime5;
-        h64 = rotl(h64, 11) * prime1;
+        h64 = rotl64(h64, 11) * prime1;
         ++offset;
       }
     }
@@ -371,11 +366,6 @@ struct XXHash_64 {
   }
 
  private:
-  constexpr __host__ __device__ std::uint64_t rotl(std::uint64_t h, std::int8_t r) const noexcept
-  {
-    return ((h << r) | (h >> (64 - r)));
-  }
-
   // avalanche helper
   constexpr __host__ __device__ std::uint64_t finalize(std::uint64_t h) const noexcept
   {

--- a/include/cuco/hash_functions.cuh
+++ b/include/cuco/hash_functions.cuh
@@ -60,6 +60,14 @@ template <typename Key>
 using murmurhash3_x64_128 = detail::MurmurHash3_x64_128<Key>;
 
 /**
+ * @brief A 128-bit `MurmurHash3` hash function to hash the given argument on host and device.
+ *
+ * @tparam Key The type of the values to hash
+ */
+template <typename Key>
+using murmurhash3_x86_128 = detail::MurmurHash3_x86_128<Key>;
+
+/**
  * @brief A 32-bit `XXH32` hash function to hash the given argument on host and device.
  *
  * @tparam Key The type of the values to hash

--- a/tests/utility/hash_test.cu
+++ b/tests/utility/hash_test.cu
@@ -238,6 +238,43 @@ __global__ void check_murmurhash3_128_result_kernel(OutputIter result)
       {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
       1024,
       {15409921801541329777ull, 10546487400963404004ull});
+
+  result[i++] = check_hash_result<cuco::murmurhash3_x86_128<int32_t>, uint32_t>(
+    0, 0, {3422973727, 2656139328, 2656139328, 2656139328});
+  result[i++] = check_hash_result<cuco::murmurhash3_x86_128<int32_t>, uint32_t>(
+    9, 0, {2808089785, 314604614, 314604614, 314604614});
+  result[i++] = check_hash_result<cuco::murmurhash3_x86_128<int32_t>, uint32_t>(
+    42, 0, {3611919118, 1962256489, 1962256489, 1962256489});
+  result[i++] = check_hash_result<cuco::murmurhash3_x86_128<int32_t>, uint32_t>(
+    42, 42, {3399017053, 732469929, 732469929, 732469929});
+  result[i++] =
+    check_hash_result<cuco::murmurhash3_x86_128<cuda::std::array<int32_t, 2>>, uint32_t>(
+      {2, 2}, 0, {1234494082, 1431451587, 431049201, 431049201});
+  result[i++] =
+    check_hash_result<cuco::murmurhash3_x86_128<cuda::std::array<int32_t, 3>>, uint32_t>(
+      {1, 4, 9}, 42, {2516796247, 2757675829, 778406919, 2453259553});
+  result[i++] =
+    check_hash_result<cuco::murmurhash3_x86_128<cuda::std::array<int32_t, 4>>, uint32_t>(
+      {42, 64, 108, 1024}, 63, {2686265656, 591236665, 3797082165, 2731908938});
+  result[i++] =
+    check_hash_result<cuco::murmurhash3_x86_128<cuda::std::array<int32_t, 16>>, uint32_t>(
+      {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+      1024,
+      {3918256832, 4205523739, 1707810111, 1625952473});
+  result[i++] =
+    check_hash_result<cuco::murmurhash3_x86_128<cuda::std::array<int64_t, 2>>, uint32_t>(
+      {2, 2}, 0, {3811075945, 727160712, 3510740342, 235225510});
+  result[i++] =
+    check_hash_result<cuco::murmurhash3_x86_128<cuda::std::array<int64_t, 3>>, uint32_t>(
+      {1, 4, 9}, 42, {2817194959, 206796677, 3391242768, 248681098});
+  result[i++] =
+    check_hash_result<cuco::murmurhash3_x86_128<cuda::std::array<int64_t, 4>>, uint32_t>(
+      {42, 64, 108, 1024}, 63, {2335912146, 1566515912, 760710030, 452077451});
+  result[i++] =
+    check_hash_result<cuco::murmurhash3_x86_128<cuda::std::array<int64_t, 16>>, uint32_t>(
+      {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+      1024,
+      {1101169764, 1758958147, 2406511780, 2903571412});
 }
 
 TEST_CASE("Test cuco::murmurhash3_x64_128", "")
@@ -275,11 +312,40 @@ TEST_CASE("Test cuco::murmurhash3_x64_128", "")
       {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
       1024,
       {15409921801541329777ull, 10546487400963404004ull}));
+
+    CHECK(check_hash_result<cuco::murmurhash3_x86_128<int32_t>, uint32_t>(
+      0, 0, {3422973727, 2656139328, 2656139328, 2656139328}));
+    CHECK(check_hash_result<cuco::murmurhash3_x86_128<int32_t>, uint32_t>(
+      9, 0, {2808089785, 314604614, 314604614, 314604614}));
+    CHECK(check_hash_result<cuco::murmurhash3_x86_128<int32_t>, uint32_t>(
+      42, 0, {3611919118, 1962256489, 1962256489, 1962256489}));
+    CHECK(check_hash_result<cuco::murmurhash3_x86_128<int32_t>, uint32_t>(
+      42, 42, {3399017053, 732469929, 732469929, 732469929}));
+    CHECK(check_hash_result<cuco::murmurhash3_x86_128<cuda::std::array<int32_t, 2>>, uint32_t>(
+      {2, 2}, 0, {1234494082, 1431451587, 431049201, 431049201}));
+    CHECK(check_hash_result<cuco::murmurhash3_x86_128<cuda::std::array<int32_t, 3>>, uint32_t>(
+      {1, 4, 9}, 42, {2516796247, 2757675829, 778406919, 2453259553}));
+    CHECK(check_hash_result<cuco::murmurhash3_x86_128<cuda::std::array<int32_t, 4>>, uint32_t>(
+      {42, 64, 108, 1024}, 63, {2686265656, 591236665, 3797082165, 2731908938}));
+    CHECK(check_hash_result<cuco::murmurhash3_x86_128<cuda::std::array<int32_t, 16>>, uint32_t>(
+      {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+      1024,
+      {3918256832, 4205523739, 1707810111, 1625952473}));
+    CHECK(check_hash_result<cuco::murmurhash3_x86_128<cuda::std::array<int64_t, 2>>, uint32_t>(
+      {2, 2}, 0, {3811075945, 727160712, 3510740342, 235225510}));
+    CHECK(check_hash_result<cuco::murmurhash3_x86_128<cuda::std::array<int64_t, 3>>, uint32_t>(
+      {1, 4, 9}, 42, {2817194959, 206796677, 3391242768, 248681098}));
+    CHECK(check_hash_result<cuco::murmurhash3_x86_128<cuda::std::array<int64_t, 4>>, uint32_t>(
+      {42, 64, 108, 1024}, 63, {2335912146, 1566515912, 760710030, 452077451}));
+    CHECK(check_hash_result<cuco::murmurhash3_x86_128<cuda::std::array<int64_t, 16>>, uint32_t>(
+      {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+      1024,
+      {1101169764, 1758958147, 2406511780, 2903571412}));
   }
 
   SECTION("Check if device-generated hash values match the reference implementation.")
   {
-    thrust::device_vector<bool> result(12, true);
+    thrust::device_vector<bool> result(24, true);
 
     check_murmurhash3_128_result_kernel<<<1, 1>>>(result.begin());
 


### PR DESCRIPTION
Closes #507 

Adds MurmurHash3 128 bit hash function of x86 version.

- [x] Adds unit test (compares hash value based on [reference_implementation ](https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp) : [compare_on_godbolt](https://godbolt.org/z/eban895E3)).
- [x] Updates documentation.
- [x] Adds benchmarks