### PR TITLE
CUPTI metrics for bloom_filter benchmarks

### DIFF
--- a/benchmarks/bloom_filter/add_bench.cu
+++ b/benchmarks/bloom_filter/add_bench.cu
@@ -70,6 +70,12 @@ void bloom_filter_add(nvbench::state& state,
 
   filter_type filter{num_sub_filters, {}, {static_cast<uint32_t>(pattern_bits)}};
 
+  state.collect_dram_throughput();
+  state.collect_l1_hit_rates();
+  state.collect_l2_hit_rates();
+  state.collect_loads_efficiency();
+  state.collect_stores_efficiency();
+
   add_fpr_summary(state, filter);
 
   state.exec([&](nvbench::launch& launch) {

--- a/benchmarks/bloom_filter/add_bench.cu
+++ b/benchmarks/bloom_filter/add_bench.cu
@@ -49,7 +49,7 @@ void bloom_filter_add(nvbench::state& state,
 
   auto const num_keys       = state.get_int64("NumInputs");
   auto const filter_size_mb = state.get_int64("FilterSizeMB");
-  auto const pattern_bits   = state.get_int64("PatternBits");
+  auto const pattern_bits   = state.get_int64_or_default("PatternBits", WordsPerBlock);
 
   try {
     auto const policy = policy_type{static_cast<uint32_t>(pattern_bits)};
@@ -93,8 +93,7 @@ NVBENCH_BENCH_TYPES(bloom_filter_add,
   .set_type_axes_names({"Key", "Hash", "Word", "WordsPerBlock", "Distribution"})
   .set_max_noise(defaults::MAX_NOISE)
   .add_int64_axis("NumInputs", {defaults::BF_N})
-  .add_int64_axis("FilterSizeMB", defaults::BF_SIZE_MB_RANGE_CACHE)
-  .add_int64_axis("PatternBits", {defaults::BF_PATTERN_BITS});
+  .add_int64_axis("FilterSizeMB", defaults::BF_SIZE_MB_RANGE_CACHE);
 
 NVBENCH_BENCH_TYPES(bloom_filter_add,
                     NVBENCH_TYPE_AXES(nvbench::type_list<defaults::BF_KEY>,
@@ -106,8 +105,7 @@ NVBENCH_BENCH_TYPES(bloom_filter_add,
   .set_type_axes_names({"Key", "Hash", "Word", "WordsPerBlock", "Distribution"})
   .set_max_noise(defaults::MAX_NOISE)
   .add_int64_axis("NumInputs", {defaults::BF_N})
-  .add_int64_axis("FilterSizeMB", {defaults::BF_SIZE_MB})
-  .add_int64_axis("PatternBits", {defaults::BF_PATTERN_BITS});
+  .add_int64_axis("FilterSizeMB", {defaults::BF_SIZE_MB});
 
 NVBENCH_BENCH_TYPES(bloom_filter_add,
                     NVBENCH_TYPE_AXES(nvbench::type_list<defaults::BF_KEY>,
@@ -119,5 +117,4 @@ NVBENCH_BENCH_TYPES(bloom_filter_add,
   .set_type_axes_names({"Key", "Hash", "Word", "WordsPerBlock", "Distribution"})
   .set_max_noise(defaults::MAX_NOISE)
   .add_int64_axis("NumInputs", {defaults::BF_N})
-  .add_int64_axis("FilterSizeMB", {defaults::BF_SIZE_MB})
-  .add_int64_axis("PatternBits", {defaults::BF_PATTERN_BITS});
+  .add_int64_axis("FilterSizeMB", {defaults::BF_SIZE_MB});

--- a/benchmarks/bloom_filter/contains_bench.cu
+++ b/benchmarks/bloom_filter/contains_bench.cu
@@ -73,6 +73,12 @@ void bloom_filter_contains(
 
   filter_type filter{num_sub_filters, {}, {static_cast<uint32_t>(pattern_bits)}};
 
+  state.collect_dram_throughput();
+  state.collect_l1_hit_rates();
+  state.collect_l2_hit_rates();
+  state.collect_loads_efficiency();
+  state.collect_stores_efficiency();
+
   add_fpr_summary(state, filter);
 
   filter.add(keys.begin(), keys.end());

--- a/benchmarks/bloom_filter/contains_bench.cu
+++ b/benchmarks/bloom_filter/contains_bench.cu
@@ -51,7 +51,7 @@ void bloom_filter_contains(
 
   auto const num_keys       = state.get_int64("NumInputs");
   auto const filter_size_mb = state.get_int64("FilterSizeMB");
-  auto const pattern_bits   = state.get_int64("PatternBits");
+  auto const pattern_bits   = state.get_int64_or_default("PatternBits", WordsPerBlock);
 
   try {
     auto const policy = policy_type{static_cast<uint32_t>(pattern_bits)};
@@ -98,8 +98,7 @@ NVBENCH_BENCH_TYPES(bloom_filter_contains,
   .set_type_axes_names({"Key", "Hash", "Word", "WordsPerBlock", "Distribution"})
   .set_max_noise(defaults::MAX_NOISE)
   .add_int64_axis("NumInputs", {defaults::BF_N})
-  .add_int64_axis("FilterSizeMB", defaults::BF_SIZE_MB_RANGE_CACHE)
-  .add_int64_axis("PatternBits", {defaults::BF_PATTERN_BITS});
+  .add_int64_axis("FilterSizeMB", defaults::BF_SIZE_MB_RANGE_CACHE);
 
 NVBENCH_BENCH_TYPES(bloom_filter_contains,
                     NVBENCH_TYPE_AXES(nvbench::type_list<defaults::BF_KEY>,
@@ -111,8 +110,7 @@ NVBENCH_BENCH_TYPES(bloom_filter_contains,
   .set_type_axes_names({"Key", "Hash", "Word", "WordsPerBlock", "Distribution"})
   .set_max_noise(defaults::MAX_NOISE)
   .add_int64_axis("NumInputs", {defaults::BF_N})
-  .add_int64_axis("FilterSizeMB", {defaults::BF_SIZE_MB})
-  .add_int64_axis("PatternBits", {defaults::BF_PATTERN_BITS});
+  .add_int64_axis("FilterSizeMB", {defaults::BF_SIZE_MB});
 
 NVBENCH_BENCH_TYPES(bloom_filter_contains,
                     NVBENCH_TYPE_AXES(nvbench::type_list<defaults::BF_KEY>,
@@ -124,5 +122,4 @@ NVBENCH_BENCH_TYPES(bloom_filter_contains,
   .set_type_axes_names({"Key", "Hash", "Word", "WordsPerBlock", "Distribution"})
   .set_max_noise(defaults::MAX_NOISE)
   .add_int64_axis("NumInputs", {defaults::BF_N})
-  .add_int64_axis("FilterSizeMB", {defaults::BF_SIZE_MB})
-  .add_int64_axis("PatternBits", {defaults::BF_PATTERN_BITS});
+  .add_int64_axis("FilterSizeMB", {defaults::BF_SIZE_MB});

--- a/benchmarks/bloom_filter/defaults.hpp
+++ b/benchmarks/bloom_filter/defaults.hpp
@@ -33,7 +33,6 @@ using BF_WORD = nvbench::uint32_t;
 static constexpr auto BF_N               = 400'000'000;
 static constexpr auto BF_SIZE_MB         = 2'000;
 static constexpr auto BF_WORDS_PER_BLOCK = 8;
-static constexpr auto BF_PATTERN_BITS    = BF_WORDS_PER_BLOCK;
 
 auto const BF_SIZE_MB_RANGE_CACHE =
   std::vector<nvbench::int64_t>{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048};


### PR DESCRIPTION
This PR introduces collecting CUPTI metrics (DRAM throughput, cache hit rates, etc.) during the `cuco::bloom_filter` benchmark.

Additionally, the benchmark now uses the default `pattern_bits` value for a given policy instead of hardcoding it to 8.