### PR TITLE
fix non-async overloads early return in `static_map`

### DIFF
--- a/include/cuco/detail/static_map/static_map.inl
+++ b/include/cuco/detail/static_map/static_map.inl
@@ -261,7 +261,7 @@ template <typename InputIt>
 void static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::
   insert_or_assign(InputIt first, InputIt last, cuda::stream_ref stream)
 {
-  return this->insert_or_assign_async(first, last, stream);
+  this->insert_or_assign_async(first, last, stream);
   stream.wait();
 }
 
@@ -299,7 +299,7 @@ template <typename InputIt, typename Op>
 void static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::
   insert_or_apply(InputIt first, InputIt last, Op op, cuda::stream_ref stream)
 {
-  return this->insert_or_apply_async(first, last, op, stream);
+  this->insert_or_apply_async(first, last, op, stream);
   stream.wait();
 }
 


### PR DESCRIPTION
Current implementation of `insert_or_assign` and `insert_or_apply` sync overloads return early and do not synchronize on stream.
This PR removes the early return from the async dispatch.