### PR TITLE
Expose `storage_ref` and `probing_scheme` in all container refs

### DIFF
--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -183,6 +183,34 @@ template <typename Key,
           typename ProbingScheme,
           typename StorageRef,
           typename... Operators>
+__host__ __device__ constexpr auto
+static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::storage_ref()
+  const noexcept
+{
+  return this->impl_.storage_ref();
+}
+
+template <typename Key,
+          typename T,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
+__host__ __device__ constexpr auto
+static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::probing_scheme()
+  const noexcept
+{
+  return this->impl_.probing_scheme();
+}
+
+template <typename Key,
+          typename T,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
 __host__ __device__ constexpr static_map_ref<Key,
                                              T,
                                              Scope,

--- a/include/cuco/detail/static_multimap/static_multimap_ref.inl
+++ b/include/cuco/detail/static_multimap/static_multimap_ref.inl
@@ -183,6 +183,34 @@ template <typename Key,
           typename ProbingScheme,
           typename StorageRef,
           typename... Operators>
+__host__ __device__ constexpr auto
+static_multimap_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::storage_ref()
+  const noexcept
+{
+  return this->impl_.storage_ref();
+}
+
+template <typename Key,
+          typename T,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
+__host__ __device__ constexpr auto
+static_multimap_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::
+  probing_scheme() const noexcept
+{
+  return this->impl_.probing_scheme();
+}
+
+template <typename Key,
+          typename T,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
 __host__ __device__ constexpr static_multimap_ref<Key,
                                                   T,
                                                   Scope,

--- a/include/cuco/detail/static_multiset/static_multiset_ref.inl
+++ b/include/cuco/detail/static_multiset/static_multiset_ref.inl
@@ -127,6 +127,32 @@ template <typename Key,
           typename ProbingScheme,
           typename StorageRef,
           typename... Operators>
+__host__ __device__ constexpr auto
+static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::storage_ref()
+  const noexcept
+{
+  return this->impl_.storage_ref();
+}
+
+template <typename Key,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
+__host__ __device__ constexpr auto
+static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::probing_scheme()
+  const noexcept
+{
+  return this->impl_.probing_scheme();
+}
+
+template <typename Key,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
 __host__ __device__ constexpr static_multiset_ref<Key,
                                                   Scope,
                                                   KeyEqual,

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -159,6 +159,32 @@ template <typename Key,
           typename ProbingScheme,
           typename StorageRef,
           typename... Operators>
+__host__ __device__ constexpr auto
+static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::storage_ref()
+  const noexcept
+{
+  return this->impl_.storage_ref();
+}
+
+template <typename Key,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
+__host__ __device__ constexpr auto
+static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::probing_scheme()
+  const noexcept
+{
+  return this->impl_.probing_scheme();
+}
+
+template <typename Key,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
 __host__ __device__ constexpr static_set_ref<Key,
                                              Scope,
                                              KeyEqual,

--- a/include/cuco/static_map_ref.cuh
+++ b/include/cuco/static_map_ref.cuh
@@ -205,6 +205,20 @@ class static_map_ref
   [[nodiscard]] __host__ __device__ constexpr iterator end() noexcept;
 
   /**
+   * @brief Gets the non-owning storage ref.
+   *
+   * @return The non-owning storage ref of the container
+   */
+  [[nodiscard]] __host__ __device__ constexpr auto storage_ref() const noexcept;
+
+  /**
+   * @brief Gets the probing scheme.
+   *
+   * @return The probing scheme used for the container
+   */
+  [[nodiscard]] __host__ __device__ constexpr auto probing_scheme() const noexcept;
+
+  /**
    * @brief Creates a reference with new operators from the current object.
    *
    * @deprecated This function is deprecated. Use the new `with_operators` instead.

--- a/include/cuco/static_multimap_ref.cuh
+++ b/include/cuco/static_multimap_ref.cuh
@@ -219,6 +219,7 @@ class static_multimap_ref
    * @return The probing scheme used for the container
    */
   [[nodiscard]] __host__ __device__ constexpr auto probing_scheme() const noexcept;
+
   /**
    * @brief Creates a reference with new operators from the current object.
    *

--- a/include/cuco/static_multimap_ref.cuh
+++ b/include/cuco/static_multimap_ref.cuh
@@ -207,6 +207,19 @@ class static_multimap_ref
   [[nodiscard]] __host__ __device__ constexpr iterator end() noexcept;
 
   /**
+   * @brief Gets the non-owning storage ref.
+   *
+   * @return The non-owning storage ref of the container
+   */
+  [[nodiscard]] __host__ __device__ constexpr auto storage_ref() const noexcept;
+
+  /**
+   * @brief Gets the probing scheme.
+   *
+   * @return The probing scheme used for the container
+   */
+  [[nodiscard]] __host__ __device__ constexpr auto probing_scheme() const noexcept;
+  /**
    * @brief Creates a reference with new operators from the current object.
    *
    * @deprecated This function is deprecated. Use the new `with_operators` instead.

--- a/include/cuco/static_multiset_ref.cuh
+++ b/include/cuco/static_multiset_ref.cuh
@@ -184,6 +184,19 @@ class static_multiset_ref
   [[nodiscard]] __host__ __device__ constexpr iterator end() noexcept;
 
   /**
+   * @brief Gets the non-owning storage ref.
+   *
+   * @return The non-owning storage ref of the container
+   */
+  [[nodiscard]] __host__ __device__ constexpr auto storage_ref() const noexcept;
+
+  /**
+   * @brief Gets the probing scheme.
+   *
+   * @return The probing scheme used for the container
+   */
+  [[nodiscard]] __host__ __device__ constexpr auto probing_scheme() const noexcept;
+  /**
    * @brief Creates a reference with new operators from the current object.
    *
    * @deprecated This function is deprecated. Use the new `with_operators` instead.

--- a/include/cuco/static_multiset_ref.cuh
+++ b/include/cuco/static_multiset_ref.cuh
@@ -196,6 +196,7 @@ class static_multiset_ref
    * @return The probing scheme used for the container
    */
   [[nodiscard]] __host__ __device__ constexpr auto probing_scheme() const noexcept;
+
   /**
    * @brief Creates a reference with new operators from the current object.
    *

--- a/include/cuco/static_set_ref.cuh
+++ b/include/cuco/static_set_ref.cuh
@@ -194,6 +194,7 @@ class static_set_ref
    * @return The probing scheme used for the container
    */
   [[nodiscard]] __host__ __device__ constexpr auto probing_scheme() const noexcept;
+
   /**
    * @brief Creates a reference with new operators from the current object.
    *

--- a/include/cuco/static_set_ref.cuh
+++ b/include/cuco/static_set_ref.cuh
@@ -182,6 +182,19 @@ class static_set_ref
   [[nodiscard]] __host__ __device__ constexpr iterator end() noexcept;
 
   /**
+   * @brief Gets the non-owning storage ref.
+   *
+   * @return The non-owning storage ref of the container
+   */
+  [[nodiscard]] __host__ __device__ constexpr auto storage_ref() const noexcept;
+
+  /**
+   * @brief Gets the probing scheme.
+   *
+   * @return The probing scheme used for the container
+   */
+  [[nodiscard]] __host__ __device__ constexpr auto probing_scheme() const noexcept;
+  /**
    * @brief Creates a reference with new operators from the current object.
    *
    * @deprecated This function is deprecated. Use the new `with_operators` instead.


### PR DESCRIPTION
This PR exposes  `storage_ref` and `probing_scheme` in all container refs.