### PR TITLE
Improve rebind utilities for cuco hash tables

### DIFF
--- a/include/cuco/detail/probing_scheme/probing_scheme_impl.inl
+++ b/include/cuco/detail/probing_scheme/probing_scheme_impl.inl
@@ -143,7 +143,7 @@ __host__ __device__ constexpr double_hashing<CGSize, Hash1, Hash2>::double_hashi
 
 template <int32_t CGSize, typename Hash1, typename Hash2>
 __host__ __device__ constexpr double_hashing<CGSize, Hash1, Hash2>::double_hashing(
-  cuco::pair<Hash1, Hash2> const& hash)
+  cuda::std::tuple<Hash1, Hash2> const& hash)
   : hash1_{hash.first}, hash2_{hash.second}
 {
 }
@@ -156,7 +156,7 @@ __host__ __device__ constexpr auto double_hashing<CGSize, Hash1, Hash2>::rebind_
   static_assert(cuco::is_tuple_like<NewHash>::value,
                 "The given hasher must be a tuple-like object");
 
-  auto const [hash1, hash2] = cuco::pair{hash};
+  auto const [hash1, hash2] = cuda::std::tuple{hash};
   using hash1_type          = cuda::std::decay_t<decltype(hash1)>;
   using hash2_type          = cuda::std::decay_t<decltype(hash2)>;
   return double_hashing<cg_size, hash1_type, hash2_type>{hash1, hash2};

--- a/include/cuco/detail/probing_scheme/probing_scheme_impl.inl
+++ b/include/cuco/detail/probing_scheme/probing_scheme_impl.inl
@@ -95,7 +95,7 @@ __host__ __device__ constexpr linear_probing<CGSize, Hash>::linear_probing(Hash 
 
 template <int32_t CGSize, typename Hash>
 template <typename NewHash>
-__host__ __device__ constexpr auto linear_probing<CGSize, Hash>::with_hash_function(
+__host__ __device__ constexpr auto linear_probing<CGSize, Hash>::rebind_hash_function(
   NewHash const& hash) const noexcept
 {
   return linear_probing<cg_size, NewHash>{hash};
@@ -149,16 +149,8 @@ __host__ __device__ constexpr double_hashing<CGSize, Hash1, Hash2>::double_hashi
 }
 
 template <int32_t CGSize, typename Hash1, typename Hash2>
-template <typename NewHash1, typename NewHash2>
-__host__ __device__ constexpr auto double_hashing<CGSize, Hash1, Hash2>::with_hash_function(
-  NewHash1 const& hash1, NewHash2 const& hash2) const noexcept
-{
-  return double_hashing<cg_size, NewHash1, NewHash2>{hash1, hash2};
-}
-
-template <int32_t CGSize, typename Hash1, typename Hash2>
 template <typename NewHash, typename Enable>
-__host__ __device__ constexpr auto double_hashing<CGSize, Hash1, Hash2>::with_hash_function(
+__host__ __device__ constexpr auto double_hashing<CGSize, Hash1, Hash2>::rebind_hash_function(
   NewHash const& hash) const
 {
   static_assert(cuco::is_tuple_like<NewHash>::value,

--- a/include/cuco/detail/static_map/kernels.cuh
+++ b/include/cuco/detail/static_map/kernels.cuh
@@ -206,7 +206,7 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void insert_or_apply_shmem(
                                      ref.probing_scheme(),
                                          {},
                                      storage};
-  auto shared_map_ref = std::move(shared_map).with(cuco::op::insert_or_apply);
+  auto shared_map_ref = shared_map.rebind_operators(cuco::op::insert_or_apply);
   shared_map_ref.initialize(block);
   block.sync();
 

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -296,11 +296,17 @@ template <typename Key,
           typename StorageRef,
           typename... Operators>
 template <typename... NewOperators>
-auto static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::with(
-  NewOperators...) && noexcept
+__host__ __device__ constexpr auto
+static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::with_operators(
+  NewOperators...) const noexcept
 {
   return static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, NewOperators...>{
-    std::move(*this)};
+    cuco::empty_key<Key>{this->empty_key_sentinel()},
+    cuco::empty_value<T>{this->empty_value_sentinel()},
+    this->key_eq(),
+    this->probing_scheme(),
+    {},
+    this->storage_ref()};
 }
 
 template <typename Key,
@@ -312,7 +318,7 @@ template <typename Key,
           typename... Operators>
 template <typename... NewOperators>
 __host__ __device__ constexpr auto
-static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::with_operators(
+static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::rebind_operators(
   NewOperators...) const noexcept
 {
   return static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, NewOperators...>{

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -331,6 +331,27 @@ template <typename Key,
           typename ProbingScheme,
           typename StorageRef,
           typename... Operators>
+template <typename NewKeyEqual>
+__host__ __device__ constexpr auto
+static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::rebind_key_eq(
+  NewKeyEqual const& key_equal) const noexcept
+{
+  return static_map_ref<Key, T, Scope, NewKeyEqual, ProbingScheme, StorageRef, Operators...>{
+    cuco::empty_key<Key>{this->empty_key_sentinel()},
+    cuco::empty_value<T>{this->empty_value_sentinel()},
+    key_equal,
+    this->probing_scheme(),
+    {},
+    this->storage_ref()};
+}
+
+template <typename Key,
+          typename T,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
 template <typename NewHash>
 __host__ __device__ constexpr auto
 static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::

--- a/include/cuco/detail/static_multimap/static_multimap_ref.inl
+++ b/include/cuco/detail/static_multimap/static_multimap_ref.inl
@@ -334,6 +334,33 @@ template <typename Key,
           typename ProbingScheme,
           typename StorageRef,
           typename... Operators>
+template <typename NewHash>
+__host__ __device__ constexpr auto
+static_multimap_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::
+  rebind_hash_function(NewHash const& hash) const
+{
+  auto const probing_scheme = this->probing_scheme().rebind_hash_function(hash);
+  return static_multimap_ref<Key,
+                             T,
+                             Scope,
+                             KeyEqual,
+                             cuda::std::decay_t<decltype(probing_scheme)>,
+                             StorageRef,
+                             Operators...>{cuco::empty_key<Key>{this->empty_key_sentinel()},
+                                           cuco::empty_value<T>{this->empty_value_sentinel()},
+                                           this->key_eq(),
+                                           probing_scheme,
+                                           {},
+                                           this->storage_ref()};
+}
+
+template <typename Key,
+          typename T,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
 template <typename CG, cuda::thread_scope NewScope>
 __device__ constexpr auto
 static_multimap_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::make_copy(

--- a/include/cuco/detail/static_multimap/static_multimap_ref.inl
+++ b/include/cuco/detail/static_multimap/static_multimap_ref.inl
@@ -307,7 +307,7 @@ __host__ __device__ auto constexpr static_multimap_ref<
     cuco::empty_key<Key>{this->empty_key_sentinel()},
     cuco::empty_value<T>{this->empty_value_sentinel()},
     this->key_eq(),
-    impl_.probing_scheme(),
+    this->probing_scheme(),
     {},
     impl_.storage_ref()};
 }
@@ -335,7 +335,7 @@ __host__ __device__ auto constexpr static_multimap_ref<
     this->key_eq(),
     impl_.probing_scheme(),
     {},
-    impl_.storage_ref()};
+    this->storage_ref()};
 }
 
 template <typename Key,

--- a/include/cuco/detail/static_multimap/static_multimap_ref.inl
+++ b/include/cuco/detail/static_multimap/static_multimap_ref.inl
@@ -334,6 +334,27 @@ template <typename Key,
           typename ProbingScheme,
           typename StorageRef,
           typename... Operators>
+template <typename NewKeyEqual>
+__host__ __device__ constexpr auto
+static_multimap_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::
+  rebind_key_eq(NewKeyEqual const& key_equal) const noexcept
+{
+  return static_multimap_ref<Key, T, Scope, NewKeyEqual, ProbingScheme, StorageRef, Operators...>{
+    cuco::empty_key<Key>{this->empty_key_sentinel()},
+    cuco::empty_value<T>{this->empty_value_sentinel()},
+    key_equal,
+    this->probing_scheme(),
+    {},
+    this->storage_ref()};
+}
+
+template <typename Key,
+          typename T,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
 template <typename NewHash>
 __host__ __device__ constexpr auto
 static_multimap_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::

--- a/include/cuco/detail/static_multimap/static_multimap_ref.inl
+++ b/include/cuco/detail/static_multimap/static_multimap_ref.inl
@@ -294,11 +294,22 @@ template <typename Key,
           typename StorageRef,
           typename... Operators>
 template <typename... NewOperators>
-auto static_multimap_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::with(
-  NewOperators...) && noexcept
+__host__ __device__ auto constexpr static_multimap_ref<
+  Key,
+  T,
+  Scope,
+  KeyEqual,
+  ProbingScheme,
+  StorageRef,
+  Operators...>::with_operators(NewOperators...) const noexcept
 {
   return static_multimap_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, NewOperators...>{
-    std::move(*this)};
+    cuco::empty_key<Key>{this->empty_key_sentinel()},
+    cuco::empty_value<T>{this->empty_value_sentinel()},
+    this->key_eq(),
+    impl_.probing_scheme(),
+    {},
+    impl_.storage_ref()};
 }
 
 template <typename Key,
@@ -316,7 +327,7 @@ __host__ __device__ auto constexpr static_multimap_ref<
   KeyEqual,
   ProbingScheme,
   StorageRef,
-  Operators...>::with_operators(NewOperators...) const noexcept
+  Operators...>::rebind_operators(NewOperators...) const noexcept
 {
   return static_multimap_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, NewOperators...>{
     cuco::empty_key<Key>{this->empty_key_sentinel()},

--- a/include/cuco/detail/static_multiset/static_multiset.inl
+++ b/include/cuco/detail/static_multiset/static_multiset.inl
@@ -308,10 +308,11 @@ static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>
   ProbeHash const& probe_hash,
   cuda::stream_ref stream) const
 {
-  return impl_->count(first,
-                      last,
-                      ref(op::count).with_key_eq(probe_key_equal).rebind_hash_function(probe_hash),
-                      stream);
+  return impl_->count(
+    first,
+    last,
+    ref(op::count).rebind_key_eq(probe_key_equal).rebind_hash_function(probe_hash),
+    stream);
 }
 
 template <class Key,
@@ -333,7 +334,7 @@ static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>
   return impl_->count_outer(
     first,
     last,
-    ref(op::count).with_key_eq(probe_key_equal).rebind_hash_function(probe_hash),
+    ref(op::count).rebind_key_eq(probe_key_equal).rebind_hash_function(probe_hash),
     stream);
 }
 

--- a/include/cuco/detail/static_multiset/static_multiset.inl
+++ b/include/cuco/detail/static_multiset/static_multiset.inl
@@ -310,7 +310,7 @@ static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>
 {
   return impl_->count(first,
                       last,
-                      ref(op::count).with_key_eq(probe_key_equal).with_hash_function(probe_hash),
+                      ref(op::count).with_key_eq(probe_key_equal).rebind_hash_function(probe_hash),
                       stream);
 }
 
@@ -333,7 +333,7 @@ static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>
   return impl_->count_outer(
     first,
     last,
-    ref(op::count).with_key_eq(probe_key_equal).with_hash_function(probe_hash),
+    ref(op::count).with_key_eq(probe_key_equal).rebind_hash_function(probe_hash),
     stream);
 }
 

--- a/include/cuco/detail/static_multiset/static_multiset_ref.inl
+++ b/include/cuco/detail/static_multiset/static_multiset_ref.inl
@@ -285,7 +285,7 @@ template <typename Key,
           typename... Operators>
 template <typename NewKeyEqual>
 __host__ __device__ constexpr auto
-static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::with_key_eq(
+static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::rebind_key_eq(
   NewKeyEqual const& key_equal) const noexcept
 {
   return static_multiset_ref<Key, Scope, NewKeyEqual, ProbingScheme, StorageRef, Operators...>{

--- a/include/cuco/detail/static_multiset/static_multiset_ref.inl
+++ b/include/cuco/detail/static_multiset/static_multiset_ref.inl
@@ -251,11 +251,16 @@ template <typename Key,
           typename StorageRef,
           typename... Operators>
 template <typename... NewOperators>
-auto static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::with(
-  NewOperators...) && noexcept
+__host__ __device__ constexpr auto
+static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::with_operators(
+  NewOperators...) const noexcept
 {
   return static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, NewOperators...>{
-    std::move(*this)};
+    cuco::empty_key<Key>{this->empty_key_sentinel()},
+    this->key_eq(),
+    this->probing_scheme(),
+    {},
+    this->storage_ref()};
 }
 
 template <typename Key,
@@ -266,8 +271,8 @@ template <typename Key,
           typename... Operators>
 template <typename... NewOperators>
 __host__ __device__ constexpr auto
-static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::with_operators(
-  NewOperators...) const noexcept
+static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::
+  rebind_operators(NewOperators...) const noexcept
 {
   return static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, NewOperators...>{
     cuco::empty_key<Key>{this->empty_key_sentinel()},

--- a/include/cuco/detail/static_multiset/static_multiset_ref.inl
+++ b/include/cuco/detail/static_multiset/static_multiset_ref.inl
@@ -272,9 +272,9 @@ static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators..
   return static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, NewOperators...>{
     cuco::empty_key<Key>{this->empty_key_sentinel()},
     this->key_eq(),
-    this->impl_.probing_scheme(),
+    this->probing_scheme(),
     {},
-    this->impl_.storage_ref()};
+    this->storage_ref()};
 }
 
 template <typename Key,
@@ -291,9 +291,9 @@ static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators..
   return static_multiset_ref<Key, Scope, NewKeyEqual, ProbingScheme, StorageRef, Operators...>{
     cuco::empty_key<Key>{this->empty_key_sentinel()},
     key_equal,
-    this->impl_.probing_scheme(),
+    this->probing_scheme(),
     {},
-    this->impl_.storage_ref()};
+    this->storage_ref()};
 }
 
 template <typename Key,
@@ -305,19 +305,19 @@ template <typename Key,
 template <typename NewHash>
 __host__ __device__ constexpr auto
 static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::
-  with_hash_function(NewHash const& hash) const
+  rebind_hash_function(NewHash const& hash) const
 {
-  auto const probing_scheme = this->impl_.probing_scheme().with_hash_function(hash);
+  auto const probing_scheme = this->probing_scheme().rebind_hash_function(hash);
   return static_multiset_ref<Key,
                              Scope,
                              KeyEqual,
                              cuda::std::decay_t<decltype(probing_scheme)>,
                              StorageRef,
                              Operators...>{cuco::empty_key<Key>{this->empty_key_sentinel()},
-                                           this->impl_.key_eq(),
+                                           this->key_eq(),
                                            probing_scheme,
                                            {},
-                                           this->impl_.storage_ref()};
+                                           this->storage_ref()};
 }
 
 namespace detail {

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -282,7 +282,7 @@ template <typename Key,
           typename... Operators>
 template <typename NewKeyEqual>
 __host__ __device__ constexpr auto
-static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::with_key_eq(
+static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::rebind_key_eq(
   NewKeyEqual const& key_equal) const noexcept
 {
   return static_set_ref<Key, Scope, NewKeyEqual, ProbingScheme, StorageRef, Operators...>{

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -269,9 +269,9 @@ static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::w
   return static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, NewOperators...>{
     cuco::empty_key<Key>{this->empty_key_sentinel()},
     this->key_eq(),
-    this->impl_.probing_scheme(),
+    this->probing_scheme(),
     {},
-    this->impl_.storage_ref()};
+    this->storage_ref()};
 }
 
 template <typename Key,
@@ -288,9 +288,9 @@ static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::w
   return static_set_ref<Key, Scope, NewKeyEqual, ProbingScheme, StorageRef, Operators...>{
     cuco::empty_key<Key>{this->empty_key_sentinel()},
     key_equal,
-    this->impl_.probing_scheme(),
+    this->probing_scheme(),
     {},
-    this->impl_.storage_ref()};
+    this->storage_ref()};
 }
 
 template <typename Key,
@@ -301,20 +301,20 @@ template <typename Key,
           typename... Operators>
 template <typename NewHash>
 __host__ __device__ constexpr auto
-static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::with_hash_function(
+static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::rebind_hash_function(
   NewHash const& hash) const
 {
-  auto const probing_scheme = this->impl_.probing_scheme().with_hash_function(hash);
+  auto const probing_scheme = this->probing_scheme().rebind_hash_function(hash);
   return static_set_ref<Key,
                         Scope,
                         KeyEqual,
                         cuda::std::decay_t<decltype(probing_scheme)>,
                         StorageRef,
                         Operators...>{cuco::empty_key<Key>{this->empty_key_sentinel()},
-                                      this->impl_.key_eq(),
+                                      this->key_eq(),
                                       probing_scheme,
                                       {},
-                                      this->impl_.storage_ref()};
+                                      this->storage_ref()};
 }
 
 template <typename Key,
@@ -335,7 +335,7 @@ static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::m
     cuco::empty_key<Key>{this->empty_key_sentinel()},
     cuco::erased_key<Key>{this->erased_key_sentinel()},
     this->key_eq(),
-    this->impl_.probing_scheme(),
+    this->probing_scheme(),
     scope,
     storage_ref_type{this->window_extent(), memory_to_use}};
 }

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -248,11 +248,16 @@ template <typename Key,
           typename StorageRef,
           typename... Operators>
 template <typename... NewOperators>
-auto static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::with(
-  NewOperators...) && noexcept
+__host__ __device__ constexpr auto
+static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::with_operators(
+  NewOperators...) const noexcept
 {
   return static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, NewOperators...>{
-    std::move(*this)};
+    cuco::empty_key<Key>{this->empty_key_sentinel()},
+    this->key_eq(),
+    this->probing_scheme(),
+    {},
+    this->storage_ref()};
 }
 
 template <typename Key,
@@ -263,7 +268,7 @@ template <typename Key,
           typename... Operators>
 template <typename... NewOperators>
 __host__ __device__ constexpr auto
-static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::with_operators(
+static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::rebind_operators(
   NewOperators...) const noexcept
 {
   return static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, NewOperators...>{

--- a/include/cuco/probing_scheme.cuh
+++ b/include/cuco/probing_scheme.cuh
@@ -143,7 +143,7 @@ class double_hashing : private detail::probing_scheme_base<CGSize> {
    *
    * @param hash Hasher tuple
    */
-  __host__ __device__ constexpr double_hashing(cuco::pair<Hash1, Hash2> const& hash);
+  __host__ __device__ constexpr double_hashing(cuda::std::tuple<Hash1, Hash2> const& hash);
 
   /**
    *@brief Makes a copy of the current probing method with the given hasher

--- a/include/cuco/probing_scheme.cuh
+++ b/include/cuco/probing_scheme.cuh
@@ -62,7 +62,7 @@ class linear_probing : private detail::probing_scheme_base<CGSize> {
    * @return Copy of the current probing method
    */
   template <typename NewHash>
-  [[nodiscard]] __host__ __device__ constexpr auto with_hash_function(
+  [[nodiscard]] __host__ __device__ constexpr auto rebind_hash_function(
     NewHash const& hash) const noexcept;
 
   /**
@@ -148,22 +148,6 @@ class double_hashing : private detail::probing_scheme_base<CGSize> {
   /**
    *@brief Makes a copy of the current probing method with the given hasher
    *
-   * @tparam NewHash1 First new hasher type
-   * @tparam NewHash2 Second new hasher type
-   *
-   * @param hash1 First hasher
-   * @param hash2 second hasher
-   *
-   * @return Copy of the current probing method
-   */
-  template <typename NewHash1, typename NewHash2 = NewHash1>
-  [[nodiscard]] __host__ __device__ constexpr auto with_hash_function(NewHash1 const& hash1,
-                                                                      NewHash2 const& hash2 = {
-                                                                        1}) const noexcept;
-
-  /**
-   *@brief Makes a copy of the current probing method with the given hasher
-   *
    * @tparam NewHash Tuple-like new hasher type
    *
    * @throw If `cuco::is_tuple_like_v<NewHash>` is `false`
@@ -174,7 +158,7 @@ class double_hashing : private detail::probing_scheme_base<CGSize> {
    */
   template <typename NewHash,
             typename Enable = cuda::std::enable_if_t<cuco::is_tuple_like<NewHash>::value>>
-  [[nodiscard]] __host__ __device__ constexpr auto with_hash_function(NewHash const& hash) const;
+  [[nodiscard]] __host__ __device__ constexpr auto rebind_hash_function(NewHash const& hash) const;
 
   /**
    * @brief Operator to return a probing iterator

--- a/include/cuco/static_map_ref.cuh
+++ b/include/cuco/static_map_ref.cuh
@@ -262,6 +262,18 @@ class static_map_ref
     NewOperators... ops) const noexcept;
 
   /**
+   * @brief Makes a copy of the current device reference with the given hasher
+   *
+   * @tparam NewHash The new hasher type
+   *
+   * @param hash New hasher
+   *
+   * @return Copy of the current device ref
+   */
+  template <typename NewHash>
+  [[nodiscard]] __host__ __device__ constexpr auto rebind_hash_function(NewHash const& hash) const;
+
+  /**
    * @brief Makes a copy of the current device reference using non-owned memory
    *
    * This function is intended to be used to create shared memory copies of small static maps,

--- a/include/cuco/static_map_ref.cuh
+++ b/include/cuco/static_map_ref.cuh
@@ -227,25 +227,6 @@ class static_map_ref
   [[nodiscard]] __host__ __device__ constexpr auto probing_scheme() const noexcept;
 
   /**
-   * @brief Creates a reference with new operators from the current object.
-   *
-   * @deprecated This function is deprecated. Use the new `with_operators` instead.
-   *
-   * Note that this function uses move semantics and thus invalidates the current object.
-   *
-   * @warning Using two or more reference objects to the same container but with
-   * a different operator set at the same time results in undefined behavior.
-   *
-   * @tparam NewOperators List of `cuco::op::*_tag` types
-   *
-   * @param ops List of operators, e.g., `cuco::insert`
-   *
-   * @return `*this` with `NewOperators...`
-   */
-  template <typename... NewOperators>
-  [[nodiscard]] __host__ __device__ auto with(NewOperators... ops) && noexcept;
-
-  /**
    * @brief Creates a reference with new operators from the current object
    *
    * @warning Using two or more reference objects to the same container but with
@@ -259,6 +240,19 @@ class static_map_ref
    */
   template <typename... NewOperators>
   [[nodiscard]] __host__ __device__ constexpr auto with_operators(
+    NewOperators... ops) const noexcept;
+
+  /**
+   * @brief Creates a copy of the current non-owning reference using the given operators
+   *
+   * @tparam NewOperators List of `cuco::op::*_tag` types
+   *
+   * @param ops List of operators, e.g., `cuco::op::insert`
+   *
+   * @return Copy of the current device ref
+   */
+  template <typename... NewOperators>
+  [[nodiscard]] __host__ __device__ constexpr auto rebind_operators(
     NewOperators... ops) const noexcept;
 
   /**

--- a/include/cuco/static_map_ref.cuh
+++ b/include/cuco/static_map_ref.cuh
@@ -262,6 +262,19 @@ class static_map_ref
     NewOperators... ops) const noexcept;
 
   /**
+   * @brief Makes a copy of the current device reference with the given key comparator
+   *
+   * @tparam NewKeyEqual The new key equal type
+   *
+   * @param key_equal New key comparator
+   *
+   * @return Copy of the current device ref
+   */
+  template <typename NewKeyEqual>
+  [[nodiscard]] __host__ __device__ constexpr auto rebind_key_eq(
+    NewKeyEqual const& key_equal) const noexcept;
+
+  /**
    * @brief Makes a copy of the current device reference with the given hasher
    *
    * @tparam NewHash The new hasher type

--- a/include/cuco/static_multimap_ref.cuh
+++ b/include/cuco/static_multimap_ref.cuh
@@ -261,6 +261,19 @@ class static_multimap_ref
     NewOperators... ops) const noexcept;
 
   /**
+   * @brief Makes a copy of the current device reference with the given key comparator
+   *
+   * @tparam NewKeyEqual The new key equal type
+   *
+   * @param key_equal New key comparator
+   *
+   * @return Copy of the current device ref
+   */
+  template <typename NewKeyEqual>
+  [[nodiscard]] __host__ __device__ constexpr auto rebind_key_eq(
+    NewKeyEqual const& key_equal) const noexcept;
+
+  /**
    * @brief Makes a copy of the current device reference with the given hasher
    *
    * @tparam NewHash The new hasher type

--- a/include/cuco/static_multimap_ref.cuh
+++ b/include/cuco/static_multimap_ref.cuh
@@ -226,25 +226,6 @@ class static_multimap_ref
   [[nodiscard]] __host__ __device__ constexpr auto probing_scheme() const noexcept;
 
   /**
-   * @brief Creates a reference with new operators from the current object.
-   *
-   * @deprecated This function is deprecated. Use the new `with_operators` instead.
-   *
-   * Note that this function uses move semantics and thus invalidates the current object.
-   *
-   * @warning Using two or more reference objects to the same container but with
-   * a different operator set at the same time results in undefined behavior.
-   *
-   * @tparam NewOperators List of `cuco::op::*_tag` types
-   *
-   * @param ops List of operators, e.g., `cuco::insert`
-   *
-   * @return `*this` with `NewOperators...`
-   */
-  template <typename... NewOperators>
-  [[nodiscard]] __host__ __device__ auto with(NewOperators... ops) && noexcept;
-
-  /**
    * @brief Creates a reference with new operators from the current object
    *
    * @warning Using two or more reference objects to the same container but with
@@ -258,6 +239,19 @@ class static_multimap_ref
    */
   template <typename... NewOperators>
   [[nodiscard]] __host__ __device__ constexpr auto with_operators(
+    NewOperators... ops) const noexcept;
+
+  /**
+   * @brief Creates a copy of the current non-owning reference using the given operators
+   *
+   * @tparam NewOperators List of `cuco::op::*_tag` types
+   *
+   * @param ops List of operators, e.g., `cuco::op::insert`
+   *
+   * @return Copy of the current device ref
+   */
+  template <typename... NewOperators>
+  [[nodiscard]] __host__ __device__ constexpr auto rebind_operators(
     NewOperators... ops) const noexcept;
 
   /**

--- a/include/cuco/static_multimap_ref.cuh
+++ b/include/cuco/static_multimap_ref.cuh
@@ -261,6 +261,18 @@ class static_multimap_ref
     NewOperators... ops) const noexcept;
 
   /**
+   * @brief Makes a copy of the current device reference with the given hasher
+   *
+   * @tparam NewHash The new hasher type
+   *
+   * @param hash New hasher
+   *
+   * @return Copy of the current device ref
+   */
+  template <typename NewHash>
+  [[nodiscard]] __host__ __device__ constexpr auto rebind_hash_function(NewHash const& hash) const;
+
+  /**
    * @brief Makes a copy of the current device reference using non-owned memory
    *
    * This function is intended to be used to create shared memory copies of small static maps,

--- a/include/cuco/static_multiset_ref.cuh
+++ b/include/cuco/static_multiset_ref.cuh
@@ -254,7 +254,7 @@ class static_multiset_ref
     NewKeyEqual const& key_equal) const noexcept;
 
   /**
-   * @brief Makes a copy of the current device reference with given hasher
+   * @brief Makes a copy of the current device reference with the given hasher
    *
    * @tparam NewHash The new hasher type
    *
@@ -263,7 +263,7 @@ class static_multiset_ref
    * @return Copy of the current device ref
    */
   template <typename NewHash>
-  [[nodiscard]] __host__ __device__ constexpr auto with_hash_function(NewHash const& hash) const;
+  [[nodiscard]] __host__ __device__ constexpr auto rebind_hash_function(NewHash const& hash) const;
 
  private:
   impl_type impl_;

--- a/include/cuco/static_multiset_ref.cuh
+++ b/include/cuco/static_multiset_ref.cuh
@@ -241,7 +241,7 @@ class static_multiset_ref
     NewOperators... ops) const noexcept;
 
   /**
-   * @brief Makes a copy of the current device reference with given key comparator
+   * @brief Makes a copy of the current device reference with the given key comparator
    *
    * @tparam NewKeyEqual The new key equal type
    *
@@ -250,7 +250,7 @@ class static_multiset_ref
    * @return Copy of the current device ref
    */
   template <typename NewKeyEqual>
-  [[nodiscard]] __host__ __device__ constexpr auto with_key_eq(
+  [[nodiscard]] __host__ __device__ constexpr auto rebind_key_eq(
     NewKeyEqual const& key_equal) const noexcept;
 
   /**

--- a/include/cuco/static_multiset_ref.cuh
+++ b/include/cuco/static_multiset_ref.cuh
@@ -206,25 +206,6 @@ class static_multiset_ref
   [[nodiscard]] __host__ __device__ constexpr auto probing_scheme() const noexcept;
 
   /**
-   * @brief Creates a reference with new operators from the current object.
-   *
-   * @deprecated This function is deprecated. Use the new `with_operators` instead.
-   *
-   * Note that this function uses move semantics and thus invalidates the current object.
-   *
-   * @warning Using two or more reference objects to the same container but with
-   * a different operator set at the same time results in undefined behavior.
-   *
-   * @tparam NewOperators List of `cuco::op::*_tag` types
-   *
-   * @param ops List of operators, e.g., `cuco::insert`
-   *
-   * @return `*this` with `NewOperators...`
-   */
-  template <typename... NewOperators>
-  [[nodiscard]] __host__ __device__ auto with(NewOperators... ops) && noexcept;
-
-  /**
    * @brief Creates a reference with new operators from the current object
    *
    * @warning Using two or more reference objects to the same container but with
@@ -238,6 +219,19 @@ class static_multiset_ref
    */
   template <typename... NewOperators>
   [[nodiscard]] __host__ __device__ constexpr auto with_operators(
+    NewOperators... ops) const noexcept;
+
+  /**
+   * @brief Creates a copy of the current non-owning reference using the given operators
+   *
+   * @tparam NewOperators List of `cuco::op::*_tag` types
+   *
+   * @param ops List of operators, e.g., `cuco::op::insert`
+   *
+   * @return Copy of the current device ref
+   */
+  template <typename... NewOperators>
+  [[nodiscard]] __host__ __device__ constexpr auto rebind_operators(
     NewOperators... ops) const noexcept;
 
   /**

--- a/include/cuco/static_set_ref.cuh
+++ b/include/cuco/static_set_ref.cuh
@@ -239,7 +239,7 @@ class static_set_ref
     NewOperators... ops) const noexcept;
 
   /**
-   * @brief Makes a copy of the current device reference with given key comparator
+   * @brief Makes a copy of the current device reference with the given key comparator
    *
    * @tparam NewKeyEqual The new key equal type
    *
@@ -248,7 +248,7 @@ class static_set_ref
    * @return Copy of the current device ref
    */
   template <typename NewKeyEqual>
-  [[nodiscard]] __host__ __device__ constexpr auto with_key_eq(
+  [[nodiscard]] __host__ __device__ constexpr auto rebind_key_eq(
     NewKeyEqual const& key_equal) const noexcept;
 
   /**

--- a/include/cuco/static_set_ref.cuh
+++ b/include/cuco/static_set_ref.cuh
@@ -204,25 +204,6 @@ class static_set_ref
   [[nodiscard]] __host__ __device__ constexpr auto probing_scheme() const noexcept;
 
   /**
-   * @brief Creates a reference with new operators from the current object.
-   *
-   * @deprecated This function is deprecated. Use the new `with_operators` instead.
-   *
-   * Note that this function uses move semantics and thus invalidates the current object.
-   *
-   * @warning Using two or more reference objects to the same container but with
-   * a different operator set at the same time results in undefined behavior.
-   *
-   * @tparam NewOperators List of `cuco::op::*_tag` types
-   *
-   * @param ops List of operators, e.g., `cuco::insert`
-   *
-   * @return `*this` with `NewOperators...`
-   */
-  template <typename... NewOperators>
-  [[nodiscard]] __host__ __device__ auto with(NewOperators... ops) && noexcept;
-
-  /**
    * @brief Creates a reference with new operators from the current object
    *
    * @warning Using two or more reference objects to the same container but with
@@ -236,6 +217,19 @@ class static_set_ref
    */
   template <typename... NewOperators>
   [[nodiscard]] __host__ __device__ constexpr auto with_operators(
+    NewOperators... ops) const noexcept;
+
+  /**
+   * @brief Creates a copy of the current non-owning reference using the given operators
+   *
+   * @tparam NewOperators List of `cuco::op::*_tag` types
+   *
+   * @param ops List of operators, e.g., `cuco::op::insert`
+   *
+   * @return Copy of the current device ref
+   */
+  template <typename... NewOperators>
+  [[nodiscard]] __host__ __device__ constexpr auto rebind_operators(
     NewOperators... ops) const noexcept;
 
   /**

--- a/include/cuco/static_set_ref.cuh
+++ b/include/cuco/static_set_ref.cuh
@@ -252,7 +252,7 @@ class static_set_ref
     NewKeyEqual const& key_equal) const noexcept;
 
   /**
-   * @brief Makes a copy of the current device reference with given hasher
+   * @brief Makes a copy of the current device reference with the given hasher
    *
    * @tparam NewHash The new hasher type
    *
@@ -261,7 +261,7 @@ class static_set_ref
    * @return Copy of the current device ref
    */
   template <typename NewHash>
-  [[nodiscard]] __host__ __device__ constexpr auto with_hash_function(NewHash const& hash) const;
+  [[nodiscard]] __host__ __device__ constexpr auto rebind_hash_function(NewHash const& hash) const;
 
   /**
    * @brief Makes a copy of the current device reference using non-owned memory

--- a/tests/static_multiset/custom_count_test.cu
+++ b/tests/static_multiset/custom_count_test.cu
@@ -63,7 +63,7 @@ void test_custom_count(Set& set, size_type num_keys)
 
   auto const hash = []() {
     if constexpr (cuco::is_double_hashing<typename Set::probing_scheme_type>::value) {
-      return cuco::pair{custom_hash{}, custom_hash{}};
+      return cuda::std::tuple{custom_hash{}, custom_hash{}};
     } else {
       return custom_hash{};
     }


### PR DESCRIPTION
This PR renames all `with_*` member functions to `rebind_*` for improved clarity.

The legacy `with_operators` will be removed once libcudf is migrated to use the new `rebind_operators`.