### PR TITLE
Expose `key_eq` member accessors

### DIFF
--- a/include/cuco/detail/static_map/static_map.inl
+++ b/include/cuco/detail/static_map/static_map.inl
@@ -717,6 +717,21 @@ template <class Key,
           class ProbingScheme,
           class Allocator,
           class Storage>
+constexpr static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::key_equal
+static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::key_eq()
+  const noexcept
+{
+  return impl_->key_eq();
+}
+
+template <class Key,
+          class T,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
 template <typename... Operators>
 auto static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::ref(
   Operators...) const noexcept

--- a/include/cuco/detail/static_multimap/static_multimap.inl
+++ b/include/cuco/detail/static_multimap/static_multimap.inl
@@ -320,6 +320,22 @@ template <class Key,
           class ProbingScheme,
           class Allocator,
           class Storage>
+constexpr static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::
+  key_equal
+  static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::key_eq()
+    const noexcept
+{
+  return impl_->key_eq();
+}
+
+template <class Key,
+          class T,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
 template <typename... Operators>
 auto static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::ref(
   Operators...) const noexcept

--- a/include/cuco/detail/static_multiset/static_multiset.inl
+++ b/include/cuco/detail/static_multiset/static_multiset.inl
@@ -400,6 +400,21 @@ template <class Key,
           class ProbingScheme,
           class Allocator,
           class Storage>
+constexpr static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::
+  key_equal
+  static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::key_eq()
+    const noexcept
+{
+  return impl_->key_eq();
+}
+
+template <class Key,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
 template <typename... Operators>
 auto static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::ref(
   Operators...) const noexcept

--- a/include/cuco/detail/static_set/static_set.inl
+++ b/include/cuco/detail/static_set/static_set.inl
@@ -521,6 +521,19 @@ template <class Key,
           class ProbingScheme,
           class Allocator,
           class Storage>
+constexpr static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::key_equal
+static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::key_eq() const noexcept
+{
+  return impl_->key_eq();
+}
+
+template <class Key,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
 template <typename... Operators>
 auto static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::ref(
   Operators...) const noexcept

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -953,6 +953,13 @@ class static_map {
   [[nodiscard]] constexpr key_type erased_key_sentinel() const noexcept;
 
   /**
+   * @brief Gets the key comparator.
+   *
+   * @return The comparator used to compare keys
+   */
+  [[nodiscard]] constexpr key_equal key_eq() const noexcept;
+
+  /**
    * @brief Get device ref with operators.
    *
    * @tparam Operators Set of `cuco::op` to be provided by the ref

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -953,9 +953,9 @@ class static_map {
   [[nodiscard]] constexpr key_type erased_key_sentinel() const noexcept;
 
   /**
-   * @brief Gets the key comparator.
+   * @brief Gets the function used to compare keys for equality
    *
-   * @return The comparator used to compare keys
+   * @return The function used to compare keys for equality
    */
   [[nodiscard]] constexpr key_equal key_eq() const noexcept;
 

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -448,6 +448,13 @@ class static_multimap {
   [[nodiscard]] constexpr key_type erased_key_sentinel() const noexcept;
 
   /**
+   * @brief Gets the key comparator.
+   *
+   * @return The comparator used to compare keys
+   */
+  [[nodiscard]] constexpr key_equal key_eq() const noexcept;
+
+  /**
    * @brief Get device ref with operators.
    *
    * @tparam Operators Set of `cuco::op` to be provided by the ref

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -448,9 +448,9 @@ class static_multimap {
   [[nodiscard]] constexpr key_type erased_key_sentinel() const noexcept;
 
   /**
-   * @brief Gets the key comparator.
+   * @brief Gets the function used to compare keys for equality
    *
-   * @return The comparator used to compare keys
+   * @return The function used to compare keys for equality
    */
   [[nodiscard]] constexpr key_equal key_eq() const noexcept;
 

--- a/include/cuco/static_multiset.cuh
+++ b/include/cuco/static_multiset.cuh
@@ -571,9 +571,9 @@ class static_multiset {
   [[nodiscard]] constexpr key_type erased_key_sentinel() const noexcept;
 
   /**
-   * @brief Gets the key comparator.
+   * @brief Gets the function used to compare keys for equality
    *
-   * @return The comparator used to compare keys
+   * @return The function used to compare keys for equality
    */
   [[nodiscard]] constexpr key_equal key_eq() const noexcept;
 

--- a/include/cuco/static_multiset.cuh
+++ b/include/cuco/static_multiset.cuh
@@ -571,6 +571,13 @@ class static_multiset {
   [[nodiscard]] constexpr key_type erased_key_sentinel() const noexcept;
 
   /**
+   * @brief Gets the key comparator.
+   *
+   * @return The comparator used to compare keys
+   */
+  [[nodiscard]] constexpr key_equal key_eq() const noexcept;
+
+  /**
    * @brief Get device ref with operators.
    *
    * @tparam Operators Set of `cuco::op` to be provided by the ref

--- a/include/cuco/static_set.cuh
+++ b/include/cuco/static_set.cuh
@@ -767,9 +767,9 @@ class static_set {
   [[nodiscard]] constexpr key_type erased_key_sentinel() const noexcept;
 
   /**
-   * @brief Gets the key comparator.
+   * @brief Gets the function used to compare keys for equality
    *
-   * @return The comparator used to compare keys
+   * @return The function used to compare keys for equality
    */
   [[nodiscard]] constexpr key_equal key_eq() const noexcept;
 

--- a/include/cuco/static_set.cuh
+++ b/include/cuco/static_set.cuh
@@ -767,6 +767,13 @@ class static_set {
   [[nodiscard]] constexpr key_type erased_key_sentinel() const noexcept;
 
   /**
+   * @brief Gets the key comparator.
+   *
+   * @return The comparator used to compare keys
+   */
+  [[nodiscard]] constexpr key_equal key_eq() const noexcept;
+
+  /**
    * @brief Get device ref with operators.
    *
    * @tparam Operators Set of `cuco::op` to be provided by the ref


### PR DESCRIPTION
Currently, `key_eq` is only accessible in ref classes, not in container classes. This PR addresses the issue by exposing `key_eq` in all classes.