### PR TITLE
Update the documentation to no longer suggest using thrust::make_pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ We plan to add many GPU-accelerated, concurrent data structures to `cuCollection
 `cuco::static_multimap` is a fixed-size hash table that supports storing equivalent keys. It uses double hashing by default and supports switching to linear probing. See the Doxygen documentation in `static_multimap.cuh` for more detailed information.
 
 #### Examples:
-- [Host-bulk APIs](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_multimap/host_bulk_example.cu) (see [live example in godbolt](https://godbolt.org/z/nx97W4f7q))
+- [Host-bulk APIs](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_multimap/host_bulk_example.cu) (see [live example in godbolt](https://godbolt.org/z/nssaTn5M8))
 
 ### `dynamic_map`
 

--- a/examples/static_multimap/host_bulk_example.cu
+++ b/examples/static_multimap/host_bulk_example.cu
@@ -43,10 +43,11 @@ int main(void)
 
   // Create a sequence of pairs. Eeach key has two matches.
   // E.g., {{0,0}, {1,1}, ... {0,25'000}, {1, 25'001}, ...}
-  thrust::transform(thrust::make_counting_iterator<int>(0),
-                    thrust::make_counting_iterator<int>(pairs.size()),
-                    pairs.begin(),
-                    [] __device__(auto i) { return cuco::pair{i % (N / 2), i}; });
+  thrust::transform(
+    thrust::make_counting_iterator<int>(0),
+    thrust::make_counting_iterator<int>(pairs.size()),
+    pairs.begin(),
+    [] __device__(auto i) { return cuco::pair<key_type, value_type>{i % (N / 2), i}; });
 
   // Inserts all pairs into the map
   map.insert(pairs.begin(), pairs.end());

--- a/examples/static_multimap/host_bulk_example.cu
+++ b/examples/static_multimap/host_bulk_example.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@
 
 #include <thrust/device_vector.h>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/pair.h>
 #include <thrust/sequence.h>
 #include <thrust/transform.h>
 
@@ -40,14 +39,14 @@ int main(void)
   cuco::static_multimap<key_type, value_type> map{
     N * 2, cuco::empty_key{empty_key_sentinel}, cuco::empty_value{empty_value_sentinel}};
 
-  thrust::device_vector<thrust::pair<key_type, value_type>> pairs(N);
+  thrust::device_vector<cuco::pair<key_type, value_type>> pairs(N);
 
   // Create a sequence of pairs. Eeach key has two matches.
   // E.g., {{0,0}, {1,1}, ... {0,25'000}, {1, 25'001}, ...}
   thrust::transform(thrust::make_counting_iterator<int>(0),
                     thrust::make_counting_iterator<int>(pairs.size()),
                     pairs.begin(),
-                    [] __device__(auto i) { return thrust::make_pair(i % (N / 2), i); });
+                    [] __device__(auto i) { return cuco::pair{i % (N / 2), i}; });
 
   // Inserts all pairs into the map
   map.insert(pairs.begin(), pairs.end());

--- a/include/cuco/dynamic_map.cuh
+++ b/include/cuco/dynamic_map.cuh
@@ -73,13 +73,13 @@ namespace cuco {
  * thrust::transform(thrust::make_counting_iterator(0),
  *                   thrust::make_counting_iterator(pairs_0.size()),
  *                   pairs_0.begin(),
- *                   []__device__(auto i){ return thrust::make_pair(i,i); };
+ *                   []__device__(auto i){ return cuco::pair{i,i}; };
  *
  * thrust::device_vector<thrust::pair<int,int>> pairs_1(100'000);
  * thrust::transform(thrust::make_counting_iterator(50'000),
  *                   thrust::make_counting_iterator(pairs_1.size()),
  *                   pairs_1.begin(),
- *                   []__device__(auto i){ return thrust::make_pair(i,i); };
+ *                   []__device__(auto i){ return cuco::pair{i,i}; };
  *
  * // Inserts all pairs into the map
  * m.insert(pairs_0.begin(), pairs_0.end());

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -791,8 +791,7 @@ namespace legacy {
  * // sentinels. The supplied erased key sentinel of -2 must be a different value from the empty
  * // key sentinel. If erase functionality is not needed, you may elect to not supply an erased
  * // key sentinel to the constructor. Note the capacity is chosen knowing we will insert 50,000
- * keys,
- * // for an load factor of 50%.
+ * // keys, for an load factor of 50%.
  * static_map<int, int> m{100'000, empty_key_sentinel, empty_value_sentinel, erased_value_sentinel};
  *
  * // Create a sequence of pairs {{0,0}, {1,1}, ... {i,i}}
@@ -800,7 +799,7 @@ namespace legacy {
  * thrust::transform(thrust::make_counting_iterator(0),
  *                   thrust::make_counting_iterator(pairs.size()),
  *                   pairs.begin(),
- *                   []__device__(auto i){ return thrust::make_pair(i,i); };
+ *                   []__device__(auto i){ return cuco::pair{i,i}; };
  *
  *
  * // Inserts all pairs into the map
@@ -1441,7 +1440,7 @@ class static_map {
    *                  thrust::make_counting_iterator(50'000),
    *                  [map = m.get_device_mutable_view()]
    *                  __device__ (auto i) mutable {
-   *                     map.insert(thrust::make_pair(i,i));
+   *                     map.insert(cuco::pair{i,i});
    *                  });
    * \endcode
    */

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -101,12 +101,11 @@ namespace cuco {
  * static_multimap<int, int> m{100'000, empty_key_sentinel, empty_value_sentinel};
  *
  * // Create a sequence of pairs {{0,0}, {1,1}, ... {i,i}}
- * thrust::device_vector<thrust::pair<int,int>> pairs(50,000);
+ * thrust::device_vector<cuco::pair<int,int>> pairs(50,000);
  * thrust::transform(thrust::make_counting_iterator(0),
  *                   thrust::make_counting_iterator(pairs.size()),
  *                   pairs.begin(),
- *                   []__device__(auto i){ return thrust::make_pair(i,i); };
- *
+ *                   []__device__(auto i){ return cuco::pair{i,i}; };
  *
  * // Inserts all pairs into the map
  * m.insert(pairs.begin(), pairs.end());
@@ -683,7 +682,7 @@ class static_multimap {
    *                  thrust::make_counting_iterator(50'000),
    *                  [map = m.get_device_mutable_view()]
    *                  __device__ (auto i) mutable {
-   *                     map.insert(thrust::make_pair(i,i));
+   *                     map.insert(cuco::pair{i,i});
    *                  });
    * \endcode
    */


### PR DESCRIPTION
This updates documentation to no longer suggest using the `thrust::make_pair` factory.

CTAD is our best friend in this case.