### PR TITLE
Optimize CG-based device insert with erase check for improved performance

### DIFF
--- a/benchmarks/static_multimap/count_bench.cu
+++ b/benchmarks/static_multimap/count_bench.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,12 +57,12 @@ std::enable_if_t<(sizeof(Key) == sizeof(Value)), void> static_multimap_count(
 
   state.add_element_count(num_keys);
 
-  cuco::static_multimap<Key, Value> map{
+  cuco::experimental::static_multimap<Key, Value> map{
     size, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};
   map.insert(pairs.begin(), pairs.end());
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    auto count = map.count(keys.begin(), keys.end(), launch.get_stream());
+    auto count = map.count(keys.begin(), keys.end(), {launch.get_stream()});
   });
 }
 

--- a/benchmarks/static_multimap/insert_bench.cu
+++ b/benchmarks/static_multimap/insert_bench.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,11 +56,18 @@ std::enable_if_t<(sizeof(Key) == sizeof(Value)), void> static_multimap_insert(
 
   state.exec(nvbench::exec_tag::sync | nvbench::exec_tag::timer,
              [&](nvbench::launch& launch, auto& timer) {
-               cuco::static_multimap<Key, Value> map{
-                 size, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}, launch.get_stream()};
+               cuco::experimental::static_multimap<Key, Value> map{size,
+                                                                   cuco::empty_key<Key>{-1},
+                                                                   cuco::empty_value<Value>{-1},
+                                                                   {},
+                                                                   {},
+                                                                   {},
+                                                                   {},
+                                                                   {},
+                                                                   {launch.get_stream()}};
 
                timer.start();
-               map.insert(pairs.begin(), pairs.end(), launch.get_stream());
+               map.insert(pairs.begin(), pairs.end(), {launch.get_stream()});
                timer.stop();
              });
 }

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -426,7 +426,7 @@ class open_addressing_ref_impl {
    *
    * @return True if the given element is successfully inserted
    */
-  template <typename Value>
+  template <bool SupportsErase, typename Value>
   __device__ bool insert(cooperative_groups::thread_block_tile<cg_size> const& group,
                          Value const& value) noexcept
   {
@@ -466,12 +466,20 @@ class open_addressing_ref_impl {
       auto const group_contains_available = group.ballot(state == detail::equal_result::AVAILABLE);
       if (group_contains_available) {
         auto const src_lane = __ffs(group_contains_available) - 1;
-        auto const status =
-          (group.thread_rank() == src_lane)
-            ? attempt_insert((storage_ref_.data() + *probing_iter)->data() + intra_bucket_index,
+        auto status         = insert_result::CONTINUE;
+        if (group.thread_rank() == src_lane) {
+          if constexpr (SupportsErase) {
+            status =
+              attempt_insert((storage_ref_.data() + *probing_iter)->data() + intra_bucket_index,
                              bucket_slots[intra_bucket_index],
-                             val)
-            : insert_result::CONTINUE;
+                             val);
+          } else {
+            status =
+              attempt_insert((storage_ref_.data() + *probing_iter)->data() + intra_bucket_index,
+                             this->empty_slot_sentinel(),
+                             val);
+          }
+        }
 
         switch (group.shfl(status, src_lane)) {
           case insert_result::SUCCESS: return true;

--- a/include/cuco/detail/operator.inl
+++ b/include/cuco/detail/operator.inl
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ class operator_impl {
  * @return `true` if `Operator` is contained in `Operators`, `false` otherwise.
  */
 template <typename Operator, typename... Operators>
-static constexpr bool has_operator()
+__host__ __device__ static constexpr bool has_operator()
 {
   return ((std::is_same_v<Operators, Operator>) || ...);
 }

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -449,8 +449,11 @@ class operator_impl<
                          Value const& value) noexcept
   {
     auto& ref_ = static_cast<ref_type&>(*this);
-    return ref_.impl_.insert<cuco::detail::has_operator<cuco::erase_tag, Operators...>()>(group,
-                                                                                          value);
+    if (ref_.erased_key_sentinel() != ref_.empty_key_sentinel()) {
+      return ref_.impl_.insert<true>(group, value);
+    } else {
+      return ref_.impl_.insert<false>(group, value);
+    }
   }
 };
 

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -449,7 +449,8 @@ class operator_impl<
                          Value const& value) noexcept
   {
     auto& ref_ = static_cast<ref_type&>(*this);
-    return ref_.impl_.insert(group, value);
+    return ref_.impl_.insert<cuco::detail::has_operator<cuco::erase_tag, Operators...>()>(group,
+                                                                                          value);
   }
 };
 

--- a/include/cuco/detail/static_multimap/static_multimap_ref.inl
+++ b/include/cuco/detail/static_multimap/static_multimap_ref.inl
@@ -455,8 +455,11 @@ class operator_impl<
                          Value const& value) noexcept
   {
     auto& ref_ = static_cast<ref_type&>(*this);
-    return ref_.impl_.insert<cuco::detail::has_operator<cuco::erase_tag, Operators...>()>(group,
-                                                                                          value);
+    if (ref_.erased_key_sentinel() != ref_.empty_key_sentinel()) {
+      return ref_.impl_.insert<true>(group, value);
+    } else {
+      return ref_.impl_.insert<false>(group, value);
+    }
   }
 };
 

--- a/include/cuco/detail/static_multimap/static_multimap_ref.inl
+++ b/include/cuco/detail/static_multimap/static_multimap_ref.inl
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -455,7 +455,8 @@ class operator_impl<
                          Value const& value) noexcept
   {
     auto& ref_ = static_cast<ref_type&>(*this);
-    return ref_.impl_.insert(group, value);
+    return ref_.impl_.insert<cuco::detail::has_operator<cuco::erase_tag, Operators...>()>(group,
+                                                                                          value);
   }
 };
 

--- a/include/cuco/detail/static_multiset/static_multiset_ref.inl
+++ b/include/cuco/detail/static_multiset/static_multiset_ref.inl
@@ -358,8 +358,11 @@ class operator_impl<
                          Value const& value) noexcept
   {
     auto& ref_ = static_cast<ref_type&>(*this);
-    return ref_.impl_.insert<cuco::detail::has_operator<cuco::erase_tag, Operators...>()>(group,
-                                                                                          value);
+    if (ref_.erased_key_sentinel() != ref_.empty_key_sentinel()) {
+      return ref_.impl_.insert<true>(group, value);
+    } else {
+      return ref_.impl_.insert<false>(group, value);
+    }
   }
 };
 

--- a/include/cuco/detail/static_multiset/static_multiset_ref.inl
+++ b/include/cuco/detail/static_multiset/static_multiset_ref.inl
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -358,7 +358,8 @@ class operator_impl<
                          Value const& value) noexcept
   {
     auto& ref_ = static_cast<ref_type&>(*this);
-    return ref_.impl_.insert(group, value);
+    return ref_.impl_.insert<cuco::detail::has_operator<cuco::erase_tag, Operators...>()>(group,
+                                                                                          value);
   }
 };
 

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -391,8 +391,11 @@ class operator_impl<op::insert_tag,
                          Value const& value) noexcept
   {
     auto& ref_ = static_cast<ref_type&>(*this);
-    return ref_.impl_.insert<cuco::detail::has_operator<cuco::erase_tag, Operators...>()>(group,
-                                                                                          value);
+    if (ref_.erased_key_sentinel() != ref_.empty_key_sentinel()) {
+      return ref_.impl_.insert<true>(group, value);
+    } else {
+      return ref_.impl_.insert<false>(group, value);
+    }
   }
 };
 

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -391,7 +391,8 @@ class operator_impl<op::insert_tag,
                          Value const& value) noexcept
   {
     auto& ref_ = static_cast<ref_type&>(*this);
-    return ref_.impl_.insert(group, value);
+    return ref_.impl_.insert<cuco::detail::has_operator<cuco::erase_tag, Operators...>()>(group,
+                                                                                          value);
   }
 };
 

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -93,10 +93,10 @@ template <class Key,
           class Extent             = cuco::extent<std::size_t>,
           cuda::thread_scope Scope = cuda::thread_scope_device,
           class KeyEqual           = thrust::equal_to<Key>,
-          class ProbingScheme      = cuco::linear_probing<4,  // CG size
+          class ProbingScheme      = cuco::double_hashing<8,  // CG size
                                                           cuco::default_hash_function<Key>>,
           class Allocator          = cuco::cuda_allocator<cuco::pair<Key, T>>,
-          class Storage            = cuco::storage<1>>
+          class Storage            = cuco::storage<2>>
 class static_multimap {
   static_assert(sizeof(Key) <= 8, "Container does not support key types larger than 8 bytes.");
 


### PR DESCRIPTION
This PR enhances the CG-based device insertion by introducing an additional `SupportsErase` build-time check. When erasure is not required, the new implementation leverages this flag to select a more efficient code path, ensuring comparisons are made against an empty sentinel without loading the target slot's content into the CAS operation. This optimization gets rid of excessive local memory transactions, resulting in a 10~30% improvement in multimap performance. This PR also updates the multimap insert and count benchmarks to run with the new implementations.

Unblocking https://github.com/rapidsai/cudf/pull/18021





