### PR TITLE
Add lazy_discard_iterator benchmark utility

### DIFF
--- a/benchmarks/benchmark_utils.hpp
+++ b/benchmarks/benchmark_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/benchmark_utils.hpp
+++ b/benchmarks/benchmark_utils.hpp
@@ -21,6 +21,11 @@
 
 #include <nvbench/nvbench.cuh>
 
+#include <thrust/iterator/iterator_traits.h>
+#include <thrust/iterator/tabulate_output_iterator.h>
+
+#include <nv/target>
+
 namespace cuco::benchmark {
 
 template <typename Dist>
@@ -49,6 +54,35 @@ struct rebind_hasher<Template<OldType>, NewType> {
 
 template <typename T, typename NewType>
 using rebind_hasher_t = typename rebind_hasher<T, NewType>::type;
+
+template <class OutputIt>
+struct lazy_discard {
+  OutputIt it;
+
+  using index_type = typename thrust::iterator_traits<OutputIt>::difference_type;
+  using value_type = typename thrust::iterator_traits<OutputIt>::value_type;
+
+  __device__ void device_dispatch(index_type index, value_type const& value) const
+  {
+    // pick some predicate that is always false, but depends on the runtime value
+    if (threadIdx.x > 2025 + *reinterpret_cast<char const*>(&value)) { *(it + index) = value; }
+  }
+  __host__ __device__ void operator()(index_type index, value_type const& value) const
+  {
+    NV_IF_TARGET(NV_IS_DEVICE,
+                 this->device_dispatch(index, value);)  // we don't care about the host path for now
+  }
+};
+
+/**
+ * @brief An output iterator similar to `thrust::discard_iterator` but prevents the write from being
+ * optimized out by the compiler.
+ */
+template <class OutputIt>
+auto make_lazy_discard_iterator(OutputIt it)
+{
+  return thrust::tabulate_output_iterator(lazy_discard<OutputIt>{it});
+}
 
 }  // namespace cuco::benchmark
 


### PR DESCRIPTION
This PR adds a benchmark utility `cuco::benchmark::make_lazy_discard_iterator`, i.e., an output iterator similar to `thrust::discard_iterator` but prevents the write from being optimized out by the compiler.

This utility is helpful when investigating kernel performance in isolation, i.e., without the additional IO induced from reading the input or writing the output.