### PR TITLE
Fix `insert_or_apply` bug

### DIFF
--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -605,6 +605,9 @@ class operator_impl<
 
         // If the key is already in the container, update the payload and return
         if (eq_res == detail::equal_result::EQUAL) {
+          if constexpr (sizeof(value_type) > 8) {
+            ref_.impl_.wait_for_payload(slot_ptr->second, empty_value);
+          }
           op(cuda::atomic_ref<T, Scope>{slot_ptr->second}, val.second);
           return;
         }
@@ -689,6 +692,9 @@ class operator_impl<
       if (group_contains_equal) {
         auto const src_lane = __ffs(group_contains_equal) - 1;
         if (group.thread_rank() == src_lane) {
+          if constexpr (sizeof(value_type) > 8) {
+            ref_.impl_.wait_for_payload(slot_ptr->second, empty_value);
+          }
           op(cuda::atomic_ref<T, Scope>{slot_ptr->second}, val.second);
         }
         return;

--- a/tests/static_map/insert_or_apply_test.cu
+++ b/tests/static_map/insert_or_apply_test.cu
@@ -92,7 +92,7 @@ TEMPLATE_TEST_CASE_SIG(
   (int64_t, int32_t, cuco::test::probe_sequence::linear_probing, 2),
   (int64_t, int64_t, cuco::test::probe_sequence::linear_probing, 2))
 {
-  constexpr size_type num_keys{400};
+  constexpr size_type num_keys{10'000};
   constexpr size_type num_unique_keys{100};
 
   using probe = std::conditional_t<


### PR DESCRIPTION
The current implementation of `insert_or_apply` does not wait for **payload** to get **materialize** before applying the operation `op` to the **payload** of the thread which wins `key_eq`. 

This will lead to overwrite of **payload** if the thread winning **key CAS** swapped its key successfuly, but another thread which wins the same `key_eq` and performs **apply** `op` operation on **sentinel payload** before the **thread** which **won key_CAS materializes** its **paylaod** using **atomic_store**.
 
This PR add's `wait_for_payload` before the **apply** `op` operation is performed. 

Closes #542 
