### PR TITLE
[REVIEW] fixed an index issue in bloom_filter_impl

### DIFF
--- a/include/cuco/detail/bloom_filter/bloom_filter_impl.cuh
+++ b/include/cuco/detail/bloom_filter/bloom_filter_impl.cuh
@@ -97,7 +97,7 @@ class bloom_filter_impl {
   template <class CG>
   __device__ constexpr void clear(CG const& group)
   {
-    for (int i = group.thread_rank(); num_blocks_ * words_per_block; i += group.size()) {
+    for (int i = group.thread_rank(); i < num_blocks_ * words_per_block; i += group.size()) {
       words_[i] = 0;
     }
   }
@@ -152,10 +152,10 @@ class bloom_filter_impl {
 
 #pragma unroll
       for (uint32_t i = rank; i < optimal_num_threads; i += num_threads) {
-        auto const word = policy_.word_pattern(hash_value, rank);
+        auto const word = policy_.word_pattern(hash_value, i);
 
         auto atom_word =
-          cuda::atomic_ref<word_type, thread_scope>{*(words_ + (idx * words_per_block + rank))};
+          cuda::atomic_ref<word_type, thread_scope>{*(words_ + (idx * words_per_block + i))};
         atom_word.fetch_or(word, cuda::memory_order_relaxed);
       }
     }


### PR DESCRIPTION
There seem to be some small issues with the for-loop indices in bloom filter. This pr aims to fix them.

In particular, there are two issues that this pr fixes:

1. in ```cuco::detail::bloom_filter_impl::add(CG const& group, ProbeKey const& key)```, variable ```i``` in the for-loop doesn't seem to be used for indexing ```word``` and ```atom_word```. This pr updates the index from ```rank``` to ```i```.
2. in ```cuco::detail::bloom_filter_impl::clear(CG const& group)```, the for-loop's terminating condition was not complete. This pr adds ```i < ``` to the condition to complete it.