### PR TITLE
Fix a dangling reference warning with GCC-13

### DIFF
--- a/include/cuco/detail/open_addressing/functors.cuh
+++ b/include/cuco/detail/open_addressing/functors.cuh
@@ -48,7 +48,7 @@ struct get_slot {
     auto const window_idx = idx / StorageRef::window_size;
     auto const intra_idx  = idx % StorageRef::window_size;
     if constexpr (HasPayload) {
-      auto const& [first, second] = storage_[window_idx][intra_idx];
+      auto const [first, second] = storage_[window_idx][intra_idx];
       return thrust::make_tuple(first, second);
     } else {
       return storage_[window_idx][intra_idx];


### PR DESCRIPTION
Related to https://github.com/rapidsai/cudf/issues/16395

This PR fixes a dangling reference to a temporary warning with gcc13.
