### PR TITLE
Restore the deprecated `with_key_eq` to prevent breaking changes in libcudf.

### DIFF
--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -304,6 +304,20 @@ template <typename Key,
           typename ProbingScheme,
           typename StorageRef,
           typename... Operators>
+template <typename NewKeyEqual>
+__host__ __device__ constexpr auto
+static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::with_key_eq(
+  NewKeyEqual const& key_equal) const noexcept
+{
+  return this->rebind_key_eq(key_equal);
+}
+
+template <typename Key,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
 template <typename NewHash>
 __host__ __device__ constexpr auto
 static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::rebind_hash_function(

--- a/include/cuco/static_set_ref.cuh
+++ b/include/cuco/static_set_ref.cuh
@@ -246,6 +246,19 @@ class static_set_ref
     NewKeyEqual const& key_equal) const noexcept;
 
   /**
+   * @brief Makes a copy of the current device reference with the given key comparator
+   *
+   * @tparam NewKeyEqual The new key equal type
+   *
+   * @param key_equal New key comparator
+   *
+   * @return Copy of the current device ref
+   */
+  template <typename NewKeyEqual>
+  [[nodiscard]] __host__ __device__ constexpr auto with_key_eq(
+    NewKeyEqual const& key_equal) const noexcept;
+
+  /**
    * @brief Makes a copy of the current device reference with the given hasher
    *
    * @tparam NewHash The new hasher type


### PR DESCRIPTION
Unblock https://github.com/rapidsai/cudf/pull/16967

This PR restores the deprecated `with_key_eq` to avoid a breaking change in libcudf.

To be reverted once libcudf is migrated to use the new `rebind_key_eq`.