### PR TITLE
Remove constexpr from the HLL finalizer to resolve a build error with CCCL 3.0

### DIFF
--- a/include/cuco/detail/hyperloglog/finalizer.cuh
+++ b/include/cuco/detail/hyperloglog/finalizer.cuh
@@ -55,7 +55,7 @@ class finalizer {
    *
    * @return Bias-corrected cardinality estimate
    */
-  __host__ __device__ constexpr std::size_t operator()(double z, int v) const noexcept
+  __host__ __device__ std::size_t operator()(double z, int v) const noexcept
   {
     double e = this->alpha_mm() / z;
 

--- a/include/cuco/detail/hyperloglog/hyperloglog_impl.cuh
+++ b/include/cuco/detail/hyperloglog/hyperloglog_impl.cuh
@@ -402,7 +402,7 @@ class hyperloglog_impl {
    *
    * @return Approximate distinct items count
    */
-  [[nodiscard]] __host__ constexpr size_t estimate(cuda::stream_ref stream) const
+  [[nodiscard]] __host__ size_t estimate(cuda::stream_ref stream) const
   {
     auto const num_regs = 1ull << this->precision_;
     std::vector<register_type> host_sketch(num_regs);


### PR DESCRIPTION
Closes #711

This PR makes the HLL finalizer non-constexpr to resolve a build error with CCCL 3.0.