### PR TITLE
Deprecate device `with_operators` utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,8 @@ We plan to add many GPU-accelerated, concurrent data structures to `cuCollection
 #### Examples:
 - [Host-bulk APIs](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_set/host_bulk_example.cu) (see [live example in godbolt](https://godbolt.org/z/96re4zhjo))
 - [Device-ref APIs for individual operations](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_set/device_ref_example.cu) (see [live example in godbolt](https://godbolt.org/z/7aKWdGTfx))
-- [One single storage for multiple sets](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_set/device_subsets_example.cu) (see [live example in godbolt](https://godbolt.org/z/sMfqGxdha))
-- [Using shared memory as storage](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_set/shared_memory_example.cu) (see [live example in godbolt](https://godbolt.org/z/zdTnbE1q5))
+- [One single storage for multiple sets](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_set/device_subsets_example.cu) (see [live example in godbolt](https://godbolt.org/z/7f9KW44P4))
+- [Using shared memory as storage](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_set/shared_memory_example.cu) (see [live example in godbolt](https://godbolt.org/z/Ws5c71T4z))
 - [Using set as mapping table to handle large keys or indeterministic sentinels](https://github.com/NVIDIA/cuCollections/blob/dev/examples/static_set/mapping_table_example.cu) (see [live example in godbolt](https://godbolt.org/z/KfYo4nMss))
 
 ### `static_map`

--- a/examples/static_set/device_subsets_example.cu
+++ b/examples/static_set/device_subsets_example.cu
@@ -85,7 +85,7 @@ __global__ void insert(ref_type* set_refs)
   auto const idx = (blockDim.x * blockIdx.x + threadIdx.x) / cg_size;
 
   auto raw_set_ref    = *(set_refs + idx);
-  auto insert_set_ref = raw_set_ref.with_operators(cuco::insert);
+  auto insert_set_ref = raw_set_ref.rebind_operators(cuco::insert);
 
   // Insert `N` elemtns into the set with CG insert
   for (int i = 0; i < N; i++) {
@@ -109,7 +109,7 @@ __global__ void find(ref_type* set_refs)
   auto const idx  = (blockDim.x * blockIdx.x + threadIdx.x) / cg_size;
 
   auto raw_set_ref  = *(set_refs + idx);
-  auto find_set_ref = raw_set_ref.with_operators(cuco::find);
+  auto find_set_ref = raw_set_ref.rebind_operators(cuco::find);
 
   // Result denoting if any of the inserted data is not found
   __shared__ int result;

--- a/examples/static_set/shared_memory_example.cu
+++ b/examples/static_set/shared_memory_example.cu
@@ -47,7 +47,7 @@ __global__ void shmem_set_kernel(typename SetRef::extent_type window_extent,
 
   // The `set` object does not come with any functionality. We first have to transform it into an
   // object that supports the function we need (in this case `insert`).
-  auto insert_ref = set.with_operators(cuco::insert);
+  auto insert_ref = set.rebind_operators(cuco::insert);
 
   // Each thread inserts its thread id into the set.
   typename SetRef::key_type const key = block.thread_rank();
@@ -61,7 +61,7 @@ __global__ void shmem_set_kernel(typename SetRef::extent_type window_extent,
   // a new non-owning object based on the `insert_ref` that supports `contains` but no longer
   // supports `insert`.
   // CAVEAT: concurrent use of `insert_ref` and `contains_ref` is undefined behavior.
-  auto const contains_ref = insert_ref.with_operators(cuco::contains);
+  auto const contains_ref = insert_ref.rebind_operators(cuco::contains);
 
   // Check if all keys can be found
   if (not contains_ref.contains(key)) { printf("ERROR: Key %d not found\n", key); }

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -297,27 +297,6 @@ template <typename Key,
           typename... Operators>
 template <typename... NewOperators>
 __host__ __device__ constexpr auto
-static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::with_operators(
-  NewOperators...) const noexcept
-{
-  return static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, NewOperators...>{
-    cuco::empty_key<Key>{this->empty_key_sentinel()},
-    cuco::empty_value<T>{this->empty_value_sentinel()},
-    this->key_eq(),
-    this->probing_scheme(),
-    {},
-    this->storage_ref()};
-}
-
-template <typename Key,
-          typename T,
-          cuda::thread_scope Scope,
-          typename KeyEqual,
-          typename ProbingScheme,
-          typename StorageRef,
-          typename... Operators>
-template <typename... NewOperators>
-__host__ __device__ constexpr auto
 static_map_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::rebind_operators(
   NewOperators...) const noexcept
 {

--- a/include/cuco/detail/static_multimap/static_multimap_ref.inl
+++ b/include/cuco/detail/static_multimap/static_multimap_ref.inl
@@ -302,32 +302,6 @@ __host__ __device__ auto constexpr static_multimap_ref<
   KeyEqual,
   ProbingScheme,
   StorageRef,
-  Operators...>::with_operators(NewOperators...) const noexcept
-{
-  return static_multimap_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, NewOperators...>{
-    cuco::empty_key<Key>{this->empty_key_sentinel()},
-    cuco::empty_value<T>{this->empty_value_sentinel()},
-    this->key_eq(),
-    this->probing_scheme(),
-    {},
-    impl_.storage_ref()};
-}
-
-template <typename Key,
-          typename T,
-          cuda::thread_scope Scope,
-          typename KeyEqual,
-          typename ProbingScheme,
-          typename StorageRef,
-          typename... Operators>
-template <typename... NewOperators>
-__host__ __device__ auto constexpr static_multimap_ref<
-  Key,
-  T,
-  Scope,
-  KeyEqual,
-  ProbingScheme,
-  StorageRef,
   Operators...>::rebind_operators(NewOperators...) const noexcept
 {
   return static_multimap_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, NewOperators...>{

--- a/include/cuco/detail/static_multiset/static_multiset_ref.inl
+++ b/include/cuco/detail/static_multiset/static_multiset_ref.inl
@@ -252,25 +252,6 @@ template <typename Key,
           typename... Operators>
 template <typename... NewOperators>
 __host__ __device__ constexpr auto
-static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::with_operators(
-  NewOperators...) const noexcept
-{
-  return static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, NewOperators...>{
-    cuco::empty_key<Key>{this->empty_key_sentinel()},
-    this->key_eq(),
-    this->probing_scheme(),
-    {},
-    this->storage_ref()};
-}
-
-template <typename Key,
-          cuda::thread_scope Scope,
-          typename KeyEqual,
-          typename ProbingScheme,
-          typename StorageRef,
-          typename... Operators>
-template <typename... NewOperators>
-__host__ __device__ constexpr auto
 static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::
   rebind_operators(NewOperators...) const noexcept
 {

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -249,25 +249,6 @@ template <typename Key,
           typename... Operators>
 template <typename... NewOperators>
 __host__ __device__ constexpr auto
-static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::with_operators(
-  NewOperators...) const noexcept
-{
-  return static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, NewOperators...>{
-    cuco::empty_key<Key>{this->empty_key_sentinel()},
-    this->key_eq(),
-    this->probing_scheme(),
-    {},
-    this->storage_ref()};
-}
-
-template <typename Key,
-          cuda::thread_scope Scope,
-          typename KeyEqual,
-          typename ProbingScheme,
-          typename StorageRef,
-          typename... Operators>
-template <typename... NewOperators>
-__host__ __device__ constexpr auto
 static_set_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>::rebind_operators(
   NewOperators...) const noexcept
 {

--- a/include/cuco/static_map_ref.cuh
+++ b/include/cuco/static_map_ref.cuh
@@ -227,22 +227,6 @@ class static_map_ref
   [[nodiscard]] __host__ __device__ constexpr auto probing_scheme() const noexcept;
 
   /**
-   * @brief Creates a reference with new operators from the current object
-   *
-   * @warning Using two or more reference objects to the same container but with
-   * a different operator set at the same time results in undefined behavior.
-   *
-   * @tparam NewOperators List of `cuco::op::*_tag` types
-   *
-   * @param ops List of operators, e.g., `cuco::insert`
-   *
-   * @return `*this` with `NewOperators...`
-   */
-  template <typename... NewOperators>
-  [[nodiscard]] __host__ __device__ constexpr auto with_operators(
-    NewOperators... ops) const noexcept;
-
-  /**
    * @brief Creates a copy of the current non-owning reference using the given operators
    *
    * @tparam NewOperators List of `cuco::op::*_tag` types

--- a/include/cuco/static_multimap_ref.cuh
+++ b/include/cuco/static_multimap_ref.cuh
@@ -226,22 +226,6 @@ class static_multimap_ref
   [[nodiscard]] __host__ __device__ constexpr auto probing_scheme() const noexcept;
 
   /**
-   * @brief Creates a reference with new operators from the current object
-   *
-   * @warning Using two or more reference objects to the same container but with
-   * a different operator set at the same time results in undefined behavior.
-   *
-   * @tparam NewOperators List of `cuco::op::*_tag` types
-   *
-   * @param ops List of operators, e.g., `cuco::insert`
-   *
-   * @return `*this` with `NewOperators...`
-   */
-  template <typename... NewOperators>
-  [[nodiscard]] __host__ __device__ constexpr auto with_operators(
-    NewOperators... ops) const noexcept;
-
-  /**
    * @brief Creates a copy of the current non-owning reference using the given operators
    *
    * @tparam NewOperators List of `cuco::op::*_tag` types

--- a/include/cuco/static_multiset_ref.cuh
+++ b/include/cuco/static_multiset_ref.cuh
@@ -206,22 +206,6 @@ class static_multiset_ref
   [[nodiscard]] __host__ __device__ constexpr auto probing_scheme() const noexcept;
 
   /**
-   * @brief Creates a reference with new operators from the current object
-   *
-   * @warning Using two or more reference objects to the same container but with
-   * a different operator set at the same time results in undefined behavior.
-   *
-   * @tparam NewOperators List of `cuco::op::*_tag` types
-   *
-   * @param ops List of operators, e.g., `cuco::insert`
-   *
-   * @return `*this` with `NewOperators...`
-   */
-  template <typename... NewOperators>
-  [[nodiscard]] __host__ __device__ constexpr auto with_operators(
-    NewOperators... ops) const noexcept;
-
-  /**
    * @brief Creates a copy of the current non-owning reference using the given operators
    *
    * @tparam NewOperators List of `cuco::op::*_tag` types

--- a/include/cuco/static_set_ref.cuh
+++ b/include/cuco/static_set_ref.cuh
@@ -204,22 +204,6 @@ class static_set_ref
   [[nodiscard]] __host__ __device__ constexpr auto probing_scheme() const noexcept;
 
   /**
-   * @brief Creates a reference with new operators from the current object
-   *
-   * @warning Using two or more reference objects to the same container but with
-   * a different operator set at the same time results in undefined behavior.
-   *
-   * @tparam NewOperators List of `cuco::op::*_tag` types
-   *
-   * @param ops List of operators, e.g., `cuco::insert`
-   *
-   * @return `*this` with `NewOperators...`
-   */
-  template <typename... NewOperators>
-  [[nodiscard]] __host__ __device__ constexpr auto with_operators(
-    NewOperators... ops) const noexcept;
-
-  /**
    * @brief Creates a copy of the current non-owning reference using the given operators
    *
    * @tparam NewOperators List of `cuco::op::*_tag` types

--- a/tests/static_map/shared_memory_test.cu
+++ b/tests/static_map/shared_memory_test.cu
@@ -46,7 +46,7 @@ __global__ void shared_memory_test_kernel(Ref* maps,
 
   auto g          = cuco::test::cg::this_thread_block();
   auto insert_ref = maps[map_id].make_copy(g, sm_buffer, cuco::thread_scope_block);
-  auto find_ref   = insert_ref.with_operators(cuco::op::find);
+  auto find_ref   = insert_ref.rebind_operators(cuco::op::find);
 
   for (int i = g.thread_rank(); i < number_of_elements; i += g.size()) {
     auto found_pair_it = find_ref.find(insterted_keys[offset + i]);
@@ -196,11 +196,11 @@ __global__ void shared_memory_hash_table_kernel(bool* key_found)
   auto const rank  = block.thread_rank();
 
   // insert {thread_rank, thread_rank} for each thread in thread-block
-  auto insert_ref = raw_ref.with_operators(cuco::op::insert);
+  auto insert_ref = raw_ref.rebind_operators(cuco::op::insert);
   insert_ref.insert(slot_type{rank, rank});
   block.sync();
 
-  auto find_ref             = insert_ref.with_operators(cuco::op::find);
+  auto find_ref             = insert_ref.rebind_operators(cuco::op::find);
   auto const retrieved_pair = find_ref.find(rank);
   block.sync();
 

--- a/tests/static_set/shared_memory_test.cu
+++ b/tests/static_set/shared_memory_test.cu
@@ -45,7 +45,7 @@ __global__ void shared_memory_test_kernel(Ref* sets,
 
   auto g          = cuco::test::cg::this_thread_block();
   auto insert_ref = sets[set_id].make_copy(g, sm_buffer, cuco::thread_scope_block);
-  auto find_ref   = insert_ref.with_operators(cuco::op::find);
+  auto find_ref   = insert_ref.rebind_operators(cuco::op::find);
 
   for (int i = g.thread_rank(); i < number_of_elements; i += g.size()) {
     auto found_it = find_ref.find(insterted_keys[offset + i]);
@@ -176,11 +176,11 @@ __global__ void shared_memory_hash_set_kernel(bool* key_found)
   auto const rank  = block.thread_rank();
 
   // insert {thread_rank, thread_rank} for each thread in thread-block
-  auto insert_ref = raw_ref.with_operators(cuco::op::insert);
+  auto insert_ref = raw_ref.rebind_operators(cuco::op::insert);
   insert_ref.insert(rank);
   block.sync();
 
-  auto find_ref           = insert_ref.with_operators(cuco::op::find);
+  auto find_ref           = insert_ref.rebind_operators(cuco::op::find);
   auto const retrieved_it = find_ref.find(rank);
   block.sync();
 


### PR DESCRIPTION
This PR deprecates the legacy `with_operators` APIs. Users should use the new `rebind_operators` instead.