### PR TITLE
Several fixes to make cuCo compile with LLVM:

### DIFF
--- a/include/cuco/detail/bloom_filter/bloom_filter_impl.cuh
+++ b/include/cuco/detail/bloom_filter/bloom_filter_impl.cuh
@@ -364,9 +364,9 @@ class bloom_filter_impl {
 
   template <class InputIt, class OutputIt>
   __host__ void contains(InputIt first,
-                                   InputIt last,
-                                   OutputIt output_begin,
-                                   cuda::stream_ref stream) const
+                         InputIt last,
+                         OutputIt output_begin,
+                         cuda::stream_ref stream) const
   {
     this->contains_async(first, last, output_begin, stream);
     stream.wait();
@@ -374,9 +374,9 @@ class bloom_filter_impl {
 
   template <class InputIt, class OutputIt>
   __host__ void contains_async(InputIt first,
-                                         InputIt last,
-                                         OutputIt output_begin,
-                                         cuda::stream_ref stream) const noexcept
+                               InputIt last,
+                               OutputIt output_begin,
+                               cuda::stream_ref stream) const noexcept
   {
     auto const always_true = thrust::constant_iterator<bool>{true};
     this->contains_if_async(first, last, always_true, cuda::std::identity{}, output_begin, stream);
@@ -384,11 +384,11 @@ class bloom_filter_impl {
 
   template <class InputIt, class StencilIt, class Predicate, class OutputIt>
   __host__ void contains_if(InputIt first,
-                                      InputIt last,
-                                      StencilIt stencil,
-                                      Predicate pred,
-                                      OutputIt output_begin,
-                                      cuda::stream_ref stream) const
+                            InputIt last,
+                            StencilIt stencil,
+                            Predicate pred,
+                            OutputIt output_begin,
+                            cuda::stream_ref stream) const
   {
     this->contains_if_async(first, last, stencil, pred, output_begin, stream);
     stream.wait();
@@ -396,11 +396,11 @@ class bloom_filter_impl {
 
   template <class InputIt, class StencilIt, class Predicate, class OutputIt>
   __host__ void contains_if_async(InputIt first,
-                                            InputIt last,
-                                            StencilIt stencil,
-                                            Predicate pred,
-                                            OutputIt output_begin,
-                                            cuda::stream_ref stream) const noexcept
+                                  InputIt last,
+                                  StencilIt stencil,
+                                  Predicate pred,
+                                  OutputIt output_begin,
+                                  cuda::stream_ref stream) const noexcept
   {
     auto const num_keys = cuco::detail::distance(first, last);
     if (num_keys == 0) { return; }

--- a/include/cuco/detail/bloom_filter/bloom_filter_impl.cuh
+++ b/include/cuco/detail/bloom_filter/bloom_filter_impl.cuh
@@ -363,7 +363,7 @@ class bloom_filter_impl {
   // const;
 
   template <class InputIt, class OutputIt>
-  __host__ constexpr void contains(InputIt first,
+  __host__ void contains(InputIt first,
                                    InputIt last,
                                    OutputIt output_begin,
                                    cuda::stream_ref stream) const
@@ -373,7 +373,7 @@ class bloom_filter_impl {
   }
 
   template <class InputIt, class OutputIt>
-  __host__ constexpr void contains_async(InputIt first,
+  __host__ void contains_async(InputIt first,
                                          InputIt last,
                                          OutputIt output_begin,
                                          cuda::stream_ref stream) const noexcept
@@ -383,7 +383,7 @@ class bloom_filter_impl {
   }
 
   template <class InputIt, class StencilIt, class Predicate, class OutputIt>
-  __host__ constexpr void contains_if(InputIt first,
+  __host__ void contains_if(InputIt first,
                                       InputIt last,
                                       StencilIt stencil,
                                       Predicate pred,
@@ -395,7 +395,7 @@ class bloom_filter_impl {
   }
 
   template <class InputIt, class StencilIt, class Predicate, class OutputIt>
-  __host__ constexpr void contains_if_async(InputIt first,
+  __host__ void contains_if_async(InputIt first,
                                             InputIt last,
                                             StencilIt stencil,
                                             Predicate pred,

--- a/include/cuco/detail/hyperloglog/kernels.cuh
+++ b/include/cuco/detail/hyperloglog/kernels.cuh
@@ -42,7 +42,7 @@ CUCO_KERNEL void add_shmem_vectorized(typename RefType::value_type const* first,
 {
   using value_type     = typename RefType::value_type;
   using vector_type    = cuda::std::array<value_type, VectorSize>;
-  using local_ref_type = typename RefType::with_scope<cuda::thread_scope_block>;
+  using local_ref_type = typename RefType::template with_scope<cuda::thread_scope_block>;
 
   // Base address of dynamic shared memory is guaranteed to be aligned to at least 16 bytes which is
   // sufficient for this purpose
@@ -91,7 +91,7 @@ CUCO_KERNEL void add_shmem_vectorized(typename RefType::value_type const* first,
 template <class InputIt, class RefType>
 CUCO_KERNEL void add_shmem(InputIt first, cuco::detail::index_type n, RefType ref)
 {
-  using local_ref_type = typename RefType::with_scope<cuda::thread_scope_block>;
+  using local_ref_type = typename RefType::template with_scope<cuda::thread_scope_block>;
 
   // TODO assert alignment
   extern __shared__ cuda::std::byte local_sketch[];

--- a/include/cuco/detail/open_addressing/kernels.cuh
+++ b/include/cuco/detail/open_addressing/kernels.cuh
@@ -692,18 +692,18 @@ CUCO_KERNEL void retrieve(InputProbeIt input_probe,
   if (block_begin_offset < block_end_offset) {
     if constexpr (IsOuter) {
       ref.template retrieve_outer<BlockSize>(block,
-                                    input_probe + block_begin_offset,
-                                    input_probe + block_end_offset,
-                                    output_probe,
-                                    output_match,
-                                    atomic_counter);
+                                             input_probe + block_begin_offset,
+                                             input_probe + block_end_offset,
+                                             output_probe,
+                                             output_match,
+                                             atomic_counter);
     } else {
       ref.template retrieve<BlockSize>(block,
-                              input_probe + block_begin_offset,
-                              input_probe + block_end_offset,
-                              output_probe,
-                              output_match,
-                              atomic_counter);
+                                       input_probe + block_begin_offset,
+                                       input_probe + block_end_offset,
+                                       output_probe,
+                                       output_match,
+                                       atomic_counter);
     }
   }
 }

--- a/include/cuco/detail/open_addressing/kernels.cuh
+++ b/include/cuco/detail/open_addressing/kernels.cuh
@@ -691,14 +691,14 @@ CUCO_KERNEL void retrieve(InputProbeIt input_probe,
 
   if (block_begin_offset < block_end_offset) {
     if constexpr (IsOuter) {
-      ref.retrieve_outer<BlockSize>(block,
+      ref.template retrieve_outer<BlockSize>(block,
                                     input_probe + block_begin_offset,
                                     input_probe + block_end_offset,
                                     output_probe,
                                     output_match,
                                     atomic_counter);
     } else {
-      ref.retrieve<BlockSize>(block,
+      ref.template retrieve<BlockSize>(block,
                               input_probe + block_begin_offset,
                               input_probe + block_end_offset,
                               output_probe,

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -524,7 +524,7 @@ class open_addressing_ref_impl {
 
     auto const val      = this->heterogeneous_value(value);
     auto const key      = this->extract_key(val);
-    auto probing_iter   = probing_scheme_.make_iterator<bucket_size>(key, storage_ref_.extent());
+    auto probing_iter   = probing_scheme_.template make_iterator<bucket_size>(key, storage_ref_.extent());
     auto const init_idx = *probing_iter;
 
     while (true) {
@@ -532,7 +532,7 @@ class open_addressing_ref_impl {
 
       for (auto i = 0; i < bucket_size; ++i) {
         auto const eq_res =
-          this->predicate_.operator()<is_insert::YES>(key, this->extract_key(bucket_slots[i]));
+          this->predicate_.template operator()<is_insert::YES>(key, this->extract_key(bucket_slots[i]));
         auto* slot_ptr = this->get_slot_ptr(*probing_iter, i);
 
         // If the key is already in the container, return false
@@ -598,7 +598,7 @@ class open_addressing_ref_impl {
     auto const val = this->heterogeneous_value(value);
     auto const key = this->extract_key(val);
     auto probing_iter =
-      probing_scheme_.make_iterator<bucket_size>(group, key, storage_ref_.extent());
+      probing_scheme_.template make_iterator<bucket_size>(group, key, storage_ref_.extent());
     auto const init_idx = *probing_iter;
 
     while (true) {
@@ -608,7 +608,7 @@ class open_addressing_ref_impl {
         auto res = detail::equal_result::UNEQUAL;
         for (auto i = 0; i < bucket_size; ++i) {
           res =
-            this->predicate_.operator()<is_insert::YES>(key, this->extract_key(bucket_slots[i]));
+            this->predicate_.template operator()<is_insert::YES>(key, this->extract_key(bucket_slots[i]));
           if (res != detail::equal_result::UNEQUAL) { return bucket_probing_results{res, i}; }
         }
         // returns dummy index `-1` for UNEQUAL
@@ -685,7 +685,7 @@ class open_addressing_ref_impl {
   {
     static_assert(cg_size == 1, "Non-CG operation is incompatible with the current probing scheme");
 
-    auto probing_iter   = probing_scheme_.make_iterator<bucket_size>(key, storage_ref_.extent());
+    auto probing_iter   = probing_scheme_.template make_iterator<bucket_size>(key, storage_ref_.extent());
     auto const init_idx = *probing_iter;
 
     while (true) {
@@ -693,7 +693,7 @@ class open_addressing_ref_impl {
 
       for (auto& slot_content : bucket_slots) {
         auto const eq_res =
-          this->predicate_.operator()<is_insert::NO>(key, this->extract_key(slot_content));
+          this->predicate_.template operator()<is_insert::NO>(key, this->extract_key(slot_content));
 
         // Key doesn't exist, return false
         if (eq_res == detail::equal_result::EMPTY) { return false; }
@@ -729,7 +729,7 @@ class open_addressing_ref_impl {
                         ProbeKey const& key) noexcept
   {
     auto probing_iter =
-      probing_scheme_.make_iterator<bucket_size>(group, key, storage_ref_.extent());
+      probing_scheme_.template make_iterator<bucket_size>(group, key, storage_ref_.extent());
     auto const init_idx = *probing_iter;
 
     while (true) {
@@ -738,7 +738,7 @@ class open_addressing_ref_impl {
       auto const [state, intra_bucket_index] = [&]() {
         auto res = detail::equal_result::UNEQUAL;
         for (auto i = 0; i < bucket_size; ++i) {
-          res = this->predicate_.operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i]));
+          res = this->predicate_.template operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i]));
           if (res != detail::equal_result::UNEQUAL) { return bucket_probing_results{res, i}; }
         }
         // returns dummy index `-1` for UNEQUAL
@@ -824,7 +824,7 @@ class open_addressing_ref_impl {
     cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey const& key) const noexcept
   {
     auto probing_iter =
-      probing_scheme_.make_iterator<bucket_size>(group, key, storage_ref_.extent());
+      probing_scheme_.template make_iterator<bucket_size>(group, key, storage_ref_.extent());
     auto const init_idx = *probing_iter;
 
     while (true) {
@@ -833,7 +833,7 @@ class open_addressing_ref_impl {
       auto const state = [&]() {
         auto res = detail::equal_result::UNEQUAL;
         for (auto i = 0; i < bucket_size; ++i) {
-          res = this->predicate_.operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i]));
+          res = this->predicate_.template operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i]));
           if (res != detail::equal_result::UNEQUAL) { return res; }
         }
         return res;
@@ -863,7 +863,7 @@ class open_addressing_ref_impl {
   [[nodiscard]] __device__ iterator find(ProbeKey const& key) const noexcept
   {
     static_assert(cg_size == 1, "Non-CG operation is incompatible with the current probing scheme");
-    auto probing_iter   = probing_scheme_.make_iterator<bucket_size>(key, storage_ref_.extent());
+    auto probing_iter   = probing_scheme_.template make_iterator<bucket_size>(key, storage_ref_.extent());
     auto const init_idx = *probing_iter;
 
     while (true) {
@@ -872,7 +872,7 @@ class open_addressing_ref_impl {
 
       for (auto i = 0; i < bucket_size; ++i) {
         switch (
-          this->predicate_.operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i]))) {
+          this->predicate_.template operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i]))) {
           case detail::equal_result::EMPTY: {
             return this->end();
           }
@@ -905,7 +905,7 @@ class open_addressing_ref_impl {
     cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey const& key) const noexcept
   {
     auto probing_iter =
-      probing_scheme_.make_iterator<bucket_size>(group, key, storage_ref_.extent());
+      probing_scheme_.template make_iterator<bucket_size>(group, key, storage_ref_.extent());
     auto const init_idx = *probing_iter;
 
     while (true) {
@@ -914,7 +914,7 @@ class open_addressing_ref_impl {
       auto const [state, intra_bucket_index] = [&]() {
         auto res = detail::equal_result::UNEQUAL;
         for (auto i = 0; i < bucket_size; ++i) {
-          res = this->predicate_.operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i]));
+          res = this->predicate_.template operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i]));
           if (res != detail::equal_result::UNEQUAL) { return bucket_probing_results{res, i}; }
         }
         // returns dummy index `-1` for UNEQUAL
@@ -954,7 +954,7 @@ class open_addressing_ref_impl {
     if constexpr (not allows_duplicates) {
       return static_cast<size_type>(this->contains(key));
     } else {
-      auto probing_iter   = probing_scheme_.make_iterator<bucket_size>(key, storage_ref_.extent());
+      auto probing_iter   = probing_scheme_.template make_iterator<bucket_size>(key, storage_ref_.extent());
       auto const init_idx = *probing_iter;
       size_type count     = 0;
 
@@ -999,7 +999,7 @@ class open_addressing_ref_impl {
     cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey const& key) const noexcept
   {
     auto probing_iter =
-      probing_scheme_.make_iterator<bucket_size>(group, key, storage_ref_.extent());
+      probing_scheme_.template make_iterator<bucket_size>(group, key, storage_ref_.extent());
     auto const init_idx = *probing_iter;
     size_type count     = 0;
 
@@ -1222,7 +1222,7 @@ class open_addressing_ref_impl {
         // perform probing
         // make sure the flushing_tile is converged at this point to get a coalesced load
         auto const probe_key = *(input_probe + idx);
-        auto probing_iter    = probing_scheme_.make_iterator<bucket_size>(
+        auto probing_iter    = probing_scheme_.template make_iterator<bucket_size>(
           probing_tile, probe_key, storage_ref_.extent());
         auto const init_idx = *probing_iter;
 
@@ -1242,7 +1242,7 @@ class open_addressing_ref_impl {
               equals[i] = false;
               if (running) {
                 // inspect slot content
-                switch (this->predicate_.operator()<is_insert::NO>(
+                switch (this->predicate_.template operator()<is_insert::NO>(
                   probe_key, this->extract_key(bucket_slots[i]))) {
                   case detail::equal_result::EMPTY: {
                     running = false;
@@ -1354,7 +1354,7 @@ class open_addressing_ref_impl {
   __device__ void for_each(ProbeKey const& key, CallbackOp&& callback_op) const noexcept
   {
     static_assert(cg_size == 1, "Non-CG operation is incompatible with the current probing scheme");
-    auto probing_iter   = probing_scheme_.make_iterator<bucket_size>(key, storage_ref_.extent());
+    auto probing_iter   = probing_scheme_.template make_iterator<bucket_size>(key, storage_ref_.extent());
     auto const init_idx = *probing_iter;
 
     while (true) {
@@ -1363,7 +1363,7 @@ class open_addressing_ref_impl {
 
       for (int32_t i = 0; i < bucket_size; ++i) {
         switch (
-          this->predicate_.operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i]))) {
+          this->predicate_.template operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i]))) {
           case detail::equal_result::EMPTY: {
             return;
           }
@@ -1404,7 +1404,7 @@ class open_addressing_ref_impl {
                            CallbackOp&& callback_op) const noexcept
   {
     auto probing_iter =
-      probing_scheme_.make_iterator<bucket_size>(group, key, storage_ref_.extent());
+      probing_scheme_.template make_iterator<bucket_size>(group, key, storage_ref_.extent());
     auto const init_idx = *probing_iter;
     bool empty          = false;
 
@@ -1414,7 +1414,7 @@ class open_addressing_ref_impl {
 
       for (int32_t i = 0; i < bucket_size and !empty; ++i) {
         switch (
-          this->predicate_.operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i]))) {
+          this->predicate_.template operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i]))) {
           case detail::equal_result::EMPTY: {
             empty = true;
             continue;
@@ -1469,7 +1469,7 @@ class open_addressing_ref_impl {
                            SyncOp&& sync_op) const noexcept
   {
     auto probing_iter =
-      probing_scheme_.make_iterator<bucket_size>(group, key, storage_ref_.extent());
+      probing_scheme_.template make_iterator<bucket_size>(group, key, storage_ref_.extent());
     auto const init_idx = *probing_iter;
     bool empty          = false;
 
@@ -1479,7 +1479,7 @@ class open_addressing_ref_impl {
 
       for (int32_t i = 0; i < bucket_size and !empty; ++i) {
         switch (
-          this->predicate_.operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i]))) {
+          this->predicate_.template operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i]))) {
           case detail::equal_result::EMPTY: {
             empty = true;
             continue;

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -522,17 +522,18 @@ class open_addressing_ref_impl {
       "insert_and_find is not supported for pair types larger than 8 bytes on pre-Volta GPUs.");
 #endif
 
-    auto const val      = this->heterogeneous_value(value);
-    auto const key      = this->extract_key(val);
-    auto probing_iter   = probing_scheme_.template make_iterator<bucket_size>(key, storage_ref_.extent());
+    auto const val = this->heterogeneous_value(value);
+    auto const key = this->extract_key(val);
+    auto probing_iter =
+      probing_scheme_.template make_iterator<bucket_size>(key, storage_ref_.extent());
     auto const init_idx = *probing_iter;
 
     while (true) {
       auto const bucket_slots = storage_ref_[*probing_iter];
 
       for (auto i = 0; i < bucket_size; ++i) {
-        auto const eq_res =
-          this->predicate_.template operator()<is_insert::YES>(key, this->extract_key(bucket_slots[i]));
+        auto const eq_res = this->predicate_.template operator()<is_insert::YES>(
+          key, this->extract_key(bucket_slots[i]));
         auto* slot_ptr = this->get_slot_ptr(*probing_iter, i);
 
         // If the key is already in the container, return false
@@ -607,8 +608,8 @@ class open_addressing_ref_impl {
       auto const [state, intra_bucket_index] = [&]() {
         auto res = detail::equal_result::UNEQUAL;
         for (auto i = 0; i < bucket_size; ++i) {
-          res =
-            this->predicate_.template operator()<is_insert::YES>(key, this->extract_key(bucket_slots[i]));
+          res = this->predicate_.template operator()<is_insert::YES>(
+            key, this->extract_key(bucket_slots[i]));
           if (res != detail::equal_result::UNEQUAL) { return bucket_probing_results{res, i}; }
         }
         // returns dummy index `-1` for UNEQUAL
@@ -685,7 +686,8 @@ class open_addressing_ref_impl {
   {
     static_assert(cg_size == 1, "Non-CG operation is incompatible with the current probing scheme");
 
-    auto probing_iter   = probing_scheme_.template make_iterator<bucket_size>(key, storage_ref_.extent());
+    auto probing_iter =
+      probing_scheme_.template make_iterator<bucket_size>(key, storage_ref_.extent());
     auto const init_idx = *probing_iter;
 
     while (true) {
@@ -738,7 +740,8 @@ class open_addressing_ref_impl {
       auto const [state, intra_bucket_index] = [&]() {
         auto res = detail::equal_result::UNEQUAL;
         for (auto i = 0; i < bucket_size; ++i) {
-          res = this->predicate_.template operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i]));
+          res = this->predicate_.template operator()<is_insert::NO>(
+            key, this->extract_key(bucket_slots[i]));
           if (res != detail::equal_result::UNEQUAL) { return bucket_probing_results{res, i}; }
         }
         // returns dummy index `-1` for UNEQUAL
@@ -833,7 +836,8 @@ class open_addressing_ref_impl {
       auto const state = [&]() {
         auto res = detail::equal_result::UNEQUAL;
         for (auto i = 0; i < bucket_size; ++i) {
-          res = this->predicate_.template operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i]));
+          res = this->predicate_.template operator()<is_insert::NO>(
+            key, this->extract_key(bucket_slots[i]));
           if (res != detail::equal_result::UNEQUAL) { return res; }
         }
         return res;
@@ -863,7 +867,8 @@ class open_addressing_ref_impl {
   [[nodiscard]] __device__ iterator find(ProbeKey const& key) const noexcept
   {
     static_assert(cg_size == 1, "Non-CG operation is incompatible with the current probing scheme");
-    auto probing_iter   = probing_scheme_.template make_iterator<bucket_size>(key, storage_ref_.extent());
+    auto probing_iter =
+      probing_scheme_.template make_iterator<bucket_size>(key, storage_ref_.extent());
     auto const init_idx = *probing_iter;
 
     while (true) {
@@ -871,8 +876,8 @@ class open_addressing_ref_impl {
       auto const bucket_slots = storage_ref_[*probing_iter];
 
       for (auto i = 0; i < bucket_size; ++i) {
-        switch (
-          this->predicate_.template operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i]))) {
+        switch (this->predicate_.template operator()<is_insert::NO>(
+          key, this->extract_key(bucket_slots[i]))) {
           case detail::equal_result::EMPTY: {
             return this->end();
           }
@@ -914,7 +919,8 @@ class open_addressing_ref_impl {
       auto const [state, intra_bucket_index] = [&]() {
         auto res = detail::equal_result::UNEQUAL;
         for (auto i = 0; i < bucket_size; ++i) {
-          res = this->predicate_.template operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i]));
+          res = this->predicate_.template operator()<is_insert::NO>(
+            key, this->extract_key(bucket_slots[i]));
           if (res != detail::equal_result::UNEQUAL) { return bucket_probing_results{res, i}; }
         }
         // returns dummy index `-1` for UNEQUAL
@@ -954,7 +960,8 @@ class open_addressing_ref_impl {
     if constexpr (not allows_duplicates) {
       return static_cast<size_type>(this->contains(key));
     } else {
-      auto probing_iter   = probing_scheme_.template make_iterator<bucket_size>(key, storage_ref_.extent());
+      auto probing_iter =
+        probing_scheme_.template make_iterator<bucket_size>(key, storage_ref_.extent());
       auto const init_idx = *probing_iter;
       size_type count     = 0;
 
@@ -1354,7 +1361,8 @@ class open_addressing_ref_impl {
   __device__ void for_each(ProbeKey const& key, CallbackOp&& callback_op) const noexcept
   {
     static_assert(cg_size == 1, "Non-CG operation is incompatible with the current probing scheme");
-    auto probing_iter   = probing_scheme_.template make_iterator<bucket_size>(key, storage_ref_.extent());
+    auto probing_iter =
+      probing_scheme_.template make_iterator<bucket_size>(key, storage_ref_.extent());
     auto const init_idx = *probing_iter;
 
     while (true) {
@@ -1362,8 +1370,8 @@ class open_addressing_ref_impl {
       auto const bucket_slots = this->storage_ref_[*probing_iter];
 
       for (int32_t i = 0; i < bucket_size; ++i) {
-        switch (
-          this->predicate_.template operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i]))) {
+        switch (this->predicate_.template operator()<is_insert::NO>(
+          key, this->extract_key(bucket_slots[i]))) {
           case detail::equal_result::EMPTY: {
             return;
           }
@@ -1413,8 +1421,8 @@ class open_addressing_ref_impl {
       auto const bucket_slots = this->storage_ref_[*probing_iter];
 
       for (int32_t i = 0; i < bucket_size and !empty; ++i) {
-        switch (
-          this->predicate_.template operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i]))) {
+        switch (this->predicate_.template operator()<is_insert::NO>(
+          key, this->extract_key(bucket_slots[i]))) {
           case detail::equal_result::EMPTY: {
             empty = true;
             continue;
@@ -1478,8 +1486,8 @@ class open_addressing_ref_impl {
       auto const bucket_slots = this->storage_ref_[*probing_iter];
 
       for (int32_t i = 0; i < bucket_size and !empty; ++i) {
-        switch (
-          this->predicate_.template operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i]))) {
+        switch (this->predicate_.template operator()<is_insert::NO>(
+          key, this->extract_key(bucket_slots[i]))) {
           case detail::equal_result::EMPTY: {
             empty = true;
             continue;

--- a/include/cuco/detail/static_map/kernels.cuh
+++ b/include/cuco/detail/static_map/kernels.cuh
@@ -191,7 +191,7 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void insert_or_apply_shmem(
 
   // Shared map initialization
   __shared__ typename SharedMapRefType::value_type slots[bucket_extent.value()];
-  using storage_ref_type = SharedMapRefType::storage_ref_type;
+  using storage_ref_type = typename SharedMapRefType::storage_ref_type;
   auto storage           = storage_ref_type(bucket_extent, slots);
   auto const num_buckets = storage.num_buckets();
 

--- a/include/cuco/detail/static_map/kernels.cuh
+++ b/include/cuco/detail/static_map/kernels.cuh
@@ -191,7 +191,8 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void insert_or_apply_shmem(
 
   // Shared map initialization
   __shared__ typename SharedMapRefType::value_type slots[bucket_extent.value()];
-  auto storage           = SharedMapRefType::storage_ref_type(bucket_extent, slots);
+  using storage_ref_type = SharedMapRefType::storage_ref_type;
+  auto storage           = storage_ref_type(bucket_extent, slots);
   auto const num_buckets = storage.num_buckets();
 
   using atomic_type = cuda::atomic<int32_t, cuda::thread_scope_block>;

--- a/include/cuco/detail/static_map/static_map.inl
+++ b/include/cuco/detail/static_map/static_map.inl
@@ -703,7 +703,7 @@ std::pair<KeyOut, ValueOut>
 static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::retrieve_all(
   KeyOut keys_out, ValueOut values_out, cuda::stream_ref stream) const
 {
-  auto const zipped_out_begin = thrust::make_zip_iterator(cuda::std::tuple{keys_out, values_out});
+  auto const zipped_out_begin = thrust::make_zip_iterator(keys_out, values_out);
   auto const zipped_out_end   = impl_->retrieve_all(zipped_out_begin, stream);
   auto const num              = std::distance(zipped_out_begin, zipped_out_end);
 

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -517,7 +517,7 @@ class operator_impl<
     auto const key            = ref_.impl_.extract_key(val);
     auto const probing_scheme = ref_.impl_.probing_scheme();
     auto storage_ref          = ref_.impl_.storage_ref();
-    auto probing_iter   = probing_scheme.make_iterator<bucket_size>(key, storage_ref.extent());
+    auto probing_iter   = probing_scheme.template make_iterator<bucket_size>(key, storage_ref.extent());
     auto const init_idx = *probing_iter;
 
     while (true) {
@@ -525,7 +525,7 @@ class operator_impl<
 
       for (auto& slot_content : bucket_slots) {
         auto const eq_res =
-          ref_.impl_.predicate_.operator()<is_insert::YES>(key, slot_content.first);
+          ref_.impl_.predicate_.template operator()<is_insert::YES>(key, slot_content.first);
         auto const intra_bucket_index = cuda::std::distance(bucket_slots.begin(), &slot_content);
         auto slot_ptr                 = ref_.impl_.get_slot_ptr(*probing_iter, intra_bucket_index);
 
@@ -565,7 +565,7 @@ class operator_impl<
     auto const key            = ref_.impl_.extract_key(val);
     auto const probing_scheme = ref_.impl_.probing_scheme();
     auto storage_ref          = ref_.impl_.storage_ref();
-    auto probing_iter = probing_scheme.make_iterator<bucket_size>(group, key, storage_ref.extent());
+    auto probing_iter = probing_scheme.template make_iterator<bucket_size>(group, key, storage_ref.extent());
     auto const init_idx = *probing_iter;
 
     while (true) {
@@ -574,7 +574,7 @@ class operator_impl<
       auto const [state, intra_bucket_index] = [&]() {
         auto res = detail::equal_result::UNEQUAL;
         for (auto i = 0; i < bucket_size; ++i) {
-          res = ref_.impl_.predicate_.operator()<is_insert::YES>(key, bucket_slots[i].first);
+          res = ref_.impl_.predicate_.template operator()<is_insert::YES>(key, bucket_slots[i].first);
           if (res != detail::equal_result::UNEQUAL) {
             return detail::bucket_probing_results{res, i};
           }
@@ -819,9 +819,9 @@ class operator_impl<
     ref_type& ref_ = static_cast<ref_type&>(*this);
     // if init equals sentinel value, then we can just `apply` op instead of write
     if (cuco::detail::bitwise_compare(init, ref_.empty_value_sentinel())) {
-      return ref_.insert_or_apply_impl<true>(value, op);
+      return ref_.template insert_or_apply_impl<true>(value, op);
     } else {
-      return ref_.insert_or_apply_impl<false>(value, op);
+      return ref_.template insert_or_apply_impl<false>(value, op);
     }
   }
 
@@ -883,7 +883,7 @@ class operator_impl<
     auto const key            = ref_.impl_.extract_key(val);
     auto const probing_scheme = ref_.impl_.probing_scheme();
     auto storage_ref          = ref_.impl_.storage_ref();
-    auto probing_iter      = probing_scheme.make_iterator<bucket_size>(key, storage_ref.extent());
+    auto probing_iter      = probing_scheme.template make_iterator<bucket_size>(key, storage_ref.extent());
     auto const init_idx    = *probing_iter;
     auto const empty_value = ref_.empty_value_sentinel();
 
@@ -895,7 +895,7 @@ class operator_impl<
 
       for (auto& slot_content : bucket_slots) {
         auto const eq_res =
-          ref_.impl_.predicate_.operator()<is_insert::YES>(key, slot_content.first);
+          ref_.impl_.predicate_.template operator()<is_insert::YES>(key, slot_content.first);
         auto const intra_bucket_index = cuda::std::distance(bucket_slots.begin(), &slot_content);
         auto slot_ptr                 = ref_.impl_.get_slot_ptr(*probing_iter, intra_bucket_index);
 
@@ -909,7 +909,7 @@ class operator_impl<
           return false;
         }
         if (eq_res == detail::equal_result::AVAILABLE) {
-          switch (ref_.attempt_insert_or_apply<UseDirectApply>(slot_ptr, slot_content, val, op)) {
+          switch (ref_.template attempt_insert_or_apply<UseDirectApply>(slot_ptr, slot_content, val, op)) {
             case insert_result::SUCCESS: return true;
             case insert_result::DUPLICATE: {
               // wait for payload only when performing insert operation
@@ -959,7 +959,7 @@ class operator_impl<
     auto const key            = ref_.impl_.extract_key(val);
     auto const probing_scheme = ref_.impl_.probing_scheme();
     auto storage_ref          = ref_.impl_.storage_ref();
-    auto probing_iter = probing_scheme.make_iterator<bucket_size>(group, key, storage_ref.extent());
+    auto probing_iter = probing_scheme.template make_iterator<bucket_size>(group, key, storage_ref.extent());
     auto const init_idx    = *probing_iter;
     auto const empty_value = ref_.empty_value_sentinel();
 
@@ -972,7 +972,7 @@ class operator_impl<
       auto const [state, intra_bucket_index] = [&]() {
         auto res = detail::equal_result::UNEQUAL;
         for (auto i = 0; i < bucket_size; ++i) {
-          res = ref_.impl_.predicate_.operator()<is_insert::YES>(key, bucket_slots[i].first);
+          res = ref_.impl_.predicate_.template operator()<is_insert::YES>(key, bucket_slots[i].first);
           if (res != detail::equal_result::UNEQUAL) {
             return detail::bucket_probing_results{res, i};
           }
@@ -1517,7 +1517,7 @@ class operator_impl<
                            AtomicCounter* atomic_counter) const
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
-    ref_.impl_.retrieve<BlockSize>(
+    ref_.impl_.template retrieve<BlockSize>(
       block, input_probe_begin, input_probe_end, output_probe, output_match, atomic_counter);
   }
 };

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -517,7 +517,8 @@ class operator_impl<
     auto const key            = ref_.impl_.extract_key(val);
     auto const probing_scheme = ref_.impl_.probing_scheme();
     auto storage_ref          = ref_.impl_.storage_ref();
-    auto probing_iter   = probing_scheme.template make_iterator<bucket_size>(key, storage_ref.extent());
+    auto probing_iter =
+      probing_scheme.template make_iterator<bucket_size>(key, storage_ref.extent());
     auto const init_idx = *probing_iter;
 
     while (true) {
@@ -565,7 +566,8 @@ class operator_impl<
     auto const key            = ref_.impl_.extract_key(val);
     auto const probing_scheme = ref_.impl_.probing_scheme();
     auto storage_ref          = ref_.impl_.storage_ref();
-    auto probing_iter = probing_scheme.template make_iterator<bucket_size>(group, key, storage_ref.extent());
+    auto probing_iter =
+      probing_scheme.template make_iterator<bucket_size>(group, key, storage_ref.extent());
     auto const init_idx = *probing_iter;
 
     while (true) {
@@ -574,7 +576,8 @@ class operator_impl<
       auto const [state, intra_bucket_index] = [&]() {
         auto res = detail::equal_result::UNEQUAL;
         for (auto i = 0; i < bucket_size; ++i) {
-          res = ref_.impl_.predicate_.template operator()<is_insert::YES>(key, bucket_slots[i].first);
+          res =
+            ref_.impl_.predicate_.template operator()<is_insert::YES>(key, bucket_slots[i].first);
           if (res != detail::equal_result::UNEQUAL) {
             return detail::bucket_probing_results{res, i};
           }
@@ -883,7 +886,8 @@ class operator_impl<
     auto const key            = ref_.impl_.extract_key(val);
     auto const probing_scheme = ref_.impl_.probing_scheme();
     auto storage_ref          = ref_.impl_.storage_ref();
-    auto probing_iter      = probing_scheme.template make_iterator<bucket_size>(key, storage_ref.extent());
+    auto probing_iter =
+      probing_scheme.template make_iterator<bucket_size>(key, storage_ref.extent());
     auto const init_idx    = *probing_iter;
     auto const empty_value = ref_.empty_value_sentinel();
 
@@ -909,7 +913,8 @@ class operator_impl<
           return false;
         }
         if (eq_res == detail::equal_result::AVAILABLE) {
-          switch (ref_.template attempt_insert_or_apply<UseDirectApply>(slot_ptr, slot_content, val, op)) {
+          switch (ref_.template attempt_insert_or_apply<UseDirectApply>(
+            slot_ptr, slot_content, val, op)) {
             case insert_result::SUCCESS: return true;
             case insert_result::DUPLICATE: {
               // wait for payload only when performing insert operation
@@ -959,7 +964,8 @@ class operator_impl<
     auto const key            = ref_.impl_.extract_key(val);
     auto const probing_scheme = ref_.impl_.probing_scheme();
     auto storage_ref          = ref_.impl_.storage_ref();
-    auto probing_iter = probing_scheme.template make_iterator<bucket_size>(group, key, storage_ref.extent());
+    auto probing_iter =
+      probing_scheme.template make_iterator<bucket_size>(group, key, storage_ref.extent());
     auto const init_idx    = *probing_iter;
     auto const empty_value = ref_.empty_value_sentinel();
 
@@ -972,7 +978,8 @@ class operator_impl<
       auto const [state, intra_bucket_index] = [&]() {
         auto res = detail::equal_result::UNEQUAL;
         for (auto i = 0; i < bucket_size; ++i) {
-          res = ref_.impl_.predicate_.template operator()<is_insert::YES>(key, bucket_slots[i].first);
+          res =
+            ref_.impl_.predicate_.template operator()<is_insert::YES>(key, bucket_slots[i].first);
           if (res != detail::equal_result::UNEQUAL) {
             return detail::bucket_probing_results{res, i};
           }

--- a/include/cuco/detail/static_multimap/device_view_impl.inl
+++ b/include/cuco/detail/static_multimap/device_view_impl.inl
@@ -402,7 +402,7 @@ class static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_mutab
   __device__ __forceinline__ cuda::std::enable_if_t<not uses_vector_load, void> insert(
     CG g, value_type const& insert_pair) noexcept
   {
-    auto current_slot = initial_slot(g, insert_pair.first);
+    auto current_slot = this->initial_slot(g, insert_pair.first);
 
     while (true) {
       value_type slot_contents = *reinterpret_cast<value_type const*>(current_slot);
@@ -436,7 +436,7 @@ class static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_mutab
       // if there are no empty slots in the current bucket,
       // we move onto the next bucket
       else {
-        current_slot = next_slot(current_slot);
+        current_slot = this->next_slot(current_slot);
       }
     }  // while true
   }
@@ -657,8 +657,8 @@ class static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_view_
     Equal equal) const noexcept
   {
     auto current_slot = [&]() {
-      if constexpr (is_pair_contains) { return initial_slot(g, element.first); }
-      if constexpr (not is_pair_contains) { return initial_slot(g, element); }
+      if constexpr (is_pair_contains) { return this->initial_slot(g, element.first); }
+      if constexpr (not is_pair_contains) { return this->initial_slot(g, element); }
     }();
 
     while (true) {
@@ -687,7 +687,7 @@ class static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_view_
 
       // otherwise, all slots in the current bucket are full with other keys, so we move onto the
       // next bucket
-      current_slot = next_slot(current_slot);
+      current_slot = this->next_slot(current_slot);
     }
   }
 

--- a/include/cuco/detail/static_multimap/kernels.cuh
+++ b/include/cuco/detail/static_multimap/kernels.cuh
@@ -405,13 +405,13 @@ CUCO_KERNEL void retrieve(InputIt first,
                                                   key_equal);
       } else {
         view.template retrieve<buffer_size>(active_flushing_cg,
-	                                   probing_cg,
-                                           key,
-                                           &flushing_cg_counter[flushing_cg_id],
-                                           output_buffer[flushing_cg_id],
-                                           num_matches,
-                                           output_begin,
-                                           key_equal);
+                                            probing_cg,
+                                            key,
+                                            &flushing_cg_counter[flushing_cg_id],
+                                            output_buffer[flushing_cg_id],
+                                            num_matches,
+                                            output_begin,
+                                            key_equal);
       }
     }
     idx += loop_stride;

--- a/include/cuco/detail/static_multimap/kernels.cuh
+++ b/include/cuco/detail/static_multimap/kernels.cuh
@@ -395,23 +395,23 @@ CUCO_KERNEL void retrieve(InputIt first,
     if (active_flag) {
       auto key = *(first + idx);
       if constexpr (is_outer) {
-        view.retrieve_outer<buffer_size>(active_flushing_cg,
-                                         probing_cg,
-                                         key,
-                                         &flushing_cg_counter[flushing_cg_id],
-                                         output_buffer[flushing_cg_id],
-                                         num_matches,
-                                         output_begin,
-                                         key_equal);
+        view.template retrieve_outer<buffer_size>(active_flushing_cg,
+                                                  probing_cg,
+                                                  key,
+                                                  &flushing_cg_counter[flushing_cg_id],
+                                                  output_buffer[flushing_cg_id],
+                                                  num_matches,
+                                                  output_begin,
+                                                  key_equal);
       } else {
-        view.retrieve<buffer_size>(active_flushing_cg,
-                                   probing_cg,
-                                   key,
-                                   &flushing_cg_counter[flushing_cg_id],
-                                   output_buffer[flushing_cg_id],
-                                   num_matches,
-                                   output_begin,
-                                   key_equal);
+        view.template retrieve<buffer_size>(active_flushing_cg,
+	                                   probing_cg,
+                                           key,
+                                           &flushing_cg_counter[flushing_cg_id],
+                                           output_buffer[flushing_cg_id],
+                                           num_matches,
+                                           output_begin,
+                                           key_equal);
       }
     }
     idx += loop_stride;

--- a/include/cuco/detail/static_multimap/static_multimap.inl
+++ b/include/cuco/detail/static_multimap/static_multimap.inl
@@ -1131,7 +1131,7 @@ static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_mutable_vie
   cooperative_groups::thread_block_tile<ProbeSequence::cg_size> const& g,
   value_type const& insert_pair) noexcept
 {
-  impl_.insert<uses_vector_load()>(g, insert_pair);
+  impl_.template insert<uses_vector_load()>(g, insert_pair);
 }
 
 template <typename Key,
@@ -1228,7 +1228,7 @@ static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_view::conta
   KeyEqual key_equal) const noexcept
 {
   constexpr bool is_pair_contains = false;
-  return impl_.contains<is_pair_contains, uses_vector_load()>(g, k, key_equal);
+  return impl_.template contains<is_pair_contains, uses_vector_load()>(g, k, key_equal);
 }
 
 template <typename Key,
@@ -1244,7 +1244,7 @@ static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_view::pair_
   PairEqual pair_equal) const noexcept
 {
   constexpr bool is_pair_contains = true;
-  return impl_.contains<is_pair_contains, uses_vector_load()>(g, p, pair_equal);
+  return impl_.template contains<is_pair_contains, uses_vector_load()>(g, p, pair_equal);
 }
 
 template <typename Key,
@@ -1334,17 +1334,17 @@ static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_view::retri
 {
   constexpr bool is_outer = false;
   if constexpr (uses_vector_load()) {
-    impl_.retrieve<buffer_size, is_outer>(flushing_cg,
-                                          probing_cg,
-                                          k,
-                                          flushing_cg_counter,
-                                          output_buffer,
-                                          num_matches,
-                                          output_begin,
-                                          key_equal);
+    impl_.template retrieve<buffer_size, is_outer>(flushing_cg,
+                                                   probing_cg,
+                                                   k,
+                                                   flushing_cg_counter,
+                                                   output_buffer,
+                                                   num_matches,
+                                                   output_begin,
+                                                   key_equal);
   } else  // In the case of scalar load, flushing CG is the same as probing CG
   {
-    impl_.retrieve<buffer_size, is_outer>(
+    impl_.template retrieve<buffer_size, is_outer>(
       probing_cg, k, flushing_cg_counter, output_buffer, num_matches, output_begin, key_equal);
   }
 }
@@ -1372,7 +1372,7 @@ static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_view::retri
 {
   constexpr bool is_outer = true;
   if constexpr (uses_vector_load()) {
-    impl_.retrieve<buffer_size, is_outer>(flushing_cg,
+    impl_.template retrieve<buffer_size, is_outer>(flushing_cg,
                                           probing_cg,
                                           k,
                                           flushing_cg_counter,
@@ -1382,7 +1382,7 @@ static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_view::retri
                                           key_equal);
   } else  // In the case of scalar load, flushing CG is the same as probing CG
   {
-    impl_.retrieve<buffer_size, is_outer>(
+    impl_.template retrieve<buffer_size, is_outer>(
       probing_cg, k, flushing_cg_counter, output_buffer, num_matches, output_begin, key_equal);
   }
 }

--- a/include/cuco/detail/static_multimap/static_multimap.inl
+++ b/include/cuco/detail/static_multimap/static_multimap.inl
@@ -1373,13 +1373,13 @@ static_multimap<Key, Value, Scope, Allocator, ProbeSequence>::device_view::retri
   constexpr bool is_outer = true;
   if constexpr (uses_vector_load()) {
     impl_.template retrieve<buffer_size, is_outer>(flushing_cg,
-                                          probing_cg,
-                                          k,
-                                          flushing_cg_counter,
-                                          output_buffer,
-                                          num_matches,
-                                          output_begin,
-                                          key_equal);
+                                                   probing_cg,
+                                                   k,
+                                                   flushing_cg_counter,
+                                                   output_buffer,
+                                                   num_matches,
+                                                   output_begin,
+                                                   key_equal);
   } else  // In the case of scalar load, flushing CG is the same as probing CG
   {
     impl_.template retrieve<buffer_size, is_outer>(

--- a/include/cuco/detail/static_multimap/static_multimap_ref.inl
+++ b/include/cuco/detail/static_multimap/static_multimap_ref.inl
@@ -476,9 +476,9 @@ class operator_impl<
   {
     auto& ref_ = static_cast<ref_type&>(*this);
     if (!cuco::detail::bitwise_compare(ref_.erased_key_sentinel(), ref_.empty_key_sentinel())) {
-      return ref_.impl_.insert<true>(group, value);
+      return ref_.impl_.template insert<true>(group, value);
     } else {
-      return ref_.impl_.insert<false>(group, value);
+      return ref_.impl_.template insert<false>(group, value);
     }
   }
 };
@@ -838,7 +838,7 @@ class operator_impl<
                            AtomicCounter* atomic_counter) const
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
-    ref_.impl_.retrieve<BlockSize>(
+    ref_.impl_.template retrieve<BlockSize>(
       block, input_probe_begin, input_probe_end, output_probe, output_match, atomic_counter);
   }
 };

--- a/include/cuco/detail/static_multiset/static_multiset_ref.inl
+++ b/include/cuco/detail/static_multiset/static_multiset_ref.inl
@@ -415,9 +415,9 @@ class operator_impl<
   {
     auto& ref_ = static_cast<ref_type&>(*this);
     if (!cuco::detail::bitwise_compare(ref_.erased_key_sentinel(), ref_.empty_key_sentinel())) {
-      return ref_.impl_.insert<true>(group, value);
+      return ref_.impl_.template insert<true>(group, value);
     } else {
-      return ref_.impl_.insert<false>(group, value);
+      return ref_.impl_.template insert<false>(group, value);
     }
   }
 };
@@ -602,7 +602,7 @@ class operator_impl<
                            AtomicCounter& atomic_counter) const
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
-    ref_.impl_.retrieve<BlockSize>(
+    ref_.impl_.template retrieve<BlockSize>(
       block, input_probe_begin, input_probe_end, output_probe, output_match, atomic_counter);
   }
 
@@ -651,7 +651,7 @@ class operator_impl<
                                  AtomicCounter& atomic_counter) const
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
-    ref_.impl_.retrieve_outer<BlockSize>(
+    ref_.impl_.template retrieve_outer<BlockSize>(
       block, input_probe_begin, input_probe_end, output_probe, output_match, atomic_counter);
   }
 };

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -410,9 +410,9 @@ class operator_impl<op::insert_tag,
   {
     auto& ref_ = static_cast<ref_type&>(*this);
     if (ref_.erased_key_sentinel() != ref_.empty_key_sentinel()) {
-      return ref_.impl_.insert<true>(group, value);
+      return ref_.impl_.template insert<true>(group, value);
     } else {
-      return ref_.impl_.insert<false>(group, value);
+      return ref_.impl_.template insert<false>(group, value);
     }
   }
 };
@@ -834,7 +834,7 @@ class operator_impl<op::retrieve_tag,
                            AtomicCounter* atomic_counter) const
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
-    ref_.impl_.retrieve<BlockSize>(
+    ref_.impl_.template retrieve<BlockSize>(
       block, input_probe_begin, input_probe_end, output_probe, output_match, atomic_counter);
   }
 };

--- a/tests/dynamic_bitset/find_next_test.cu
+++ b/tests/dynamic_bitset/find_next_test.cu
@@ -35,7 +35,7 @@ __global__ void find_next_kernel(BitsetRef ref, size_type num_elements, OutputIt
   }
 }
 
-extern bool modulo_bitgen(uint64_t i);  // Defined in get_test.cu
+using cuco::test::modulo_bitgen;
 
 TEST_CASE("dynamic_bitset find next set test", "")
 {

--- a/tests/dynamic_bitset/get_test.cu
+++ b/tests/dynamic_bitset/get_test.cu
@@ -35,7 +35,7 @@ __global__ void test_kernel(BitsetRef ref, size_type num_elements, OutputIt outp
   }
 }
 
-bool modulo_bitgen(uint64_t i) { return i % 7 == 0; }
+using cuco::test::modulo_bitgen;
 
 TEST_CASE("dynamic_bitset get test", "")
 {

--- a/tests/dynamic_bitset/rank_test.cu
+++ b/tests/dynamic_bitset/rank_test.cu
@@ -24,7 +24,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-extern bool modulo_bitgen(uint64_t i);  // Defined in get_test.cu
+using cuco::test::modulo_bitgen;
 
 TEST_CASE("dynamic_bitset rank test", "")
 {

--- a/tests/dynamic_bitset/select_test.cu
+++ b/tests/dynamic_bitset/select_test.cu
@@ -35,7 +35,7 @@ __global__ void select_false_kernel(BitsetRef ref, size_type num_elements, Outpu
   }
 }
 
-extern bool modulo_bitgen(uint64_t i);  // Defined in get_test.cu
+using cuco::test::modulo_bitgen;
 
 TEST_CASE("dynamic_bitset select test", "")
 {

--- a/tests/static_map/insert_or_apply_test.cu
+++ b/tests/static_map/insert_or_apply_test.cu
@@ -100,7 +100,7 @@ void test_insert_or_apply_shmem(Map& map, size_type num_keys, size_type num_uniq
                                            Allocator,
                                            cuco::storage<1>>;
 
-  using shared_map_ref_type = typename shared_map_type::ref_type<>;
+  using shared_map_ref_type = typename shared_map_type::template ref_type<>;
   auto constexpr valid_extent =
     cuco::make_valid_extent<typename shared_map_ref_type::probing_scheme_type,
                             typename shared_map_ref_type::storage_ref_type>(extent_type{});

--- a/tests/test_utils.hpp
+++ b/tests/test_utils.hpp
@@ -100,5 +100,7 @@ bool equal(Iterator1 begin1, Iterator1 end1, Iterator2 begin2, Predicate p, cuda
   return res == size;
 }
 
+inline bool modulo_bitgen(uint64_t i) { return i % 7 == 0; }
+
 }  // namespace test
 }  // namespace cuco

--- a/tests/utility/probing_scheme_test.cu
+++ b/tests/utility/probing_scheme_test.cu
@@ -44,7 +44,7 @@ __global__ void generate_scalar_probing_sequence(Key key,
   auto probing_scheme = ProbingScheme{};
 
   if (tid == 0) {
-    auto iter = probing_scheme.make_iterator<BucketSize>(key, upper_bound);
+    auto iter = probing_scheme.template make_iterator<BucketSize>(key, upper_bound);
 
     for (size_t i = 0; i < seq_length; ++i) {
       out_seq[i] = *iter;
@@ -68,7 +68,7 @@ __global__ void generate_cg_probing_sequence(Key key,
     auto const tile =
       cooperative_groups::tiled_partition<cg_size>(cooperative_groups::this_thread_block());
 
-    auto iter = probing_scheme.make_iterator<BucketSize>(tile, key, upper_bound);
+    auto iter = probing_scheme.template make_iterator<BucketSize>(tile, key, upper_bound);
 
     for (size_t i = tile.thread_rank(); i < seq_length; ++i) {
       out_seq[i] = *iter;


### PR DESCRIPTION
- add `template` keyword to help parsing.
- do not mark as `constexpr` functions that cannot be evaluated at compile-time.
