### PR TITLE
Get rid of the unknown pragma unroll warning

### DIFF
--- a/benchmarks/hash_function/hash_function_bench.cu
+++ b/benchmarks/hash_function/hash_function_bench.cu
@@ -34,7 +34,6 @@ template <int32_t Words>
 struct large_key {
   constexpr __host__ __device__ large_key(int32_t seed) noexcept
   {
-#pragma unroll
     for (int32_t i = 0; i < Words; ++i) {
       data_[i] = seed;
     }


### PR DESCRIPTION
This PR resolves the unknown #pragma unroll warning by removing it, as it's not supported by GCC.