### PR TITLE
Add capacity case for static_map benchmark

### DIFF
--- a/benchmarks/hash_table/static_map/contains_bench.cu
+++ b/benchmarks/hash_table/static_map/contains_bench.cu
@@ -99,4 +99,4 @@ NVBENCH_BENCH_TYPES(static_map_contains,
   .set_name("static_map_contains_unique_capacity")
   .set_type_axes_names({"Key", "Value", "Distribution"})
   .set_max_noise(defaults::MAX_NOISE)
-  .add_float64_axis("NumInputs", defaults::N_RANGE_CACHE);
+  .add_int64_axis("NumInputs", defaults::N_RANGE_CACHE);

--- a/benchmarks/hash_table/static_map/contains_bench.cu
+++ b/benchmarks/hash_table/static_map/contains_bench.cu
@@ -91,3 +91,12 @@ NVBENCH_BENCH_TYPES(static_map_contains,
   .set_type_axes_names({"Key", "Value", "Distribution"})
   .set_max_noise(defaults::MAX_NOISE)
   .add_float64_axis("MatchingRate", defaults::MATCHING_RATE_RANGE);
+
+NVBENCH_BENCH_TYPES(static_map_contains,
+                    NVBENCH_TYPE_AXES(defaults::KEY_TYPE_RANGE,
+                                      defaults::VALUE_TYPE_RANGE,
+                                      nvbench::type_list<distribution::unique>))
+  .set_name("static_map_contains_unique_capacity")
+  .set_type_axes_names({"Key", "Value", "Distribution"})
+  .set_max_noise(defaults::MAX_NOISE)
+  .add_float64_axis("NumInputs", defaults::N_RANGE_CACHE);

--- a/benchmarks/hash_table/static_multiset/contains_bench.cu
+++ b/benchmarks/hash_table/static_multiset/contains_bench.cu
@@ -77,6 +77,6 @@ NVBENCH_BENCH_TYPES(static_multiset_contains,
 NVBENCH_BENCH_TYPES(static_multiset_contains,
                     NVBENCH_TYPE_AXES(defaults::KEY_TYPE_RANGE,
                                       nvbench::type_list<distribution::unique>))
-  .set_name("static_multiset_constains_unique_capacity")
+  .set_name("static_multiset_contains_unique_capacity")
   .set_type_axes_names({"Key", "Distribution"})
   .add_int64_axis("NumInputs", defaults::N_RANGE_CACHE);

--- a/benchmarks/hash_table/static_set/contains_bench.cu
+++ b/benchmarks/hash_table/static_set/contains_bench.cu
@@ -77,6 +77,6 @@ NVBENCH_BENCH_TYPES(static_set_contains,
 NVBENCH_BENCH_TYPES(static_set_contains,
                     NVBENCH_TYPE_AXES(defaults::KEY_TYPE_RANGE,
                                       nvbench::type_list<distribution::unique>))
-  .set_name("static_set_constains_unique_capacity")
+  .set_name("static_set_contains_unique_capacity")
   .set_type_axes_names({"Key", "Distribution"})
   .add_int64_axis("NumInputs", defaults::N_RANGE_CACHE);


### PR DESCRIPTION
This PR adds `static_map_contains_unique_capacity` benchmark case and fixes two typos in set/multiset benchmarks