### PR TITLE
Minor improvements for arrow_filter_policy

### DIFF
--- a/include/cuco/bloom_filter_policies.cuh
+++ b/include/cuco/bloom_filter_policies.cuh
@@ -33,7 +33,7 @@ namespace cuco {
  * By default, cuco::xxhash_64 hasher will be used.
  *
  */
-template <class Key, class XXHash64 = cuco::xxhash_64<Key>>
+template <typename Key, template <typename> class XXHash64 = cuco::xxhash_64>
 using arrow_filter_policy = detail::arrow_filter_policy<Key, XXHash64>;
 
 /**

--- a/include/cuco/detail/bloom_filter/arrow_filter_policy.cuh
+++ b/include/cuco/detail/bloom_filter/arrow_filter_policy.cuh
@@ -84,11 +84,10 @@ namespace cuco::detail {
 template <class Key, template <typename> class XXHash64>
 class arrow_filter_policy {
  public:
-  using hasher             = XXHash64<Key>;  ///< 64-bit XXHash hasher for Arrow bloom filter policy
-  using word_type          = std::uint32_t;  ///< uint32_t for Arrow bloom filter policy
-  using key_type = Key;  ///< Hash function input type
-  using hash_value_type   = uint64_t;
-    std::declval<hash_argument_type>()));  ///< hash function output type
+  using hasher          = XXHash64<Key>;  ///< 64-bit XXHash hasher for Arrow bloom filter policy
+  using word_type       = std::uint32_t;  ///< uint32_t for Arrow bloom filter policy
+  using key_type        = Key;            ///< Hash function input type
+  using hash_value_type = std::uint64_t;  ///< hash function output type
 
   static constexpr uint32_t bits_set_per_block = 8;  ///< hardcoded bits set per Arrow filter block
   static constexpr uint32_t words_per_block    = 8;  ///< hardcoded words per Arrow filter block

--- a/include/cuco/detail/bloom_filter/arrow_filter_policy.cuh
+++ b/include/cuco/detail/bloom_filter/arrow_filter_policy.cuh
@@ -83,10 +83,10 @@ namespace cuco::detail {
 template <class Key, template <typename> class XXHash64>
 class arrow_filter_policy {
  public:
-  using hasher             = XXHash64<Key>;  ///< 64-bit XXHash hasher for Arrow bloom filter policy
-  using word_type          = std::uint32_t;  ///< uint32_t for Arrow bloom filter policy
-  using hash_argument_type = Key;            ///< Hash function input type
-  using hash_result_type   = std::uint64_t;  ///< hash function output type
+  using hasher          = XXHash64<Key>;  ///< 64-bit XXHash hasher for Arrow bloom filter policy
+  using word_type       = std::uint32_t;  ///< uint32_t for Arrow bloom filter policy
+  using key_type        = Key;            ///< Hash function input type
+  using hash_value_type = std::uint64_t;  ///< hash function output type
 
   static constexpr uint32_t bits_set_per_block = 8;  ///< hardcoded bits set per Arrow filter block
   static constexpr uint32_t words_per_block    = 8;  ///< hardcoded words per Arrow filter block
@@ -133,10 +133,7 @@ class arrow_filter_policy {
    *
    * @return The hash value of the key
    */
-  __device__ constexpr hash_result_type hash(hash_argument_type const& key) const
-  {
-    return hash_(key);
-  }
+  __device__ constexpr hash_value_type hash(key_type const& key) const { return hash_(key); }
 
   /**
    * @brief Determines the filter block a key is added into.
@@ -153,7 +150,7 @@ class arrow_filter_policy {
    * @return The block index for the given key's hash value
    */
   template <class Extent>
-  __device__ constexpr auto block_index(hash_result_type hash, Extent num_blocks) const
+  __device__ constexpr auto block_index(hash_value_type hash, Extent num_blocks) const
   {
     constexpr auto hash_bits = cuda::std::numeric_limits<word_type>::digits;
     // TODO: assert if num_blocks > max_filter_blocks
@@ -171,7 +168,7 @@ class arrow_filter_policy {
    *
    * @return The bit pattern for the word/segment in the filter block
    */
-  __device__ constexpr word_type word_pattern(hash_result_type hash, std::uint32_t word_index) const
+  __device__ constexpr word_type word_pattern(hash_value_type hash, std::uint32_t word_index) const
   {
     // SALT array to calculate bit indexes for the current word
     auto constexpr salt = SALT();

--- a/include/cuco/detail/bloom_filter/arrow_filter_policy.cuh
+++ b/include/cuco/detail/bloom_filter/arrow_filter_policy.cuh
@@ -81,10 +81,10 @@ namespace cuco::detail {
  * @tparam Key The type of the values to generate a fingerprint for.
  * @tparam XXHash64 64-bit XXHash hasher implementation for fingerprint generation.
  */
-template <class Key, class XXHash64>
+template <class Key, template <typename> class XXHash64>
 class arrow_filter_policy {
  public:
-  using hasher             = XXHash64;       ///< 64-bit XXHash hasher for Arrow bloom filter policy
+  using hasher             = XXHash64<Key>;  ///< 64-bit XXHash hasher for Arrow bloom filter policy
   using word_type          = std::uint32_t;  ///< uint32_t for Arrow bloom filter policy
   using hash_argument_type = typename hasher::argument_type;  ///< Hash function input type
   using hash_result_type   = decltype(std::declval<hasher>()(

--- a/include/cuco/detail/bloom_filter/arrow_filter_policy.cuh
+++ b/include/cuco/detail/bloom_filter/arrow_filter_policy.cuh
@@ -40,8 +40,7 @@ namespace cuco::detail {
  * void bulk_insert_and_eval_arrow_policy_bloom_filter(device_vector<KeyType> const& positive_keys,
  *                                                 device_vector<KeyType> const& negative_keys)
  * {
- *     using xxhash_64 = cuco::xxhash_64<KeyType>;
- *     using policy_type = cuco::arrow_filter_policy<KeyType, xxhash_64>;
+ *     using policy_type = cuco::arrow_filter_policy<KeyType, cuco::xxhash_64>;
  *
  *     // Warn or throw if the number of filter blocks is greater than maximum used by Arrow policy.
  *     static_assert(NUM_FILTER_BLOCKS <= policy_type::max_filter_blocks, "NUM_FILTER_BLOCKS must be
@@ -84,10 +83,10 @@ namespace cuco::detail {
 template <class Key, template <typename> class XXHash64>
 class arrow_filter_policy {
  public:
-  using hasher          = XXHash64<Key>;  ///< 64-bit XXHash hasher for Arrow bloom filter policy
-  using word_type       = std::uint32_t;  ///< uint32_t for Arrow bloom filter policy
-  using key_type        = Key;            ///< Hash function input type
-  using hash_value_type = std::uint64_t;  ///< hash function output type
+  using hasher             = XXHash64<Key>;  ///< 64-bit XXHash hasher for Arrow bloom filter policy
+  using word_type          = std::uint32_t;  ///< uint32_t for Arrow bloom filter policy
+  using hash_argument_type = Key;            ///< Hash function input type
+  using hash_result_type   = std::uint64_t;  ///< hash function output type
 
   static constexpr uint32_t bits_set_per_block = 8;  ///< hardcoded bits set per Arrow filter block
   static constexpr uint32_t words_per_block    = 8;  ///< hardcoded words per Arrow filter block

--- a/include/cuco/detail/bloom_filter/arrow_filter_policy.cuh
+++ b/include/cuco/detail/bloom_filter/arrow_filter_policy.cuh
@@ -86,8 +86,8 @@ class arrow_filter_policy {
  public:
   using hasher             = XXHash64<Key>;  ///< 64-bit XXHash hasher for Arrow bloom filter policy
   using word_type          = std::uint32_t;  ///< uint32_t for Arrow bloom filter policy
-  using hash_argument_type = typename hasher::argument_type;  ///< Hash function input type
-  using hash_result_type   = decltype(std::declval<hasher>()(
+  using key_type = Key;  ///< Hash function input type
+  using hash_value_type   = uint64_t;
     std::declval<hash_argument_type>()));  ///< hash function output type
 
   static constexpr uint32_t bits_set_per_block = 8;  ///< hardcoded bits set per Arrow filter block


### PR DESCRIPTION
<!--

Thank you for contributing to cuCollections :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

This PR make the hasher to `arrow_filter_policy` a template type for users to simply pass the hasher without specifying the `Key` type twice. See this comment for discussion: https://github.com/NVIDIA/cuCollections/issues/653#issuecomment-2530111406. Also update member types `argument_type` and `hash_result_type` to directly use `Key` and `std::uint64_t` for this policy.