### PR TITLE
Fix a multimap buffer flushing bug with zip iterator

### DIFF
--- a/include/cuco/detail/static_multimap/device_view_impl.inl
+++ b/include/cuco/detail/static_multimap/device_view_impl.inl
@@ -512,7 +512,8 @@ class static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_view_
 #endif  // end CUCO_HAS_CUDA_BARRIER
     } else {
       for (auto index = lane_id; index < num_outputs; index += g.size()) {
-        *(output_begin + offset + index) = output_buffer[index];
+        thrust::get<0>(*(output_begin + offset + index)) = output_buffer[index].first;
+        thrust::get<1>(*(output_begin + offset + index)) = output_buffer[index].second;
       }
     }
   }


### PR DESCRIPTION
Helps https://github.com/NVIDIA/cuCollections/discussions/528

This PR fixes a bug where the `static_multimap::retrieve` couldn't work properly with `thrust::zip_iterator`.