### PR TITLE
Use std::pair as the return type in host API

### DIFF
--- a/include/cuco/detail/static_set/static_set.inl
+++ b/include/cuco/detail/static_set/static_set.inl
@@ -346,7 +346,7 @@ template <class Key,
           class Allocator,
           class Storage>
 template <typename InputIt, typename OutputIt1, typename OutputIt2>
-cuda::std::pair<OutputIt1, OutputIt2>
+std::pair<OutputIt1, OutputIt2>
 static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::retrieve(
   InputIt first,
   InputIt last,

--- a/include/cuco/static_set.cuh
+++ b/include/cuco/static_set.cuh
@@ -28,7 +28,6 @@
 #include <cuco/utility/traits.hpp>
 
 #include <cuda/atomic>
-#include <cuda/std/utility>
 #include <cuda/stream_ref>
 #include <thrust/functional.h>
 
@@ -38,6 +37,7 @@
 
 #include <cstddef>
 #include <type_traits>
+#include <utility>
 
 namespace cuco {
 /**
@@ -617,11 +617,11 @@ class static_set {
    * @return The iterator indicating the last valid pair in the output
    */
   template <typename InputIt, typename OutputIt1, typename OutputIt2>
-  cuda::std::pair<OutputIt1, OutputIt2> retrieve(InputIt first,
-                                                 InputIt last,
-                                                 OutputIt1 output_probe,
-                                                 OutputIt2 output_match,
-                                                 cuda::stream_ref stream = {}) const;
+  std::pair<OutputIt1, OutputIt2> retrieve(InputIt first,
+                                           InputIt last,
+                                           OutputIt1 output_probe,
+                                           OutputIt2 output_match,
+                                           cuda::stream_ref stream = {}) const;
 
   /**
    * @brief Asynchronously retrieves the matched key in the set corresponding to all probe keys in


### PR DESCRIPTION
A small fix using `std::pair` instead of `cuda::std::pair` as the host return type.