### PR TITLE
Enable Initialization for Empty Storage

### DIFF
--- a/include/cuco/detail/storage/aow_storage.inl
+++ b/include/cuco/detail/storage/aow_storage.inl
@@ -74,6 +74,8 @@ template <typename T, int32_t WindowSize, typename Extent, typename Allocator>
 void aow_storage<T, WindowSize, Extent, Allocator>::initialize_async(
   value_type key, cuda::stream_ref stream) noexcept
 {
+  if (this->num_windows() == 0) { return; }
+
   auto constexpr cg_size = 1;
   auto constexpr stride  = 4;
   auto const grid_size   = cuco::detail::grid_size(this->num_windows(), cg_size, stride);

--- a/tests/utility/storage_test.cu
+++ b/tests/utility/storage_test.cu
@@ -37,6 +37,15 @@ TEMPLATE_TEST_CASE_SIG("Storage tests",
   using allocator_type = cuco::cuda_allocator<char>;
   auto allocator       = allocator_type{};
 
+  SECTION("Initialize empty storage is allowed.")
+  {
+    auto s = cuco::
+      aow_storage<cuco::pair<Key, Value>, window_size, cuco::extent<std::size_t>, allocator_type>{
+        cuco::extent<std::size_t>{0}, allocator};
+
+    s.initialize(cuco::pair<Key, Value>{1, 1});
+  }
+
   SECTION("Allocate array of pairs with AoS storage.")
   {
     auto s = cuco::


### PR DESCRIPTION
This PR adds an early return for storage initialization so launching an empty kernel won't crash.