### PR TITLE
Use `cuda::std::min` in a host device function

### DIFF
--- a/include/cuco/detail/pair/helpers.cuh
+++ b/include/cuco/detail/pair/helpers.cuh
@@ -15,10 +15,9 @@
 
 #pragma once
 
+#include <cuda/functional>
 #include <cuda/std/bit>
 #include <cuda/std/type_traits>
-
-#include <algorithm>
 
 namespace cuco::detail {
 
@@ -30,8 +29,7 @@ namespace cuco::detail {
 template <typename First, typename Second>
 __host__ __device__ constexpr std::size_t pair_alignment()
 {
-  // TODO: migrate to cuda::std::min once bumping to CCCL 2.3
-  return std::min(std::size_t{16}, cuda::std::bit_ceil(sizeof(First) + sizeof(Second)));
+  return cuda::std::min(std::size_t{16}, cuda::std::bit_ceil(sizeof(First) + sizeof(Second)));
 }
 
 /**


### PR DESCRIPTION
A minor cleanup by using `cuda::std::min` instead of `std::min` in a host-device function.