### PR TITLE
Add a missing header for the dynamic map kernel

### DIFF
--- a/include/cuco/detail/dynamic_map_kernels.cuh
+++ b/include/cuco/detail/dynamic_map_kernels.cuh
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 #pragma once
+
+#include <cuco/detail/bitwise_compare.cuh>
 #include <cuco/detail/utility/cuda.cuh>
 
 #include <cub/block/block_reduce.cuh>


### PR DESCRIPTION
This PR adds a missing include that was causing a build-time error. It's unclear why this wasn't caught by our unit tests.









