### PR TITLE
Add consistent `for_each` APIs for cuco hash tables

### DIFF
--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -21,9 +21,8 @@
 #include <cuco/operator.hpp>
 
 #include <cuda/atomic>
-#include <cuda/std/functional>
 #include <cuda/std/type_traits>
-#include <thrust/tuple.h>
+#include <cuda/std/utility>
 
 #include <cooperative_groups.h>
 
@@ -1335,7 +1334,7 @@ class operator_impl<
   {
     // CRTP: cast `this` to the actual ref type
     auto const& ref_ = static_cast<ref_type const&>(*this);
-    ref_.impl_.for_each(key, std::forward<CallbackOp>(callback_op));
+    ref_.impl_.for_each(key, cuda::std::forward<CallbackOp>(callback_op));
   }
 
   /**
@@ -1363,7 +1362,7 @@ class operator_impl<
   {
     // CRTP: cast `this` to the actual ref type
     auto const& ref_ = static_cast<ref_type const&>(*this);
-    ref_.impl_.for_each(group, key, std::forward<CallbackOp>(callback_op));
+    ref_.impl_.for_each(group, key, cuda::std::forward<CallbackOp>(callback_op));
   }
 };
 

--- a/include/cuco/detail/static_multimap/static_multimap.inl
+++ b/include/cuco/detail/static_multimap/static_multimap.inl
@@ -323,6 +323,73 @@ template <class Key,
           class ProbingScheme,
           class Allocator,
           class Storage>
+template <typename CallbackOp>
+void static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::for_each(
+  CallbackOp&& callback_op, cuda::stream_ref stream) const
+{
+  impl_->for_each_async(std::forward<CallbackOp>(callback_op), stream);
+  stream.wait();
+}
+
+template <class Key,
+          class T,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
+template <typename CallbackOp>
+void static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::
+  for_each_async(CallbackOp&& callback_op, cuda::stream_ref stream) const
+{
+  impl_->for_each_async(std::forward<CallbackOp>(callback_op), stream);
+}
+
+template <class Key,
+          class T,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
+template <typename InputIt, typename CallbackOp>
+void static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::for_each(
+  InputIt first, InputIt last, CallbackOp&& callback_op, cuda::stream_ref stream) const
+{
+  impl_->for_each_async(
+    first, last, std::forward<CallbackOp>(callback_op), ref(op::for_each), stream);
+  stream.wait();
+}
+
+template <class Key,
+          class T,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
+template <typename InputIt, typename CallbackOp>
+void static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::
+  for_each_async(InputIt first,
+                 InputIt last,
+                 CallbackOp&& callback_op,
+                 cuda::stream_ref stream) const noexcept
+{
+  impl_->for_each_async(
+    first, last, std::forward<CallbackOp>(callback_op), ref(op::for_each), stream);
+}
+
+template <class Key,
+          class T,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
 template <typename InputIt>
 static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::size_type
 static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::count(

--- a/include/cuco/detail/static_multiset/static_multiset.inl
+++ b/include/cuco/detail/static_multiset/static_multiset.inl
@@ -417,7 +417,7 @@ static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>
   OutputMatchIt output_match,
   cuda::stream_ref stream) const
 {
-  return this->impl_->retrieve(
+  return impl_->retrieve(
     first, last, output_probe, output_match, this->ref(op::retrieve), stream);
 }
 
@@ -445,7 +445,7 @@ static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>
 {
   auto const probe_ref =
     this->ref(op::retrieve).rebind_key_eq(probe_equal).rebind_hash_function(probe_hash);
-  return this->impl_->retrieve(first, last, output_probe, output_match, probe_ref, stream);
+  return impl_->retrieve(first, last, output_probe, output_match, probe_ref, stream);
 }
 
 template <class Key,
@@ -472,7 +472,7 @@ static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>
 {
   auto const probe_ref =
     this->ref(op::retrieve).rebind_key_eq(probe_equal).rebind_hash_function(probe_hash);
-  return this->impl_->retrieve_outer(first, last, output_probe, output_match, probe_ref, stream);
+  return impl_->retrieve_outer(first, last, output_probe, output_match, probe_ref, stream);
 }
 
 template <class Key,

--- a/include/cuco/detail/static_multiset/static_multiset.inl
+++ b/include/cuco/detail/static_multiset/static_multiset.inl
@@ -417,8 +417,7 @@ static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>
   OutputMatchIt output_match,
   cuda::stream_ref stream) const
 {
-  return impl_->retrieve(
-    first, last, output_probe, output_match, this->ref(op::retrieve), stream);
+  return impl_->retrieve(first, last, output_probe, output_match, this->ref(op::retrieve), stream);
 }
 
 template <class Key,

--- a/include/cuco/detail/static_multiset/static_multiset.inl
+++ b/include/cuco/detail/static_multiset/static_multiset.inl
@@ -284,6 +284,130 @@ template <class Key,
           class ProbingScheme,
           class Allocator,
           class Storage>
+template <typename CallbackOp>
+void static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::for_each(
+  CallbackOp&& callback_op, cuda::stream_ref stream) const
+{
+  impl_->for_each_async(std::forward<CallbackOp>(callback_op), stream);
+  stream.wait();
+}
+
+template <class Key,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
+template <typename CallbackOp>
+void static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::
+  for_each_async(CallbackOp&& callback_op, cuda::stream_ref stream) const
+{
+  impl_->for_each_async(std::forward<CallbackOp>(callback_op), stream);
+}
+
+template <class Key,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
+template <typename InputIt, typename CallbackOp>
+void static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::for_each(
+  InputIt first, InputIt last, CallbackOp&& callback_op, cuda::stream_ref stream) const
+{
+  impl_->for_each_async(
+    first, last, std::forward<CallbackOp>(callback_op), ref(op::for_each), stream);
+  stream.wait();
+}
+
+template <class Key,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
+template <typename InputIt, typename CallbackOp>
+void static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::
+  for_each_async(InputIt first,
+                 InputIt last,
+                 CallbackOp&& callback_op,
+                 cuda::stream_ref stream) const noexcept
+{
+  impl_->for_each_async(
+    first, last, std::forward<CallbackOp>(callback_op), ref(op::for_each), stream);
+}
+
+template <class Key,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
+template <typename InputIt>
+static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::size_type
+static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::count(
+  InputIt first, InputIt last, cuda::stream_ref stream) const
+{
+  return impl_->count(first, last, ref(op::count), stream);
+}
+
+template <class Key,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
+template <typename InputIt, typename ProbeKeyEqual, typename ProbeHash>
+static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::size_type
+static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::count(
+  InputIt first,
+  InputIt last,
+  ProbeKeyEqual const& probe_key_equal,
+  ProbeHash const& probe_hash,
+  cuda::stream_ref stream) const
+{
+  return impl_->count(
+    first,
+    last,
+    ref(op::count).rebind_key_eq(probe_key_equal).rebind_hash_function(probe_hash),
+    stream);
+}
+
+template <class Key,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
+template <typename InputIt, typename ProbeKeyEqual, typename ProbeHash>
+static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::size_type
+static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::count_outer(
+  InputIt first,
+  InputIt last,
+  ProbeKeyEqual const& probe_key_equal,
+  ProbeHash const& probe_hash,
+  cuda::stream_ref stream) const
+{
+  return impl_->count_outer(
+    first,
+    last,
+    ref(op::count).rebind_key_eq(probe_key_equal).rebind_hash_function(probe_hash),
+    stream);
+}
+
+template <class Key,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
 template <class InputProbeIt, class OutputProbeIt, class OutputMatchIt>
 std::pair<OutputProbeIt, OutputMatchIt>
 static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::retrieve(
@@ -349,67 +473,6 @@ static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>
   auto const probe_ref =
     this->ref(op::retrieve).rebind_key_eq(probe_equal).rebind_hash_function(probe_hash);
   return this->impl_->retrieve_outer(first, last, output_probe, output_match, probe_ref, stream);
-}
-
-template <class Key,
-          class Extent,
-          cuda::thread_scope Scope,
-          class KeyEqual,
-          class ProbingScheme,
-          class Allocator,
-          class Storage>
-template <typename InputIt>
-static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::size_type
-static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::count(
-  InputIt first, InputIt last, cuda::stream_ref stream) const
-{
-  return impl_->count(first, last, ref(op::count), stream);
-}
-
-template <class Key,
-          class Extent,
-          cuda::thread_scope Scope,
-          class KeyEqual,
-          class ProbingScheme,
-          class Allocator,
-          class Storage>
-template <typename InputIt, typename ProbeKeyEqual, typename ProbeHash>
-static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::size_type
-static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::count(
-  InputIt first,
-  InputIt last,
-  ProbeKeyEqual const& probe_key_equal,
-  ProbeHash const& probe_hash,
-  cuda::stream_ref stream) const
-{
-  return impl_->count(
-    first,
-    last,
-    ref(op::count).rebind_key_eq(probe_key_equal).rebind_hash_function(probe_hash),
-    stream);
-}
-
-template <class Key,
-          class Extent,
-          cuda::thread_scope Scope,
-          class KeyEqual,
-          class ProbingScheme,
-          class Allocator,
-          class Storage>
-template <typename InputIt, typename ProbeKeyEqual, typename ProbeHash>
-static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::size_type
-static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::count_outer(
-  InputIt first,
-  InputIt last,
-  ProbeKeyEqual const& probe_key_equal,
-  ProbeHash const& probe_hash,
-  cuda::stream_ref stream) const
-{
-  return impl_->count_outer(
-    first,
-    last,
-    ref(op::count).rebind_key_eq(probe_key_equal).rebind_hash_function(probe_hash),
-    stream);
 }
 
 template <class Key,

--- a/include/cuco/detail/static_set/static_set.inl
+++ b/include/cuco/detail/static_set/static_set.inl
@@ -345,6 +345,66 @@ template <class Key,
           class ProbingScheme,
           class Allocator,
           class Storage>
+template <typename CallbackOp>
+void static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::for_each(
+  CallbackOp&& callback_op, cuda::stream_ref stream) const
+{
+  impl_->for_each_async(std::forward<CallbackOp>(callback_op), stream);
+  stream.wait();
+}
+
+template <class Key,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
+template <typename CallbackOp>
+void static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::for_each_async(
+  CallbackOp&& callback_op, cuda::stream_ref stream) const
+{
+  impl_->for_each_async(std::forward<CallbackOp>(callback_op), stream);
+}
+
+template <class Key,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
+template <typename InputIt, typename CallbackOp>
+void static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::for_each(
+  InputIt first, InputIt last, CallbackOp&& callback_op, cuda::stream_ref stream) const
+{
+  impl_->for_each_async(
+    first, last, std::forward<CallbackOp>(callback_op), ref(op::for_each), stream);
+  stream.wait();
+}
+
+template <class Key,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
+template <typename InputIt, typename CallbackOp>
+void static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::for_each_async(
+  InputIt first, InputIt last, CallbackOp&& callback_op, cuda::stream_ref stream) const noexcept
+{
+  impl_->for_each_async(
+    first, last, std::forward<CallbackOp>(callback_op), ref(op::for_each), stream);
+}
+
+template <class Key,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
 template <typename InputIt>
 static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::size_type
 static_set<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::count(

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -775,7 +775,7 @@ class static_map {
    *
    * @tparam CallbackOp Type of unary callback function object
    *
-   * @param callback_op Function to apply to the copy of the matched key-value pair
+   * @param callback_op Function to apply to the copy of the filled slot
    * @param stream CUDA stream used for this operation
    */
   template <typename CallbackOp>
@@ -789,7 +789,7 @@ class static_map {
    *
    * @tparam CallbackOp Type of unary callback function object
    *
-   * @param callback_op Function to apply to the copy of the matched key-value pair
+   * @param callback_op Function to apply to the copy of the filled slot
    * @param stream CUDA stream used for this operation
    */
   template <typename CallbackOp>
@@ -806,7 +806,7 @@ class static_map {
    *
    * @param first Beginning of the sequence of keys
    * @param last End of the sequence of keys
-   * @param callback_op Function to apply to the copy of the matched key-value pair
+   * @param callback_op Function to apply to the copy of the matched slot
    * @param stream CUDA stream used for this operation
    */
   template <typename InputIt, typename CallbackOp>
@@ -826,7 +826,7 @@ class static_map {
    *
    * @param first Beginning of the sequence of keys
    * @param last End of the sequence of keys
-   * @param callback_op Function to apply to the copy of the matched key-value pair
+   * @param callback_op Function to apply to the copy of the matched slot
    * @param stream CUDA stream used for this operation
    */
   template <typename InputIt, typename CallbackOp>

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -519,6 +519,74 @@ class static_multimap {
                   cuda::stream_ref stream = {}) const;
 
   /**
+   * @brief Applies the given function object `callback_op` to the copy of every filled slot in the
+   * container
+   *
+   * @note The return value of `callback_op`, if any, is ignored.
+   *
+   * @tparam CallbackOp Type of unary callback function object
+   *
+   * @param callback_op Function to apply to the copy of the filled slot
+   * @param stream CUDA stream used for this operation
+   */
+  template <typename CallbackOp>
+  void for_each(CallbackOp&& callback_op, cuda::stream_ref stream = {}) const;
+
+  /**
+   * @brief Asynchronously applies the given function object `callback_op` to the copy of every
+   * filled slot in the container
+   *
+   * @note The return value of `callback_op`, if any, is ignored.
+   *
+   * @tparam CallbackOp Type of unary callback function object
+   *
+   * @param callback_op Function to apply to the copy of the filled slot
+   * @param stream CUDA stream used for this operation
+   */
+  template <typename CallbackOp>
+  void for_each_async(CallbackOp&& callback_op, cuda::stream_ref stream = {}) const;
+
+  /**
+   * @brief For each key in the range [first, last), applies the function object `callback_op` to
+   * the copy of all corresponding matches found in the container.
+   *
+   * @note The return value of `callback_op`, if any, is ignored.
+   *
+   * @tparam InputIt Device accessible random access input iterator
+   * @tparam CallbackOp Type of unary callback function object
+   *
+   * @param first Beginning of the sequence of keys
+   * @param last End of the sequence of keys
+   * @param callback_op Function to apply to the copy of the matched slot
+   * @param stream CUDA stream used for this operation
+   */
+  template <typename InputIt, typename CallbackOp>
+  void for_each(InputIt first,
+                InputIt last,
+                CallbackOp&& callback_op,
+                cuda::stream_ref stream = {}) const;
+
+  /**
+   * @brief For each key in the range [first, last), asynchronously applies the function object
+   * `callback_op` to the copy of all corresponding matches found in the container.
+   *
+   * @note The return value of `callback_op`, if any, is ignored.
+   *
+   * @tparam InputIt Device accessible random access input iterator
+   * @tparam CallbackOp Type of unary callback function object
+   *
+   * @param first Beginning of the sequence of keys
+   * @param last End of the sequence of keys
+   * @param callback_op Function to apply to the copy of the matched slot
+   * @param stream CUDA stream used for this operation
+   */
+  template <typename InputIt, typename CallbackOp>
+  void for_each_async(InputIt first,
+                      InputIt last,
+                      CallbackOp&& callback_op,
+                      cuda::stream_ref stream = {}) const noexcept;
+
+  /**
    * @brief Counts the occurrences of keys in `[first, last)` contained in the multimap
    *
    * @note This function synchronizes the given stream.

--- a/include/cuco/static_multiset.cuh
+++ b/include/cuco/static_multiset.cuh
@@ -483,6 +483,140 @@ class static_multiset {
                   cuda::stream_ref stream = {}) const;
 
   /**
+   * @brief Applies the given function object `callback_op` to the copy of every filled slot in the
+   * container
+   *
+   * @note The return value of `callback_op`, if any, is ignored.
+   *
+   * @tparam CallbackOp Type of unary callback function object
+   *
+   * @param callback_op Function to apply to the copy of the filled slot
+   * @param stream CUDA stream used for this operation
+   */
+  template <typename CallbackOp>
+  void for_each(CallbackOp&& callback_op, cuda::stream_ref stream = {}) const;
+
+  /**
+   * @brief Asynchronously applies the given function object `callback_op` to the copy of every
+   * filled slot in the container
+   *
+   * @note The return value of `callback_op`, if any, is ignored.
+   *
+   * @tparam CallbackOp Type of unary callback function object
+   *
+   * @param callback_op Function to apply to the copy of the filled slot
+   * @param stream CUDA stream used for this operation
+   */
+  template <typename CallbackOp>
+  void for_each_async(CallbackOp&& callback_op, cuda::stream_ref stream = {}) const;
+
+  /**
+   * @brief For each key in the range [first, last), applies the function object `callback_op` to
+   * the copy of all corresponding matches found in the container.
+   *
+   * @note The return value of `callback_op`, if any, is ignored.
+   *
+   * @tparam InputIt Device accessible random access input iterator
+   * @tparam CallbackOp Type of unary callback function object
+   *
+   * @param first Beginning of the sequence of keys
+   * @param last End of the sequence of keys
+   * @param callback_op Function to apply to the copy of the matched slot
+   * @param stream CUDA stream used for this operation
+   */
+  template <typename InputIt, typename CallbackOp>
+  void for_each(InputIt first,
+                InputIt last,
+                CallbackOp&& callback_op,
+                cuda::stream_ref stream = {}) const;
+
+  /**
+   * @brief For each key in the range [first, last), asynchronously applies the function object
+   * `callback_op` to the copy of all corresponding matches found in the container.
+   *
+   * @note The return value of `callback_op`, if any, is ignored.
+   *
+   * @tparam InputIt Device accessible random access input iterator
+   * @tparam CallbackOp Type of unary callback function object
+   *
+   * @param first Beginning of the sequence of keys
+   * @param last End of the sequence of keys
+   * @param callback_op Function to apply to the copy of the matched slot
+   * @param stream CUDA stream used for this operation
+   */
+  template <typename InputIt, typename CallbackOp>
+  void for_each_async(InputIt first,
+                      InputIt last,
+                      CallbackOp&& callback_op,
+                      cuda::stream_ref stream = {}) const noexcept;
+
+  /**
+   * @brief Counts the occurrences of keys in `[first, last)` contained in the multiset
+   *
+   * @note This function synchronizes the given stream.
+   *
+   * @tparam Input Device accessible input iterator
+   *
+   * @param first Beginning of the sequence of keys to count
+   * @param last End of the sequence of keys to count
+   * @param stream CUDA stream used for count
+   *
+   * @return The sum of total occurrences of all keys in `[first, last)`
+   */
+  template <typename InputIt>
+  size_type count(InputIt first, InputIt last, cuda::stream_ref stream = {}) const;
+
+  /**
+   * @brief Counts the occurrences of keys in `[first, last)` contained in the multiset
+   *
+   * @note This function synchronizes the given stream.
+   *
+   * @tparam Input Device accessible input iterator
+   * @tparam ProbeKeyEqual Binary callable
+   * @tparam ProbeHash Unary hash callable
+   *
+   * @param first Beginning of the sequence of keys to count
+   * @param last End of the sequence of keys to count
+   * @param probe_key_equal Binary callable to compare two keys for equality
+   * @param probe_hash Unary callable to hash a given key
+   * @param stream CUDA stream used for count
+   *
+   * @return The sum of total occurrences of all keys in `[first, last)`
+   */
+  template <typename InputIt, typename ProbeKeyEqual, typename ProbeHash>
+  size_type count(InputIt first,
+                  InputIt last,
+                  ProbeKeyEqual const& probe_key_equal,
+                  ProbeHash const& probe_hash,
+                  cuda::stream_ref stream = {}) const;
+
+  /**
+   * @brief Counts the occurrences of keys in `[first, last)` contained in the multiset
+   *
+   * @note This function synchronizes the given stream.
+   * @note If a given key has no matches, its occurrence is 1.
+   *
+   * @tparam Input Device accessible input iterator
+   * @tparam ProbeKeyEqual Binary callable
+   * @tparam ProbeHash Unary hash callable
+   *
+   * @param first Beginning of the sequence of keys to count
+   * @param last End of the sequence of keys to count
+   * @param probe_key_equal Binary callable to compare two keys for equality
+   * @param probe_hash Unary callable to hash a given key
+   * @param stream CUDA stream used for count
+   *
+   * @return The sum of total occurrences of all keys in `[first, last)` where keys have no matches
+   * are considered to have a single occurrence.
+   */
+  template <typename InputIt, typename ProbeKeyEqual, typename ProbeHash>
+  size_type count_outer(InputIt first,
+                        InputIt last,
+                        ProbeKeyEqual const& probe_key_equal,
+                        ProbeHash const& probe_hash,
+                        cuda::stream_ref stream = {}) const;
+
+  /**
    * @brief Retrieves all the slots corresponding to all keys in the range `[first, last)`.
    *
    * If key `k = *(first + i)` exists in the container, copies `k` to `output_probe` and associated
@@ -603,72 +737,6 @@ class static_multiset {
                                                          OutputProbeIt output_probe,
                                                          OutputMatchIt output_match,
                                                          cuda::stream_ref stream = {}) const;
-
-  /**
-   * @brief Counts the occurrences of keys in `[first, last)` contained in the multiset
-   *
-   * @note This function synchronizes the given stream.
-   *
-   * @tparam Input Device accessible input iterator
-   *
-   * @param first Beginning of the sequence of keys to count
-   * @param last End of the sequence of keys to count
-   * @param stream CUDA stream used for count
-   *
-   * @return The sum of total occurrences of all keys in `[first, last)`
-   */
-  template <typename InputIt>
-  size_type count(InputIt first, InputIt last, cuda::stream_ref stream = {}) const;
-
-  /**
-   * @brief Counts the occurrences of keys in `[first, last)` contained in the multiset
-   *
-   * @note This function synchronizes the given stream.
-   *
-   * @tparam Input Device accessible input iterator
-   * @tparam ProbeKeyEqual Binary callable
-   * @tparam ProbeHash Unary hash callable
-   *
-   * @param first Beginning of the sequence of keys to count
-   * @param last End of the sequence of keys to count
-   * @param probe_key_equal Binary callable to compare two keys for equality
-   * @param probe_hash Unary callable to hash a given key
-   * @param stream CUDA stream used for count
-   *
-   * @return The sum of total occurrences of all keys in `[first, last)`
-   */
-  template <typename InputIt, typename ProbeKeyEqual, typename ProbeHash>
-  size_type count(InputIt first,
-                  InputIt last,
-                  ProbeKeyEqual const& probe_key_equal,
-                  ProbeHash const& probe_hash,
-                  cuda::stream_ref stream = {}) const;
-
-  /**
-   * @brief Counts the occurrences of keys in `[first, last)` contained in the multiset
-   *
-   * @note This function synchronizes the given stream.
-   * @note If a given key has no matches, its occurrence is 1.
-   *
-   * @tparam Input Device accessible input iterator
-   * @tparam ProbeKeyEqual Binary callable
-   * @tparam ProbeHash Unary hash callable
-   *
-   * @param first Beginning of the sequence of keys to count
-   * @param last End of the sequence of keys to count
-   * @param probe_key_equal Binary callable to compare two keys for equality
-   * @param probe_hash Unary callable to hash a given key
-   * @param stream CUDA stream used for count
-   *
-   * @return The sum of total occurrences of all keys in `[first, last)` where keys have no matches
-   * are considered to have a single occurrence.
-   */
-  template <typename InputIt, typename ProbeKeyEqual, typename ProbeHash>
-  size_type count_outer(InputIt first,
-                        InputIt last,
-                        ProbeKeyEqual const& probe_key_equal,
-                        ProbeHash const& probe_hash,
-                        cuda::stream_ref stream = {}) const;
 
   /**
    * @brief Gets the number of elements in the container.

--- a/include/cuco/static_set.cuh
+++ b/include/cuco/static_set.cuh
@@ -351,7 +351,7 @@ class static_set {
    *
    * @tparam InputIt Device accessible random access input iterator
    * @tparam FoundIt Device accessible random access output iterator whose `value_type`
-   * is constructible from `map::iterator` type
+   * is constructible from `set::iterator` type
    * @tparam InsertedIt Device accessible random access output iterator whose `value_type`
    * is constructible from `bool`
    *
@@ -379,7 +379,7 @@ class static_set {
    *
    * @tparam InputIt Device accessible random access input iterator
    * @tparam FoundIt Device accessible random access output iterator whose `value_type`
-   * is constructible from `map::iterator` type
+   * is constructible from `set::iterator` type
    * @tparam InsertedIt Device accessible random access output iterator whose `value_type`
    * is constructible from `bool`
    *
@@ -589,6 +589,74 @@ class static_set {
                   InputIt last,
                   OutputIt output_begin,
                   cuda::stream_ref stream = {}) const;
+
+  /**
+   * @brief Applies the given function object `callback_op` to the copy of every filled slot in the
+   * container
+   *
+   * @note The return value of `callback_op`, if any, is ignored.
+   *
+   * @tparam CallbackOp Type of unary callback function object
+   *
+   * @param callback_op Function to apply to the copy of the filled slot
+   * @param stream CUDA stream used for this operation
+   */
+  template <typename CallbackOp>
+  void for_each(CallbackOp&& callback_op, cuda::stream_ref stream = {}) const;
+
+  /**
+   * @brief Asynchronously applies the given function object `callback_op` to the copy of every
+   * filled slot in the container
+   *
+   * @note The return value of `callback_op`, if any, is ignored.
+   *
+   * @tparam CallbackOp Type of unary callback function object
+   *
+   * @param callback_op Function to apply to the copy of the filled slot
+   * @param stream CUDA stream used for this operation
+   */
+  template <typename CallbackOp>
+  void for_each_async(CallbackOp&& callback_op, cuda::stream_ref stream = {}) const;
+
+  /**
+   * @brief For each key in the range [first, last), applies the function object `callback_op` to
+   * the copy of all corresponding matches found in the container.
+   *
+   * @note The return value of `callback_op`, if any, is ignored.
+   *
+   * @tparam InputIt Device accessible random access input iterator
+   * @tparam CallbackOp Type of unary callback function object
+   *
+   * @param first Beginning of the sequence of keys
+   * @param last End of the sequence of keys
+   * @param callback_op Function to apply to the copy of the matched slot
+   * @param stream CUDA stream used for this operation
+   */
+  template <typename InputIt, typename CallbackOp>
+  void for_each(InputIt first,
+                InputIt last,
+                CallbackOp&& callback_op,
+                cuda::stream_ref stream = {}) const;
+
+  /**
+   * @brief For each key in the range [first, last), asynchronously applies the function object
+   * `callback_op` to the copy of all corresponding matches found in the container.
+   *
+   * @note The return value of `callback_op`, if any, is ignored.
+   *
+   * @tparam InputIt Device accessible random access input iterator
+   * @tparam CallbackOp Type of unary callback function object
+   *
+   * @param first Beginning of the sequence of keys
+   * @param last End of the sequence of keys
+   * @param callback_op Function to apply to the copy of the matched slot
+   * @param stream CUDA stream used for this operation
+   */
+  template <typename InputIt, typename CallbackOp>
+  void for_each_async(InputIt first,
+                      InputIt last,
+                      CallbackOp&& callback_op,
+                      cuda::stream_ref stream = {}) const noexcept;
 
   /**
    * @brief Counts the occurrences of keys in `[first, last)` contained in the set

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ ConfigureTest(UTILITY_TEST
 # - static_set tests ------------------------------------------------------------------------------
 ConfigureTest(STATIC_SET_TEST
     static_set/capacity_test.cu
+    static_set/for_each_test.cu
     static_set/heterogeneous_lookup_test.cu
     static_set/insert_and_find_test.cu
     static_set/large_input_test.cu

--- a/tests/static_set/for_each_test.cu
+++ b/tests/static_set/for_each_test.cu
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <test_utils.hpp>
+
+#include <cuco/static_set.cuh>
+
+#include <cuda/atomic>
+#include <thrust/device_vector.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
+#include <thrust/tuple.h>
+
+#include <catch2/catch_template_test_macros.hpp>
+
+using size_type = std::size_t;
+
+template <typename Set>
+void test_for_each(Set& set, size_type num_keys)
+{
+  using Key = typename Set::key_type;
+
+  REQUIRE(num_keys % 2 == 0);
+
+  cuda::stream_ref stream{};
+
+  // Insert keys
+  auto keys_begin = thrust::make_transform_iterator(
+    thrust::counting_iterator<size_type>{0}, cuda::proclaim_return_type<Key>([] __device__(auto i) {
+      // generates a sequence of 1, 2, 1, 2, ...
+      return static_cast<Key>(i);
+    }));
+  set.insert(keys_begin, keys_begin + num_keys, stream);
+
+  using Allocator = cuco::cuda_allocator<cuda::atomic<size_type, cuda::thread_scope_device>>;
+  cuco::detail::counter_storage<size_type, cuda::thread_scope_device, Allocator> counter_storage(
+    Allocator{});
+  counter_storage.reset(stream);
+
+  // count the sum of all even keys
+  set.for_each(
+    [counter = counter_storage.data()] __device__(auto const slot) {
+      if (slot % 2 == 0) { counter->fetch_add(slot, cuda::memory_order_relaxed); }
+    },
+    stream);
+  REQUIRE(counter_storage.load_to_host(stream) == 249'500);
+
+  counter_storage.reset(stream);
+
+  // count the sum of all odd keys
+  set.for_each(
+    thrust::counting_iterator<size_type>(0),
+    thrust::counting_iterator<size_type>(2 * num_keys),  // test for false-positives
+    [counter = counter_storage.data()] __device__(auto const slot) {
+      if (!(slot % 2 == 0)) { counter->fetch_add(slot, cuda::memory_order_relaxed); }
+    },
+    stream);
+  REQUIRE(counter_storage.load_to_host(stream) == 250'000);
+}
+
+TEMPLATE_TEST_CASE_SIG(
+  "static_set for_each tests",
+  "",
+  ((typename Key, cuco::test::probe_sequence Probe, int CGSize), Key, Probe, CGSize),
+  (int32_t, cuco::test::probe_sequence::double_hashing, 1),
+  (int32_t, cuco::test::probe_sequence::double_hashing, 2),
+  (int64_t, cuco::test::probe_sequence::double_hashing, 1),
+  (int64_t, cuco::test::probe_sequence::double_hashing, 2),
+  (int32_t, cuco::test::probe_sequence::linear_probing, 1),
+  (int32_t, cuco::test::probe_sequence::linear_probing, 2),
+  (int64_t, cuco::test::probe_sequence::linear_probing, 1),
+  (int64_t, cuco::test::probe_sequence::linear_probing, 2))
+{
+  constexpr size_type num_keys{1'000};
+  using probe = std::conditional_t<
+    Probe == cuco::test::probe_sequence::linear_probing,
+    cuco::linear_probing<CGSize, cuco::murmurhash3_32<Key>>,
+    cuco::double_hashing<CGSize, cuco::murmurhash3_32<Key>, cuco::murmurhash3_32<Key>>>;
+
+  using set_t = cuco::static_set<Key,
+                                 cuco::extent<size_type>,
+                                 cuda::thread_scope_device,
+                                 thrust::equal_to<Key>,
+                                 probe,
+                                 cuco::cuda_allocator<cuda::std::byte>,
+                                 cuco::storage<2>>;
+
+  auto set = set_t{num_keys, cuco::empty_key<Key>{-1}};
+  test_for_each(set, num_keys);
+}


### PR DESCRIPTION
This PR adds host and device `for_each` APIs for all cuco hash tables.