### PR TITLE
Fix retrieve_all for containers with large capacity

### DIFF
--- a/include/cuco/detail/open_addressing/open_addressing_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_impl.cuh
@@ -649,6 +649,7 @@ class open_addressing_impl {
     auto d_num_out      = reinterpret_cast<size_type*>(
       std::allocator_traits<temp_allocator_type>::allocate(temp_allocator, sizeof(size_type)));
 
+    // TODO: PR #580 to be reverted once https://github.com/NVIDIA/cccl/issues/1422 is resolved
     for (cuco::detail::index_type offset = 0;
          offset < static_cast<cuco::detail::index_type>(this->capacity());
          offset += stride) {

--- a/tests/static_set/large_input_test.cu
+++ b/tests/static_set/large_input_test.cu
@@ -56,7 +56,7 @@ void test_unique_sequence(Set& set, bool* res_begin, std::size_t num_keys)
 }
 
 TEMPLATE_TEST_CASE_SIG(
-  "Large input",
+  "cuco::static_set large input test",
   "",
   ((typename Key, cuco::test::probe_sequence Probe, int CGSize), Key, Probe, CGSize),
   (int32_t, cuco::test::probe_sequence::double_hashing, 1),


### PR DESCRIPTION
Fix #576

This PR fixes the large input retrieve_all bug with a method similar to the streaming approach mentioned in https://github.com/NVIDIA/cccl/issues/1422#issuecomment-2285307255.

To be reverted once the CCCL fix is in place.