### PR TITLE
Add benchmark evaluating hash function performance on random byte strings

### DIFF
--- a/benchmarks/hash_bench.cu
+++ b/benchmarks/hash_bench.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/hash_bench.cu
+++ b/benchmarks/hash_bench.cu
@@ -199,6 +199,7 @@ NVBENCH_BENCH_TYPES(string_hash_eval,
                     NVBENCH_TYPE_AXES(nvbench::type_list<cuco::murmurhash3_32<std::byte>,
                                                          cuco::xxhash_32<std::byte>,
                                                          cuco::xxhash_64<std::byte>,
+                                                         cuco::murmurhash3_x86_128<std::byte>,
                                                          cuco::murmurhash3_x64_128<std::byte>>))
   .set_name("string_hash_function_eval")
   .set_type_axes_names({"Hash"})

--- a/benchmarks/hash_bench.cu
+++ b/benchmarks/hash_bench.cu
@@ -17,12 +17,18 @@
 #include <benchmark_defaults.hpp>
 
 #include <cuco/hash_functions.cuh>
+#include <cuco/utility/key_generator.cuh>
 
 #include <nvbench/nvbench.cuh>
 
 #include <thrust/device_vector.h>
 
+#include <cstddef>
 #include <cstdint>
+#include <type_traits>
+
+// repeat hash computation n times
+static constexpr auto n_repeats = 100;
 
 template <int32_t Words>
 struct large_key {
@@ -65,7 +71,7 @@ __global__ void hash_bench_kernel(Hasher hash,
 
   while (idx < n) {
     typename Hasher::argument_type key(idx);
-    for (int32_t i = 0; i < 100; ++i) {  // execute hash func 100 times
+    for (int32_t i = 0; i < n_repeats; ++i) {  // execute hash func n times
       hash_result_aggregate(agg, hash(key));
     }
     idx += loop_stride;
@@ -96,6 +102,66 @@ void hash_eval(nvbench::state& state, nvbench::type_list<Hash>)
   });
 }
 
+template <int32_t BlockSize, typename Hasher, typename InputIt, typename OutputIt>
+__global__ void string_hash_bench_kernel(
+  Hasher hash, InputIt in, cuco::detail::index_type n, OutputIt out, bool materialize_result)
+{
+  cuco::detail::index_type const gid         = BlockSize * blockIdx.x + threadIdx.x;
+  cuco::detail::index_type const loop_stride = gridDim.x * BlockSize;
+  cuco::detail::index_type idx               = gid;
+  typename Hasher::result_type agg           = {};
+
+  while (idx < n) {
+    auto const key = thrust::raw_reference_cast(*(in + idx));
+    for (int32_t i = 0; i < n_repeats; ++i) {  // execute hash func n times
+      hash_result_aggregate(agg, hash.compute_hash(key.data(), key.size()));
+    }
+    idx += loop_stride;
+  }
+
+  if (materialize_result) { out[gid] = agg; }
+}
+
+/**
+ * @brief A benchmark evaluating performance of various hash functions on random strings with
+ * variable length and alignment
+ */
+template <typename Hash>
+void string_hash_eval(nvbench::state& state, nvbench::type_list<Hash>)
+{
+  static_assert(std::is_same_v<typename Hash::argument_type, std::byte>,
+                "Argument type must be std::byte");
+
+  bool const materialize_result = false;
+  constexpr auto block_size     = 128;
+  auto const num_keys           = state.get_int64("NumInputs");
+  auto const min_length         = state.get_int64("MinLength");
+  auto const max_length         = state.get_int64("MaxLength");
+  auto const grid_size          = (num_keys + block_size * 16 - 1) / block_size * 16;
+
+  if (min_length > max_length) {
+    state.skip("MinLength > MaxLength");
+    return;
+  }
+
+  // auto const [keys, storage] = ... (can't capture structured bindings into lambdas in C++17)
+  auto const sequences =
+    cuco::utility::generate_random_byte_sequences(num_keys, min_length, max_length);
+  auto const& keys = sequences.first;
+  // auto const& storage = sequences.second;
+
+  thrust::device_vector<typename Hash::result_type> hash_values((materialize_result) ? num_keys
+                                                                                     : 1);
+
+  state.add_element_count(num_keys);
+  // state.add_global_memory_reads<std::byte>(storage.size() * n_repeats);
+
+  state.exec([&](nvbench::launch& launch) {
+    string_hash_bench_kernel<block_size><<<grid_size, block_size, 0, launch.get_stream()>>>(
+      Hash{}, keys.begin(), num_keys, hash_values.begin(), materialize_result);
+  });
+}
+
 NVBENCH_BENCH_TYPES(
   hash_eval,
   NVBENCH_TYPE_AXES(nvbench::type_list<cuco::murmurhash3_32<nvbench::int32_t>,
@@ -114,4 +180,16 @@ NVBENCH_BENCH_TYPES(
                                        cuco::murmurhash3_x64_128<large_key<32>>>))
   .set_name("hash_function_eval")
   .set_type_axes_names({"Hash"})
+  .set_max_noise(cuco::benchmark::defaults::MAX_NOISE);
+
+NVBENCH_BENCH_TYPES(string_hash_eval,
+                    NVBENCH_TYPE_AXES(nvbench::type_list<cuco::murmurhash3_32<std::byte>,
+                                                         cuco::xxhash_32<std::byte>,
+                                                         cuco::xxhash_64<std::byte>,
+                                                         cuco::murmurhash3_x64_128<std::byte>>))
+  .set_name("string_hash_function_eval")
+  .set_type_axes_names({"Hash"})
+  .add_int64_axis("NumInputs", {cuco::benchmark::defaults::N / 4})
+  .add_int64_axis("MinLength", {1, 4})
+  .add_int64_axis("MaxLength", {4, 32, 64})
   .set_max_noise(cuco::benchmark::defaults::MAX_NOISE);


### PR DESCRIPTION
This PR adds a benchmark evaluating performance of our hash functions on random strings with variable length and alignment.

This setup has to use the `compute_hash(std::byte* …)` overload of our hashers directly and can't make the shortcut of making a local copy of the key, thus having to fall back to misaligned global loads.