### PR TITLE
Expose default benchmark axes in the output

### DIFF
--- a/benchmarks/benchmark_utils.hpp
+++ b/benchmarks/benchmark_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,10 +29,10 @@ auto dist_from_state(nvbench::state const& state)
   if constexpr (std::is_same_v<Dist, cuco::utility::distribution::unique>) {
     return Dist{};
   } else if constexpr (std::is_same_v<Dist, cuco::utility::distribution::uniform>) {
-    auto const multiplicity = state.get_int64_or_default("Multiplicity", defaults::MULTIPLICITY);
+    auto const multiplicity = state.get_int64("Multiplicity");
     return Dist{multiplicity};
   } else if constexpr (std::is_same_v<Dist, cuco::utility::distribution::gaussian>) {
-    auto const skew = state.get_float64_or_default("Skew", defaults::SKEW);
+    auto const skew = state.get_float64("Skew");
     return Dist{skew};
   } else {
     CUCO_FAIL("Unexpected distribution type");

--- a/benchmarks/bloom_filter/add_bench.cu
+++ b/benchmarks/bloom_filter/add_bench.cu
@@ -49,7 +49,7 @@ void bloom_filter_add(nvbench::state& state,
 
   auto const num_keys       = state.get_int64("NumInputs");
   auto const filter_size_mb = state.get_int64("FilterSizeMB");
-  auto const pattern_bits   = state.get_int64_or_default("PatternBits", WordsPerBlock);
+  auto const pattern_bits   = WordsPerBlock;
 
   try {
     auto const policy = policy_type{static_cast<uint32_t>(pattern_bits)};

--- a/benchmarks/bloom_filter/contains_bench.cu
+++ b/benchmarks/bloom_filter/contains_bench.cu
@@ -51,7 +51,7 @@ void bloom_filter_contains(
 
   auto const num_keys       = state.get_int64("NumInputs");
   auto const filter_size_mb = state.get_int64("FilterSizeMB");
-  auto const pattern_bits   = state.get_int64_or_default("PatternBits", WordsPerBlock);
+  auto const pattern_bits   = WordsPerBlock;
 
   try {
     auto const policy = policy_type{static_cast<uint32_t>(pattern_bits)};

--- a/benchmarks/static_multiset/retrieve_bench.cu
+++ b/benchmarks/static_multiset/retrieve_bench.cu
@@ -34,9 +34,9 @@ using namespace cuco::utility;
 template <typename Key, typename Dist>
 void static_multiset_retrieve(nvbench::state& state, nvbench::type_list<Key, Dist>)
 {
-  auto const num_keys      = state.get_int64_or_default("NumInputs", defaults::N);
-  auto const occupancy     = state.get_float64_or_default("Occupancy", defaults::OCCUPANCY);
-  auto const matching_rate = state.get_float64_or_default("MatchingRate", defaults::MATCHING_RATE);
+  auto const num_keys      = state.get_int64("NumInputs");
+  auto const occupancy     = state.get_float64("Occupancy");
+  auto const matching_rate = state.get_float64("MatchingRate");
 
   std::size_t const size = num_keys / occupancy;
 
@@ -68,7 +68,10 @@ NVBENCH_BENCH_TYPES(static_multiset_retrieve,
   .set_name("static_multiset_retrieve_uniform_occupancy")
   .set_type_axes_names({"Key", "Distribution"})
   .set_max_noise(defaults::MAX_NOISE)
-  .add_float64_axis("Occupancy", defaults::OCCUPANCY_RANGE);
+  .add_int64_axis("NumInputs", {defaults::N})
+  .add_float64_axis("Occupancy", defaults::OCCUPANCY_RANGE)
+  .add_float64_axis("MatchingRate", {defaults::MATCHING_RATE})
+  .add_int64_axis("Multiplicity", {defaults::MULTIPLICITY});
 
 NVBENCH_BENCH_TYPES(static_multiset_retrieve,
                     NVBENCH_TYPE_AXES(defaults::KEY_TYPE_RANGE,
@@ -76,7 +79,10 @@ NVBENCH_BENCH_TYPES(static_multiset_retrieve,
   .set_name("static_multiset_retrieve_uniform_matching_rate")
   .set_type_axes_names({"Key", "Distribution"})
   .set_max_noise(defaults::MAX_NOISE)
-  .add_float64_axis("MatchingRate", defaults::MATCHING_RATE_RANGE);
+  .add_int64_axis("NumInputs", {defaults::N})
+  .add_float64_axis("Occupancy", {defaults::OCCUPANCY})
+  .add_float64_axis("MatchingRate", defaults::MATCHING_RATE_RANGE)
+  .add_int64_axis("Multiplicity", {defaults::MULTIPLICITY});
 
 NVBENCH_BENCH_TYPES(static_multiset_retrieve,
                     NVBENCH_TYPE_AXES(defaults::KEY_TYPE_RANGE,
@@ -84,4 +90,7 @@ NVBENCH_BENCH_TYPES(static_multiset_retrieve,
   .set_name("static_multiset_retrieve_uniform_multiplicity")
   .set_type_axes_names({"Key", "Distribution"})
   .set_max_noise(defaults::MAX_NOISE)
+  .add_int64_axis("NumInputs", {defaults::N})
+  .add_float64_axis("Occupancy", {defaults::OCCUPANCY})
+  .add_float64_axis("MatchingRate", {defaults::MATCHING_RATE})
   .add_int64_axis("Multiplicity", defaults::MULTIPLICITY_RANGE);


### PR DESCRIPTION
Close #286

This PR removes the use of `get_*_or_default` APIs in the benchmark to expose all default axes to the benchmark output.