### PR TITLE
Restore with_hash_function for static_set

### DIFF
--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -342,6 +342,20 @@ template <typename Key,
           typename ProbingScheme,
           typename StorageRef,
           typename... Operators>
+template <typename NewHash>
+__host__ __device__ constexpr auto
+static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::with_hash_function(
+  NewHash const& hash) const
+{
+  return this->rebind_hash_function(hash);
+}
+
+template <typename Key,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
 template <typename CG, cuda::thread_scope NewScope>
 __device__ constexpr auto
 static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::make_copy(

--- a/include/cuco/static_set_ref.cuh
+++ b/include/cuco/static_set_ref.cuh
@@ -271,6 +271,18 @@ class static_set_ref
   [[nodiscard]] __host__ __device__ constexpr auto rebind_hash_function(NewHash const& hash) const;
 
   /**
+   * @brief Makes a copy of the current device reference with the given hasher
+   *
+   * @tparam NewHash The new hasher type
+   *
+   * @param hash New hasher
+   *
+   * @return Copy of the current device ref
+   */
+  template <typename NewHash>
+  [[nodiscard]] __host__ __device__ constexpr auto with_hash_function(NewHash const& hash) const;
+
+  /**
    * @brief Makes a copy of the current device reference using non-owned memory
    *
    * This function is intended to be used to create shared memory copies of small static sets,


### PR DESCRIPTION
This is the last piece required by https://github.com/rapidsai/cudf/pull/16967

To be reverted once libcudf has been updated to use the new `rebind_*` equivalents.