### PR TITLE
Add rehash for multiset and multimap

### DIFF
--- a/include/cuco/detail/static_multimap/static_multimap.inl
+++ b/include/cuco/detail/static_multimap/static_multimap.inl
@@ -406,6 +406,64 @@ template <class Key,
           class ProbingScheme,
           class Allocator,
           class Storage>
+void static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::rehash(
+  cuda::stream_ref stream)
+{
+  this->impl_->rehash(*this, stream);
+}
+
+template <class Key,
+          class T,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
+void static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::rehash(
+  size_type capacity, cuda::stream_ref stream)
+{
+  auto const extent = make_bucket_extent<static_multimap>(capacity);
+  this->impl_->rehash(extent, *this, stream);
+}
+
+template <class Key,
+          class T,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
+void static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::
+  rehash_async(cuda::stream_ref stream)
+{
+  this->impl_->rehash_async(*this, stream);
+}
+
+template <class Key,
+          class T,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
+void static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::
+  rehash_async(size_type capacity, cuda::stream_ref stream)
+{
+  auto const extent = make_bucket_extent<static_multimap>(capacity);
+  this->impl_->rehash_async(extent, *this, stream);
+}
+
+template <class Key,
+          class T,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
 constexpr auto
 static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::capacity()
   const noexcept

--- a/include/cuco/detail/static_multimap/static_multimap.inl
+++ b/include/cuco/detail/static_multimap/static_multimap.inl
@@ -409,7 +409,7 @@ template <class Key,
 void static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::rehash(
   cuda::stream_ref stream)
 {
-  this->impl_->rehash(*this, stream);
+  impl_->rehash(*this, stream);
 }
 
 template <class Key,
@@ -424,7 +424,7 @@ void static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, 
   size_type capacity, cuda::stream_ref stream)
 {
   auto const extent = make_bucket_extent<static_multimap>(capacity);
-  this->impl_->rehash(extent, *this, stream);
+  impl_->rehash(extent, *this, stream);
 }
 
 template <class Key,
@@ -438,7 +438,7 @@ template <class Key,
 void static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::
   rehash_async(cuda::stream_ref stream)
 {
-  this->impl_->rehash_async(*this, stream);
+  impl_->rehash_async(*this, stream);
 }
 
 template <class Key,
@@ -453,7 +453,7 @@ void static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, 
   rehash_async(size_type capacity, cuda::stream_ref stream)
 {
   auto const extent = make_bucket_extent<static_multimap>(capacity);
-  this->impl_->rehash_async(extent, *this, stream);
+  impl_->rehash_async(extent, *this, stream);
 }
 
 template <class Key,

--- a/include/cuco/detail/static_multimap/static_multimap.inl
+++ b/include/cuco/detail/static_multimap/static_multimap.inl
@@ -464,6 +464,21 @@ template <class Key,
           class ProbingScheme,
           class Allocator,
           class Storage>
+static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::size_type
+static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::size(
+  cuda::stream_ref stream) const
+{
+  return impl_->size(stream);
+}
+
+template <class Key,
+          class T,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
 constexpr auto
 static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::capacity()
   const noexcept

--- a/include/cuco/detail/static_multiset/static_multiset.inl
+++ b/include/cuco/detail/static_multiset/static_multiset.inl
@@ -481,6 +481,60 @@ template <class Key,
           class ProbingScheme,
           class Allocator,
           class Storage>
+void static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::rehash(
+  cuda::stream_ref stream)
+{
+  this->impl_->rehash(*this, stream);
+}
+
+template <class Key,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
+void static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::rehash(
+  size_type capacity, cuda::stream_ref stream)
+{
+  auto const extent = make_bucket_extent<static_multiset>(capacity);
+  this->impl_->rehash(extent, *this, stream);
+}
+
+template <class Key,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
+void static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::rehash_async(
+  cuda::stream_ref stream)
+{
+  this->impl_->rehash_async(*this, stream);
+}
+
+template <class Key,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
+void static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::rehash_async(
+  size_type capacity, cuda::stream_ref stream)
+{
+  auto const extent = make_bucket_extent<static_multiset>(capacity);
+  this->impl_->rehash_async(extent, *this, stream);
+}
+
+template <class Key,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
 static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::size_type
 static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::size(
   cuda::stream_ref stream) const

--- a/include/cuco/detail/static_multiset/static_multiset.inl
+++ b/include/cuco/detail/static_multiset/static_multiset.inl
@@ -484,7 +484,7 @@ template <class Key,
 void static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::rehash(
   cuda::stream_ref stream)
 {
-  this->impl_->rehash(*this, stream);
+  impl_->rehash(*this, stream);
 }
 
 template <class Key,
@@ -498,7 +498,7 @@ void static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Sto
   size_type capacity, cuda::stream_ref stream)
 {
   auto const extent = make_bucket_extent<static_multiset>(capacity);
-  this->impl_->rehash(extent, *this, stream);
+  impl_->rehash(extent, *this, stream);
 }
 
 template <class Key,
@@ -511,7 +511,7 @@ template <class Key,
 void static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::rehash_async(
   cuda::stream_ref stream)
 {
-  this->impl_->rehash_async(*this, stream);
+  impl_->rehash_async(*this, stream);
 }
 
 template <class Key,
@@ -525,7 +525,7 @@ void static_multiset<Key, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Sto
   size_type capacity, cuda::stream_ref stream)
 {
   auto const extent = make_bucket_extent<static_multiset>(capacity);
-  this->impl_->rehash_async(extent, *this, stream);
+  impl_->rehash_async(extent, *this, stream);
 }
 
 template <class Key,

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -658,6 +658,16 @@ class static_multimap {
   void rehash_async(size_type capacity, cuda::stream_ref stream = {});
 
   /**
+   * @brief Gets the number of elements in the container.
+   *
+   * @note This function synchronizes the given stream.
+   *
+   * @param stream CUDA stream used to get the number of inserted elements
+   * @return The number of elements in the container
+   */
+  [[nodiscard]] size_type size(cuda::stream_ref stream = {}) const;
+
+  /**
    * @brief Gets the maximum number of elements the hash map can hold.
    *
    * @return The maximum number of elements the hash map can hold

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -603,6 +603,61 @@ class static_multimap {
   size_type count(InputIt first, InputIt last, cuda::stream_ref stream = {}) const;
 
   /**
+   * @brief Regenerates the container.
+   *
+   * @note This function synchronizes the given stream. For asynchronous execution use
+   * `rehash_async`.
+   *
+   * @param stream CUDA stream used for this operation
+   */
+  void rehash(cuda::stream_ref stream = {});
+
+  /**
+   * @brief Reserves at least the specified number of slots and regenerates the container
+   *
+   * @note Changes the number of slots to a value that is not less than `capacity`, then
+   * rehashes the container, i.e. puts the elements into appropriate slots considering
+   * that the total number of slots has changed.
+   *
+   * @note This function synchronizes the given stream. For asynchronous execution use
+   * `rehash_async`.
+   *
+   * @note Behavior is undefined if the desired `capacity` is insufficient to store all of the
+   * contained elements.
+   *
+   * @note This function is not available if the conatiner's `extent_type` is static.
+   *
+   * @param capacity New capacity of the container
+   * @param stream CUDA stream used for this operation
+   */
+  void rehash(size_type capacity, cuda::stream_ref stream = {});
+
+  /**
+   * @brief Asynchronously regenerates the container.
+   *
+   * @param stream CUDA stream used for this operation
+   */
+  void rehash_async(cuda::stream_ref stream = {});
+
+  /**
+   * @brief Asynchronously reserves at least the specified number of slots and regenerates the
+   * container
+   *
+   * @note Changes the number of slots to a value that is not less than `capacity`, then
+   * rehashes the container, i.e. puts the elements into appropriate slots considering
+   * that the total number of slots has changed.
+   *
+   * @note Behavior is undefined if the desired `capacity` is insufficient to store all of the
+   * contained elements.
+   *
+   * @note This function is not available if the conatiner's `extent_type` is static.
+   *
+   * @param capacity New capacity of the container
+   * @param stream CUDA stream used for this operation
+   */
+  void rehash_async(size_type capacity, cuda::stream_ref stream = {});
+
+  /**
    * @brief Gets the maximum number of elements the hash map can hold.
    *
    * @return The maximum number of elements the hash map can hold

--- a/include/cuco/static_multiset.cuh
+++ b/include/cuco/static_multiset.cuh
@@ -739,6 +739,61 @@ class static_multiset {
                                                          cuda::stream_ref stream = {}) const;
 
   /**
+   * @brief Regenerates the container.
+   *
+   * @note This function synchronizes the given stream. For asynchronous execution use
+   * `rehash_async`.
+   *
+   * @param stream CUDA stream used for this operation
+   */
+  void rehash(cuda::stream_ref stream = {});
+
+  /**
+   * @brief Reserves at least the specified number of slots and regenerates the container
+   *
+   * @note Changes the number of slots to a value that is not less than `capacity`, then
+   * rehashes the container, i.e. puts the elements into appropriate slots considering
+   * that the total number of slots has changed.
+   *
+   * @note This function synchronizes the given stream. For asynchronous execution use
+   * `rehash_async`.
+   *
+   * @note Behavior is undefined if the desired `capacity` is insufficient to store all of the
+   * contained elements.
+   *
+   * @note This function is not available if the conatiner's `extent_type` is static.
+   *
+   * @param capacity New capacity of the container
+   * @param stream CUDA stream used for this operation
+   */
+  void rehash(size_type capacity, cuda::stream_ref stream = {});
+
+  /**
+   * @brief Asynchronously regenerates the container.
+   *
+   * @param stream CUDA stream used for this operation
+   */
+  void rehash_async(cuda::stream_ref stream = {});
+
+  /**
+   * @brief Asynchronously reserves at least the specified number of slots and regenerates the
+   * container
+   *
+   * @note Changes the number of slots to a value that is not less than `capacity`, then
+   * rehashes the container, i.e. puts the elements into appropriate slots considering
+   * that the total number of slots has changed.
+   *
+   * @note Behavior is undefined if the desired `capacity` is insufficient to store all of the
+   * contained elements.
+   *
+   * @note This function is not available if the conatiner's `extent_type` is static.
+   *
+   * @param capacity New capacity of the container
+   * @param stream CUDA stream used for this operation
+   */
+  void rehash_async(size_type capacity, cuda::stream_ref stream = {});
+
+  /**
    * @brief Gets the number of elements in the container.
    *
    * @note This function synchronizes the given stream.


### PR DESCRIPTION
This PR adds `rehash` APIs for multiset and multimap. It also adds `size` to multimap.