### PR TITLE
Update map insert bench to avoid fully occupied map

### DIFF
--- a/benchmarks/static_map/insert_bench.cu
+++ b/benchmarks/static_map/insert_bench.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmarks/static_map/insert_bench.cu
+++ b/benchmarks/static_map/insert_bench.cu
@@ -54,10 +54,19 @@ std::enable_if_t<(sizeof(Key) == sizeof(Value)), void> static_map_insert(
 
   state.add_element_count(num_keys);
 
-  auto map = cuco::static_map{size, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};
-
-  state.exec([&](nvbench::launch& launch) {
+  state.exec(nvbench::exec_tag::timer, [&](nvbench::launch& launch, auto& timer) {
+    auto map = cuco::static_map{size,
+                                cuco::empty_key<Key>{-1},
+                                cuco::empty_value<Value>{-1},
+                                {},
+                                {},
+                                {},
+                                {},
+                                {},
+                                {launch.get_stream()}};
+    timer.start();
     map.insert_async(pairs.begin(), pairs.end(), {launch.get_stream()});
+    timer.stop();
   });
 }
 

--- a/benchmarks/static_map/insert_bench.cu
+++ b/benchmarks/static_map/insert_bench.cu
@@ -52,21 +52,14 @@ std::enable_if_t<(sizeof(Key) == sizeof(Value)), void> static_map_insert(
     return pair_type(key, {});
   });
 
-  state.add_element_count(num_keys);
+  auto map = cuco::static_map{size, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};
 
+  state.add_element_count(num_keys);
   state.exec(nvbench::exec_tag::timer, [&](nvbench::launch& launch, auto& timer) {
-    auto map = cuco::static_map{size,
-                                cuco::empty_key<Key>{-1},
-                                cuco::empty_value<Value>{-1},
-                                {},
-                                {},
-                                {},
-                                {},
-                                {},
-                                {launch.get_stream()}};
     timer.start();
     map.insert_async(pairs.begin(), pairs.end(), {launch.get_stream()});
     timer.stop();
+    map.clear_async({launch.get_stream()});
   });
 }
 


### PR DESCRIPTION
This PR modifies the single map insert benchmark to construct the map on the fly in each loop iteration, preventing insertions into a fully occupied map.