### PR TITLE
Use relaxed memory-order in dynamic_map::find

### DIFF
--- a/include/cuco/detail/dynamic_map_kernels.cuh
+++ b/include/cuco/detail/dynamic_map_kernels.cuh
@@ -389,7 +389,7 @@ CUCO_KERNEL void find(InputIt first,
       auto submap_view = submap_views[i];
       auto found       = submap_view.find(key, hash, key_equal);
       if (found != submap_view.end()) {
-        found_value = found->second;
+        found_value = found->second.load(cuda::std::memory_order_relaxed);
         break;
       }
     }
@@ -466,7 +466,7 @@ CUCO_KERNEL void find(InputIt first,
       auto submap_view = submap_views[i];
       auto found       = submap_view.find(tile, key, hash, key_equal);
       if (found != submap_view.end()) {
-        found_value = found->second;
+        found_value = found->second.load(cuda::std::memory_order_relaxed);
         break;
       }
     }


### PR DESCRIPTION
This PR updates the dynamic kernel code to use relaxed memory ordering for retrieving the matched payload, instead of strict sequential ordering, in order to improve runtime performance.
