### PR TITLE
Replace custom atomic operations with cuda atomic_ref

### DIFF
--- a/include/cuco/detail/hyperloglog/hyperloglog_ref.cuh
+++ b/include/cuco/detail/hyperloglog/hyperloglog_ref.cuh
@@ -25,6 +25,7 @@
 #include <cuco/utility/cuda_thread_scope.cuh>
 #include <cuco/utility/traits.hpp>
 
+#include <cuda/atomic>
 #include <cuda/std/bit>
 #include <cuda/std/span>
 #include <cuda/std/utility>
@@ -35,7 +36,6 @@
 #include <cooperative_groups/reduce.h>
 
 #include <algorithm>  // there is no <cuda/std/algorithm>
-#include <atomic>
 #include <cstddef>
 #include <vector>
 

--- a/include/cuco/detail/hyperloglog/hyperloglog_ref.cuh
+++ b/include/cuco/detail/hyperloglog/hyperloglog_ref.cuh
@@ -35,6 +35,7 @@
 #include <cooperative_groups/reduce.h>
 
 #include <algorithm>  // there is no <cuda/std/algorithm>
+#include <atomic>
 #include <cstddef>
 #include <vector>
 
@@ -524,17 +525,8 @@ class hyperloglog_ref {
    */
   __device__ constexpr void update_max(int i, register_type value) noexcept
   {
-    if constexpr (Scope == cuda::thread_scope_thread) {
-      this->sketch_[i] = max(this->sketch_[i], value);
-    } else if constexpr (Scope == cuda::thread_scope_block) {
-      atomicMax_block(&(this->sketch_[i]), value);
-    } else if constexpr (Scope == cuda::thread_scope_device) {
-      atomicMax(&(this->sketch_[i]), value);
-    } else if constexpr (Scope == cuda::thread_scope_system) {
-      atomicMax_system(&(this->sketch_[i]), value);
-    } else {
-      static_assert(cuco::dependent_false<decltype(Scope)>, "Unsupported thread scope");
-    }
+    cuda::atomic_ref<register_type, Scope> register_ref(this->sketch_[i]);
+    register_ref.fetch_max(value, cuda::memory_order_relaxed);
   }
 
   /**

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -1355,7 +1355,7 @@ class open_addressing_ref_impl {
     if constexpr (sizeof(value_type) <= 8) {
       return packed_cas(address, expected, desired);
     } else {
-#if (_CUDA_ARCH__ < 700)
+#if (__CUDA_ARCH__ < 700)
       return cas_dependent_write(address, expected, desired);
 #else
       return back_to_back_cas(address, expected, desired);

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -1121,90 +1121,6 @@ class open_addressing_ref_impl {
   }
 
   /**
-   * @brief Compares the content of the address `address` (old value) with the `expected` value and,
-   * only if they are the same, sets the content of `address` to `desired`.
-   *
-   * @tparam T Address content type
-   *
-   * @param address The target address
-   * @param expected The value expected to be found at the target address
-   * @param desired The value to store at the target address if it is as expected
-   *
-   * @return The old value located at address `address`
-   */
-  template <typename T>
-  __device__ constexpr auto compare_and_swap(T* address, T expected, T desired)
-  {
-    // temporary workaround due to performance regression
-    // https://github.com/NVIDIA/libcudacxx/issues/366
-    if constexpr (sizeof(T) == sizeof(unsigned int)) {
-      auto* const slot_ptr           = reinterpret_cast<unsigned int*>(address);
-      auto const* const expected_ptr = reinterpret_cast<unsigned int*>(&expected);
-      auto const* const desired_ptr  = reinterpret_cast<unsigned int*>(&desired);
-      if constexpr (Scope == cuda::thread_scope_system) {
-        return atomicCAS_system(slot_ptr, *expected_ptr, *desired_ptr);
-      } else if constexpr (Scope == cuda::thread_scope_device) {
-        return atomicCAS(slot_ptr, *expected_ptr, *desired_ptr);
-      } else if constexpr (Scope == cuda::thread_scope_block) {
-        return atomicCAS_block(slot_ptr, *expected_ptr, *desired_ptr);
-      } else {
-        static_assert(cuco::dependent_false<decltype(Scope)>, "Unsupported thread scope");
-      }
-    } else if constexpr (sizeof(T) == sizeof(unsigned long long int)) {
-      auto* const slot_ptr           = reinterpret_cast<unsigned long long int*>(address);
-      auto const* const expected_ptr = reinterpret_cast<unsigned long long int*>(&expected);
-      auto const* const desired_ptr  = reinterpret_cast<unsigned long long int*>(&desired);
-      if constexpr (Scope == cuda::thread_scope_system) {
-        return atomicCAS_system(slot_ptr, *expected_ptr, *desired_ptr);
-      } else if constexpr (Scope == cuda::thread_scope_device) {
-        return atomicCAS(slot_ptr, *expected_ptr, *desired_ptr);
-      } else if constexpr (Scope == cuda::thread_scope_block) {
-        return atomicCAS_block(slot_ptr, *expected_ptr, *desired_ptr);
-      } else {
-        static_assert(cuco::dependent_false<decltype(Scope)>, "Unsupported thread scope");
-      }
-    }
-  }
-
-  /**
-   * @brief Atomically stores `value` at the given `address`.
-   *
-   * @tparam T Address content type
-   *
-   * @param address The target address
-   * @param value The value to store
-   */
-  template <typename T>
-  __device__ constexpr void atomic_store(T* address, T value)
-  {
-    if constexpr (sizeof(T) == sizeof(unsigned int)) {
-      auto* const slot_ptr        = reinterpret_cast<unsigned int*>(address);
-      auto const* const value_ptr = reinterpret_cast<unsigned int*>(&value);
-      if constexpr (Scope == cuda::thread_scope_system) {
-        atomicExch_system(slot_ptr, *value_ptr);
-      } else if constexpr (Scope == cuda::thread_scope_device) {
-        atomicExch(slot_ptr, *value_ptr);
-      } else if constexpr (Scope == cuda::thread_scope_block) {
-        atomicExch_block(slot_ptr, *value_ptr);
-      } else {
-        static_assert(cuco::dependent_false<decltype(Scope)>, "Unsupported thread scope");
-      }
-    } else if constexpr (sizeof(T) == sizeof(unsigned long long int)) {
-      auto* const slot_ptr        = reinterpret_cast<unsigned long long int*>(address);
-      auto const* const value_ptr = reinterpret_cast<unsigned long long int*>(&value);
-      if constexpr (Scope == cuda::thread_scope_system) {
-        atomicExch_system(slot_ptr, *value_ptr);
-      } else if constexpr (Scope == cuda::thread_scope_device) {
-        atomicExch(slot_ptr, *value_ptr);
-      } else if constexpr (Scope == cuda::thread_scope_block) {
-        atomicExch_block(slot_ptr, *value_ptr);
-      } else {
-        static_assert(cuco::dependent_false<decltype(Scope)>, "Unsupported thread scope");
-      }
-    }
-  }
-
-  /**
    * @brief Extracts the key from a given value type.
    *
    * @tparam Value Input type which is convertible to 'value_type'
@@ -1317,12 +1233,17 @@ class open_addressing_ref_impl {
                                                               value_type const& expected,
                                                               Value const& desired) noexcept
   {
-    auto old      = compare_and_swap(address, expected, this->native_value(desired));
-    auto* old_ptr = reinterpret_cast<value_type*>(&old);
-    if (cuco::detail::bitwise_compare(this->extract_key(*old_ptr), this->extract_key(expected))) {
+    cuda::atomic_ref<value_type, Scope> slot_ref(*address);
+    auto expected_slot = expected;
+
+    auto const success = slot_ref.compare_exchange_strong(
+      expected_slot, this->native_value(desired), cuda::std::memory_order_relaxed);
+
+    if (success) {
       return insert_result::SUCCESS;
     } else {
-      return this->predicate_.equal_to(this->extract_key(desired), this->extract_key(*old_ptr)) ==
+      return this->predicate_.equal_to(this->extract_key(desired),
+                                       this->extract_key(expected_slot)) ==
                  detail::equal_result::EQUAL
                ? insert_result::DUPLICATE
                : insert_result::CONTINUE;
@@ -1345,31 +1266,29 @@ class open_addressing_ref_impl {
                                                                     value_type const& expected,
                                                                     Value const& desired) noexcept
   {
-    using mapped_type = decltype(this->empty_value_sentinel());
+    using mapped_type = cuda::std::decay_t<decltype(this->empty_value_sentinel())>;
 
-    auto const expected_key     = expected.first;
-    auto const expected_payload = expected.second;
+    auto expected_key     = expected.first;
+    auto expected_payload = expected.second;
 
-    auto old_key =
-      compare_and_swap(&address->first, expected_key, static_cast<key_type>(desired.first));
-    auto old_payload = compare_and_swap(&address->second, expected_payload, desired.second);
+    cuda::atomic_ref<key_type, Scope> key_ref(address->first);
+    cuda::atomic_ref<mapped_type, Scope> payload_ref(address->second);
 
-    auto* old_key_ptr     = reinterpret_cast<key_type*>(&old_key);
-    auto* old_payload_ptr = reinterpret_cast<mapped_type*>(&old_payload);
+    auto const key_cas_success =
+      key_ref.atomic_exchange_strong(expected_key, desired.first, cuda::memory_order_relaxed);
+    auto const payload_cas_success = payload_ref.atomic_exchange_strong(
+      expected_payload, desired.second, cuda::memory_order_relaxed);
 
     // if key success
-    if (cuco::detail::bitwise_compare(*old_key_ptr, expected_key)) {
-      while (not cuco::detail::bitwise_compare(*old_payload_ptr, expected_payload)) {
-        old_payload = compare_and_swap(&address->second, expected_payload, desired.second);
-      }
+    if (key_cas_success) {
       return insert_result::SUCCESS;
-    } else if (cuco::detail::bitwise_compare(*old_payload_ptr, expected_payload)) {
-      atomic_store(&address->second, expected_payload);
+    } else if (payload_cas_success) {
+      payload_ref.store(expected_payload, cuda::memory_order_relaxed);
     }
 
     // Our key was already present in the slot, so our key is a duplicate
     // Shouldn't use `predicate` operator directly since it includes a redundant bitwise compare
-    if (this->predicate_.equal_to(desired.first, *old_key_ptr) == detail::equal_result::EQUAL) {
+    if (this->predicate_.equal_to(desired.first, expected_key) == detail::equal_result::EQUAL) {
       return insert_result::DUPLICATE;
     }
 
@@ -1391,24 +1310,23 @@ class open_addressing_ref_impl {
   [[nodiscard]] __device__ constexpr insert_result cas_dependent_write(
     value_type* address, value_type const& expected, Value const& desired) noexcept
   {
-    using mapped_type = decltype(this->empty_value_sentinel());
+    using mapped_type = cuda::std::decay_t<decltype(this->empty_value_sentinel())>;
 
-    auto const expected_key = expected.first;
-
-    auto old_key =
-      compare_and_swap(&address->first, expected_key, static_cast<key_type>(desired.first));
-
-    auto* old_key_ptr = reinterpret_cast<key_type*>(&old_key);
+    cuda::atomic_ref<key_type, Scope> key_ref(address->first);
+    auto expected_key  = expected.first;
+    auto const success = key_ref.compare_exchange_strong(
+      expected_key, static_cast<key_type>(desired.first), cuda::memory_order_relaxed);
 
     // if key success
-    if (cuco::detail::bitwise_compare(*old_key_ptr, expected_key)) {
-      atomic_store(&address->second, desired.second);
+    if (success) {
+      cuda::atomic_ref<mapped_type, Scope> payload_ref(address->second);
+      payload_ref.store(desired.second, cuda::memory_order_relaxed);
       return insert_result::SUCCESS;
     }
 
     // Our key was already present in the slot, so our key is a duplicate
     // Shouldn't use `predicate` operator directly since it includes a redundant bitwise compare
-    if (this->predicate_.equal_to(desired.first, *old_key_ptr) == detail::equal_result::EQUAL) {
+    if (this->predicate_.equal_to(desired.first, expected_key) == detail::equal_result::EQUAL) {
       return insert_result::DUPLICATE;
     }
 

--- a/include/cuco/detail/static_map.inl
+++ b/include/cuco/detail/static_map.inl
@@ -408,7 +408,7 @@ __device__ bool static_map<Key, Value, Scope, Allocator>::device_mutable_view::i
         }
 
         if constexpr (not cuco::detail::is_packable<value_type>()) {
-#if (_CUDA_ARCH__ < 700)
+#if (__CUDA_ARCH__ < 700)
           return cas_dependent_write(current_slot, insert_pair, key_equal, existing_key);
 #else
           return back_to_back_cas(current_slot, insert_pair, key_equal, existing_key);

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -423,21 +423,17 @@ class operator_impl<
       for (auto& slot_content : window_slots) {
         auto const eq_res =
           ref_.impl_.predicate_.operator()<is_insert::YES>(key, slot_content.first);
+        auto const intra_window_index = thrust::distance(window_slots.begin(), &slot_content);
+        auto slot_ptr = (storage_ref.data() + *probing_iter)->data() + intra_window_index;
 
         // If the key is already in the container, update the payload and return
         if (eq_res == detail::equal_result::EQUAL) {
-          auto const intra_window_index = thrust::distance(window_slots.begin(), &slot_content);
-          ref_.impl_.atomic_store(
-            &((storage_ref.data() + *probing_iter)->data() + intra_window_index)->second,
-            val.second);
+          cuda::atomic_ref<mapped_type, Scope> payload_ref(slot_ptr->second);
+          payload_ref.store(val.second, cuda::memory_order_relaxed);
           return;
         }
         if (eq_res == detail::equal_result::AVAILABLE) {
-          auto const intra_window_index = thrust::distance(window_slots.begin(), &slot_content);
-          if (attempt_insert_or_assign(
-                (storage_ref.data() + *probing_iter)->data() + intra_window_index, val)) {
-            return;
-          }
+          if (attempt_insert_or_assign(slot_ptr, val)) { return; }
         }
       }
       ++probing_iter;
@@ -482,13 +478,14 @@ class operator_impl<
         return detail::window_probing_results{res, -1};
       }();
 
+      auto slot_ptr = (storage_ref.data() + *probing_iter)->data() + intra_window_index;
+
       auto const group_contains_equal = group.ballot(state == detail::equal_result::EQUAL);
       if (group_contains_equal) {
         auto const src_lane = __ffs(group_contains_equal) - 1;
         if (group.thread_rank() == src_lane) {
-          ref_.impl_.atomic_store(
-            &((storage_ref.data() + *probing_iter)->data() + intra_window_index)->second,
-            val.second);
+          cuda::atomic_ref<mapped_type, Scope> payload_ref(slot_ptr->second);
+          payload_ref.store(val.second, cuda::memory_order_relaxed);
         }
         group.sync();
         return;
@@ -498,10 +495,7 @@ class operator_impl<
       if (group_contains_available) {
         auto const src_lane = __ffs(group_contains_available) - 1;
         auto const status =
-          (group.thread_rank() == src_lane)
-            ? attempt_insert_or_assign(
-                (storage_ref.data() + *probing_iter)->data() + intra_window_index, val)
-            : false;
+          (group.thread_rank() == src_lane) ? attempt_insert_or_assign(slot_ptr, val) : false;
 
         // Exit if inserted or assigned
         if (group.shfl(status, src_lane)) { return; }
@@ -529,19 +523,19 @@ class operator_impl<
   template <typename Value>
   __device__ constexpr bool attempt_insert_or_assign(value_type* slot, Value const& value) noexcept
   {
-    ref_type& ref_          = static_cast<ref_type&>(*this);
-    auto const expected_key = ref_.impl_.empty_slot_sentinel().first;
+    ref_type& ref_    = static_cast<ref_type&>(*this);
+    auto expected_key = ref_.impl_.empty_slot_sentinel().first;
 
-    auto old_key =
-      ref_.impl_.compare_and_swap(&slot->first, expected_key, static_cast<key_type>(value.first));
-    auto* old_key_ptr = reinterpret_cast<key_type*>(&old_key);
+    cuda::atomic_ref<key_type, Scope> key_ref(slot->first);
+    auto const success = key_ref.compare_exchange_strong(
+      expected_key, static_cast<key_type>(value.first), cuda::memory_order_relaxed);
 
     // if key success or key was already present in the map
-    if (cuco::detail::bitwise_compare(*old_key_ptr, expected_key) or
-        (ref_.impl_.predicate().equal_to(value.first, *old_key_ptr) ==
-         detail::equal_result::EQUAL)) {
+    if (success or (ref_.impl_.predicate().equal_to(value.first, expected_key) ==
+                    detail::equal_result::EQUAL)) {
       // Update payload
-      ref_.impl_.atomic_store(&slot->second, value.second);
+      cuda::atomic_ref<mapped_type, Scope> payload_ref(slot->second);
+      payload_ref.store(value.second, cuda::memory_order_relaxed);
       return true;
     }
     return false;


### PR DESCRIPTION
The current cuco implementations use custom atomic functions due to a performance regression with `cuda::atomic_ref` (https://github.com/NVIDIA/cccl/issues/1008). 

This PR replaces the custom atomic operations with `cuda::atomic_ref` operations. 

Closes #469 