### PR TITLE
Add `count` and `retrieve` APIs to multimap with support for custom hash and key_eq

### DIFF
--- a/include/cuco/detail/static_multimap/static_multimap.inl
+++ b/include/cuco/detail/static_multimap/static_multimap.inl
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/cuco/detail/static_multimap/static_multimap.inl
+++ b/include/cuco/detail/static_multimap/static_multimap.inl
@@ -447,6 +447,29 @@ template <class Key,
           class ProbingScheme,
           class Allocator,
           class Storage>
+template <typename InputIt, typename ProbeEqual, typename ProbeHash>
+static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::size_type
+static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::count(
+  InputIt first,
+  InputIt last,
+  ProbeEqual const& probe_equal,
+  ProbeHash const& probe_hash,
+  cuda::stream_ref stream) const
+{
+  return impl_->count(first,
+                      last,
+                      ref(op::count).rebind_key_eq(probe_equal).rebind_hash_function(probe_hash),
+                      stream);
+}
+
+template <class Key,
+          class T,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
 template <typename InputIt, typename OutputProbeIt, typename OutputMatchIt>
 std::pair<OutputProbeIt, OutputMatchIt>
 static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::retrieve(
@@ -457,6 +480,34 @@ static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Stora
   cuda::stream_ref stream) const
 {
   return impl_->retrieve(first, last, output_probe, output_match, this->ref(op::retrieve), stream);
+}
+
+template <class Key,
+          class T,
+          class Extent,
+          cuda::thread_scope Scope,
+          class KeyEqual,
+          class ProbingScheme,
+          class Allocator,
+          class Storage>
+template <typename InputProbeIt,
+          class ProbeEqual,
+          class ProbeHash,
+          typename OutputProbeIt,
+          typename OutputMatchIt>
+std::pair<OutputProbeIt, OutputMatchIt>
+static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::retrieve(
+  InputProbeIt first,
+  InputProbeIt last,
+  ProbeEqual const& probe_equal,
+  ProbeHash const& probe_hash,
+  OutputProbeIt output_probe,
+  OutputMatchIt output_match,
+  cuda::stream_ref stream) const
+{
+  auto const probe_ref =
+    this->ref(op::retrieve).rebind_key_eq(probe_equal).rebind_hash_function(probe_hash);
+  return impl_->retrieve(first, last, output_probe, output_match, probe_ref, stream);
 }
 
 template <class Key,

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -667,9 +667,33 @@ class static_multimap {
   size_type count(InputIt first, InputIt last, cuda::stream_ref stream = {}) const;
 
   /**
+   * @brief Counts the occurrences of keys in `[first, last)` contained in the
+   * multimap with custom hash and key comparator
+   *
+   * @note This function synchronizes the given stream.
+   *
+   * @tparam Input Device accessible input iterator
+   * @tparam ProbeEqual Binary callable
+   * @tparam ProbeHash Unary hash callable
+   *
+   * @param first Beginning of the sequence of keys to count
+   * @param last End of the sequence of keys to count
+   * @param probe_equal Binary callable to compare two keys for equality
+   * @param probe_hash Unary callable to hash a given key
+   * @param stream CUDA stream used for count
+   *
+   * @return The sum of total occurrences of all keys in `[first, last)`
+   */
+  template <typename InputIt, typename ProbeEqual, typename ProbeHash>
+  size_type count(InputIt first,
+                  InputIt last,
+                  ProbeEqual const& probe_equal,
+                  ProbeHash const& probe_hash,
+                  cuda::stream_ref stream = {}) const;
+
+  /**
    * @brief Retrieves the matched key-value pair in the multimap corresponding to all probe keys in
-   * the range
-   * `[first, last)`
+   * the range `[first, last)`
    *
    * If key `k = *(first + i)` has a match `m` in the multimap, copies a `cuco::pair{k, m}` to
    * unspecified locations in `[output_begin, output_end)`. Else, does nothing.
@@ -696,6 +720,49 @@ class static_multimap {
   template <typename InputIt, typename OutputProbeIt, typename OutputMatchIt>
   std::pair<OutputProbeIt, OutputMatchIt> retrieve(InputIt first,
                                                    InputIt last,
+                                                   OutputProbeIt output_probe,
+                                                   OutputMatchIt output_match,
+                                                   cuda::stream_ref stream = {}) const;
+
+  /**
+   * @brief Retrieves all the slots corresponding to all keys in the range `[first, last)`.
+   *
+   * If key `k = *(first + i)` exists in the container, copies `k` to `output_probe` and associated
+   * slot contents to `output_match`, respectively. The output order is unspecified.
+   *
+   * Behavior is undefined if the size of the output range exceeds the number of retrieved slots.
+   * Use `count()` to determine the size of the output range.
+   *
+   * This function synchronizes the given CUDA stream.
+   *
+   * @tparam InputProbeIt Device accessible input iterator
+   * @tparam ProbeEqual Binary callable equal type
+   * @tparam ProbeHash Unary callable hasher type that can be constructed from
+   * @tparam OutputProbeIt Device accessible input iterator whose `value_type` is
+   * convertible to the `InputProbeIt`'s `value_type`
+   * @tparam OutputMatchIt Device accessible input iterator whose `value_type` is
+   * convertible to the container's `value_type`
+   *
+   * @param first Beginning of the input sequence of keys
+   * @param last End of the input sequence of keys
+   * @param probe_equal The binary function to compare set keys and probe keys for equality
+   * @param probe_hash The unary function to hash probe keys
+   * @param output_probe Beginning of the sequence of keys corresponding to matching elements in
+   * `output_match`
+   * @param output_match Beginning of the sequence of matching elements
+   * @param stream CUDA stream this operation is executed in
+   *
+   * @return Iterator pair indicating the the end of the output sequences
+   */
+  template <class InputProbeIt,
+            class ProbeEqual,
+            class ProbeHash,
+            class OutputProbeIt,
+            class OutputMatchIt>
+  std::pair<OutputProbeIt, OutputMatchIt> retrieve(InputProbeIt first,
+                                                   InputProbeIt last,
+                                                   ProbeEqual const& probe_equal,
+                                                   ProbeHash const& probe_hash,
                                                    OutputProbeIt output_probe,
                                                    OutputMatchIt output_match,
                                                    cuda::stream_ref stream = {}) const;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2018-2024, NVIDIA CORPORATION.
+# Copyright (c) 2018-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -120,7 +120,8 @@ ConfigureTest(STATIC_MULTIMAP_TEST
     static_multimap/insert_contains_test.cu
     static_multimap/insert_if_test.cu
     static_multimap/multiplicity_test.cu
-    static_multimap/for_each_test.cu)
+    static_multimap/for_each_test.cu
+    static_multimap/retrieve_test.cu)
 
 ###################################################################################################
 # - dynamic_bitset tests --------------------------------------------------------------------------

--- a/tests/static_multimap/insert_contains_test.cu
+++ b/tests/static_multimap/insert_contains_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/static_multimap/insert_contains_test.cu
+++ b/tests/static_multimap/insert_contains_test.cu
@@ -33,12 +33,8 @@ void test_insert(Map& map, std::size_t num_keys)
   using Key   = typename Map::key_type;
   using Value = typename Map::mapped_type;
 
-  thrust::device_vector<Key> d_keys(num_keys);
-
-  thrust::sequence(thrust::device, d_keys.begin(), d_keys.end());
-
-  auto keys_begin  = d_keys.begin();
-  auto pairs_begin = thrust::make_transform_iterator(
+  auto const keys_begin = thrust::counting_iterator<Key>{0};
+  auto pairs_begin      = thrust::make_transform_iterator(
     thrust::make_counting_iterator(0),
     cuda::proclaim_return_type<cuco::pair<Key, Value>>(
       [] __device__(auto i) { return cuco::pair<Key, Value>{i, i}; }));

--- a/tests/static_multimap/multiplicity_test.cu
+++ b/tests/static_multimap/multiplicity_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/static_multimap/retrieve_test.cu
+++ b/tests/static_multimap/retrieve_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,22 +28,30 @@
 
 #include <catch2/catch_template_test_macros.hpp>
 
+struct custom_key_eq {
+  template <typename T>
+  __device__ bool operator()(T const& lhs, T const& rhs) const
+  {
+    return lhs % 2 == 0 ? lhs == rhs : false;
+  }
+};
+
 template <typename Map>
-void test_multiplicity_two(Map& map, std::size_t num_items)
+void test_retrieve(Map& map, std::size_t num_items)
 {
   using Key   = typename Map::key_type;
   using Value = typename Map::mapped_type;
 
-  auto const num_keys = num_items / 2;
+  auto const num_gold = num_items / 2;
 
   auto const keys_begin = thrust::counting_iterator<Key>{0};
-  // multiplicity = 2
+  // multiplicity = 1
   auto const pairs_begin = thrust::make_transform_iterator(
     keys_begin, cuda::proclaim_return_type<cuco::pair<Key, Value>>([] __device__(auto i) {
-      return cuco::pair<Key, Value>{i / 2, i};
+      return cuco::pair<Key, Value>{i, i};
     }));
 
-  thrust::device_vector<cuco::pair<Key, Value>> d_results(num_items);
+  thrust::device_vector<cuco::pair<Key, Value>> d_results(num_gold);
   auto output_begin = d_results.begin();
 
   map.insert(pairs_begin, pairs_begin + num_items);
@@ -51,15 +59,20 @@ void test_multiplicity_two(Map& map, std::size_t num_items)
   SECTION("Total count should be equal to the number of inserted pairs.")
   {
     // Count matching keys
-    auto const num = map.count(keys_begin, keys_begin + num_keys);
+    auto const num =
+      map.count(keys_begin, keys_begin + num_items, custom_key_eq{}, map.hash_function());
 
-    REQUIRE(num == num_items);
+    REQUIRE(num == num_gold);
 
-    auto [_, output_end] =
-      map.retrieve(keys_begin, keys_begin + num_keys, thrust::discard_iterator{}, output_begin);
+    auto [_, output_end]   = map.retrieve(keys_begin,
+                                        keys_begin + num_items,
+                                        custom_key_eq{},
+                                        map.hash_function(),
+                                        thrust::discard_iterator{},
+                                        output_begin);
     std::size_t const size = thrust::distance(output_begin, output_end);
 
-    REQUIRE(size == num_items);
+    REQUIRE(size == num_gold);
 
     // sort before compare
     thrust::sort(
@@ -71,9 +84,13 @@ void test_multiplicity_two(Map& map, std::size_t num_items)
         return lhs.second < rhs.second;
       });
 
+    auto const gold_begin = thrust::make_transform_iterator(
+      keys_begin, cuda::proclaim_return_type<cuco::pair<Key, Value>>([] __device__(auto i) {
+        return cuco::pair<Key, Value>{i * 2, i * 2};
+      }));
     REQUIRE(
-      cuco::test::equal(pairs_begin,
-                        pairs_begin + num_items,
+      cuco::test::equal(gold_begin,
+                        gold_begin + num_gold,
                         output_begin,
                         [] __device__(cuco::pair<Key, Value> lhs, cuco::pair<Key, Value> rhs) {
                           return lhs.first == rhs.first and lhs.second == rhs.second;
@@ -82,17 +99,17 @@ void test_multiplicity_two(Map& map, std::size_t num_items)
 }
 
 TEMPLATE_TEST_CASE_SIG(
-  "static_multimap multiplicity tests",
+  "static_multimap retrieve tests",
   "",
   ((typename T, cuco::test::probe_sequence Probe, int CGSize), T, Probe, CGSize),
   (int32_t, cuco::test::probe_sequence::double_hashing, 1),
-  (int32_t, cuco::test::probe_sequence::double_hashing, 8),
+  (int32_t, cuco::test::probe_sequence::double_hashing, 4),
   (int64_t, cuco::test::probe_sequence::double_hashing, 1),
-  (int64_t, cuco::test::probe_sequence::double_hashing, 8),
+  (int64_t, cuco::test::probe_sequence::double_hashing, 4),
   (int32_t, cuco::test::probe_sequence::linear_probing, 1),
-  (int32_t, cuco::test::probe_sequence::linear_probing, 8),
+  (int32_t, cuco::test::probe_sequence::linear_probing, 4),
   (int64_t, cuco::test::probe_sequence::linear_probing, 1),
-  (int64_t, cuco::test::probe_sequence::linear_probing, 8))
+  (int64_t, cuco::test::probe_sequence::linear_probing, 4))
 {
   constexpr std::size_t num_items{400};
 
@@ -111,5 +128,5 @@ TEMPLATE_TEST_CASE_SIG(
                                                  cuco::storage<2>>{
     num_items * 2, cuco::empty_key<T>{-1}, cuco::empty_value<T>{-1}};
 
-  test_multiplicity_two(map, num_items);
+  test_retrieve(map, num_items);
 }

--- a/tests/static_multimap/retrieve_test.cu
+++ b/tests/static_multimap/retrieve_test.cu
@@ -45,10 +45,10 @@ void test_retrieve(Map& map, std::size_t num_items)
   auto const num_gold = num_items / 2;
 
   auto const keys_begin = thrust::counting_iterator<Key>{0};
-  // multiplicity = 1
+  // multiplicity = 2
   auto const pairs_begin = thrust::make_transform_iterator(
     keys_begin, cuda::proclaim_return_type<cuco::pair<Key, Value>>([] __device__(auto i) {
-      return cuco::pair<Key, Value>{i, i};
+      return cuco::pair<Key, Value>{i / 2, i / 2};
     }));
 
   thrust::device_vector<cuco::pair<Key, Value>> d_results(num_gold);
@@ -86,7 +86,7 @@ void test_retrieve(Map& map, std::size_t num_items)
 
     auto const gold_begin = thrust::make_transform_iterator(
       keys_begin, cuda::proclaim_return_type<cuco::pair<Key, Value>>([] __device__(auto i) {
-        return cuco::pair<Key, Value>{i * 2, i * 2};
+        return cuco::pair<Key, Value>{(i / 2) * 2, (i / 2) * 2};
       }));
     REQUIRE(
       cuco::test::equal(gold_begin,
@@ -111,7 +111,7 @@ TEMPLATE_TEST_CASE_SIG(
   (int64_t, cuco::test::probe_sequence::linear_probing, 1),
   (int64_t, cuco::test::probe_sequence::linear_probing, 4))
 {
-  constexpr std::size_t num_items{400};
+  constexpr std::size_t num_items{1'000};
 
   using probe = std::conditional_t<
     Probe == cuco::test::probe_sequence::linear_probing,


### PR DESCRIPTION
Resolve #662

This PR introduces `count` and `retrieve` APIs to the multimap, allowing custom hash and key equality as inputs for more flexible query requests. Additionally, it includes unit test cleanups to remove unused Thrust algorithms.







