### PR TITLE
Fix while loop predicate

### DIFF
--- a/include/cuco/detail/open_addressing/kernels.cuh
+++ b/include/cuco/detail/open_addressing/kernels.cuh
@@ -577,7 +577,7 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void rehash(
   auto idx                       = cuco::detail::global_thread_id();
   auto const n                   = storage_ref.num_windows();
 
-  while ((idx - thread_rank / cg_size) < n) {
+  while (idx - thread_rank < n) {
     if (thread_rank == 0) { buffer_size = 0; }
     block.sync();
 

--- a/include/cuco/detail/open_addressing/kernels.cuh
+++ b/include/cuco/detail/open_addressing/kernels.cuh
@@ -230,7 +230,7 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void contains_if_n(InputIt first,
 
   __shared__ bool output_buffer[BlockSize / CGSize];
 
-  while (idx - thread_idx < n) {  // the whole thread block falls into the same iteration
+  while ((idx - thread_idx / CGSize) < n) {  // the whole thread block falls into the same iteration
     if constexpr (CGSize == 1) {
       if (idx < n) {
         typename std::iterator_traits<InputIt>::value_type const& key = *(first + idx);
@@ -331,7 +331,7 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void find(InputIt first,
     }
   });
 
-  while (idx - thread_idx < n) {  // the whole thread block falls into the same iteration
+  while ((idx - thread_idx / CGSize) < n) {  // the whole thread block falls into the same iteration
     if constexpr (CGSize == 1) {
       if (idx < n) {
         typename std::iterator_traits<InputIt>::value_type const& key = *(first + idx);
@@ -418,7 +418,7 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void insert_and_find(InputIt first,
   __shared__ output_type output_location_buffer[BlockSize / CGSize];
   __shared__ bool output_inserted_buffer[BlockSize / CGSize];
 
-  while (idx - thread_idx < n) {  // the whole thread block falls into the same iteration
+  while ((idx - thread_idx / CGSize) < n) {  // the whole thread block falls into the same iteration
     if constexpr (CGSize == 1) {
       if (idx < n) {
         typename std::iterator_traits<InputIt>::value_type const& insert_element{*(first + idx)};
@@ -577,7 +577,7 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void rehash(
   auto idx                       = cuco::detail::global_thread_id();
   auto const n                   = storage_ref.num_windows();
 
-  while (idx - thread_rank < n) {
+  while ((idx - thread_rank / cg_size) < n) {
     if (thread_rank == 0) { buffer_size = 0; }
     block.sync();
 


### PR DESCRIPTION
The existing while pred works properly only if `CGSize == 1`. This PR fixes the issue and slightly improves the performance by 1 or 2 percent in certain scenarios.