### PR TITLE
Update device retrieve signature to pass atomic counter by reference

### DIFF
--- a/include/cuco/detail/open_addressing/kernels.cuh
+++ b/include/cuco/detail/open_addressing/kernels.cuh
@@ -696,14 +696,14 @@ CUCO_KERNEL void retrieve(InputProbeIt input_probe,
                                              input_probe + block_end_offset,
                                              output_probe,
                                              output_match,
-                                             atomic_counter);
+                                             *atomic_counter);
     } else {
       ref.template retrieve<BlockSize>(block,
                                        input_probe + block_begin_offset,
                                        input_probe + block_end_offset,
                                        output_probe,
                                        output_match,
-                                       atomic_counter);
+                                       *atomic_counter);
     }
   }
 }

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -1062,7 +1062,7 @@ class open_addressing_ref_impl {
    * @param output_probe Beginning of the sequence of keys corresponding to matching elements in
    * `output_match`
    * @param output_match Beginning of the sequence of matching elements
-   * @param atomic_counter Pointer to an atomic object of integral type that is used to count the
+   * @param atomic_counter Atomic object of integral type that is used to count the
    * number of output elements
    */
   template <int32_t BlockSize,
@@ -1075,7 +1075,7 @@ class open_addressing_ref_impl {
                            InputProbeIt input_probe_end,
                            OutputProbeIt output_probe,
                            OutputMatchIt output_match,
-                           AtomicCounter* atomic_counter) const
+                           AtomicCounter& atomic_counter) const
   {
     auto constexpr is_outer = false;
     auto const n = cuco::detail::distance(input_probe_begin, input_probe_end);  // TODO include
@@ -1111,7 +1111,7 @@ class open_addressing_ref_impl {
    * @param output_probe Beginning of the sequence of keys corresponding to matching elements in
    * `output_match`
    * @param output_match Beginning of the sequence of matching elements
-   * @param atomic_counter Pointer to an atomic object of integral type that is used to count the
+   * @param atomic_counter Atomic object of integral type that is used to count the
    * number of output elements
    */
   template <int32_t BlockSize,
@@ -1124,7 +1124,7 @@ class open_addressing_ref_impl {
                                  InputProbeIt input_probe_end,
                                  OutputProbeIt output_probe,
                                  OutputMatchIt output_match,
-                                 AtomicCounter* atomic_counter) const
+                                 AtomicCounter& atomic_counter) const
   {
     auto constexpr is_outer = true;
     auto const n = cuco::detail::distance(input_probe_begin, input_probe_end);  // TODO include
@@ -1161,7 +1161,7 @@ class open_addressing_ref_impl {
    * @param output_probe Beginning of the sequence of keys corresponding to matching elements in
    * `output_match`
    * @param output_match Beginning of the sequence of matching elements
-   * @param atomic_counter Pointer to an atomic object of integral type that is used to count the
+   * @param atomic_counter Atomic object of integral type that is used to count the
    * number of output elements
    */
   template <bool IsOuter,
@@ -1175,7 +1175,7 @@ class open_addressing_ref_impl {
                                 cuco::detail::index_type n,
                                 OutputProbeIt output_probe,
                                 OutputMatchIt output_match,
-                                AtomicCounter* atomic_counter) const
+                                AtomicCounter& atomic_counter) const
   {
     namespace cg = cooperative_groups;
 
@@ -1212,7 +1212,7 @@ class open_addressing_ref_impl {
       size_type offset = 0;
       auto const count = counters[flushing_tile_id];
       auto const rank  = tile.thread_rank();
-      if (rank == 0) { offset = atomic_counter->fetch_add(count, cuda::memory_order_relaxed); }
+      if (rank == 0) { offset = atomic_counter.fetch_add(count, cuda::memory_order_relaxed); }
       offset = tile.shfl(offset, 0);
 
       // flush_buffers

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -1521,7 +1521,7 @@ class operator_impl<
                            InputProbeIt input_probe_end,
                            OutputProbeIt output_probe,
                            OutputMatchIt output_match,
-                           AtomicCounter* atomic_counter) const
+                           AtomicCounter& atomic_counter) const
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     ref_.impl_.template retrieve<BlockSize>(

--- a/include/cuco/detail/static_multimap/static_multimap_ref.inl
+++ b/include/cuco/detail/static_multimap/static_multimap_ref.inl
@@ -835,7 +835,7 @@ class operator_impl<
                            InputProbeIt input_probe_end,
                            OutputProbeIt output_probe,
                            OutputMatchIt output_match,
-                           AtomicCounter* atomic_counter) const
+                           AtomicCounter& atomic_counter) const
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     ref_.impl_.template retrieve<BlockSize>(

--- a/include/cuco/detail/static_multiset/static_multiset_ref.inl
+++ b/include/cuco/detail/static_multiset/static_multiset_ref.inl
@@ -599,7 +599,7 @@ class operator_impl<
                            InputProbeIt input_probe_end,
                            OutputProbeIt output_probe,
                            OutputMatchIt output_match,
-                           AtomicCounter* atomic_counter) const
+                           AtomicCounter& atomic_counter) const
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     ref_.impl_.template retrieve<BlockSize>(
@@ -648,7 +648,7 @@ class operator_impl<
                                  InputProbeIt input_probe_end,
                                  OutputProbeIt output_probe,
                                  OutputMatchIt output_match,
-                                 AtomicCounter* atomic_counter) const
+                                 AtomicCounter& atomic_counter) const
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     ref_.impl_.template retrieve_outer<BlockSize>(

--- a/include/cuco/detail/static_multiset/static_multiset_ref.inl
+++ b/include/cuco/detail/static_multiset/static_multiset_ref.inl
@@ -599,7 +599,7 @@ class operator_impl<
                            InputProbeIt input_probe_end,
                            OutputProbeIt output_probe,
                            OutputMatchIt output_match,
-                           AtomicCounter& atomic_counter) const
+                           AtomicCounter* atomic_counter) const
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     ref_.impl_.template retrieve<BlockSize>(
@@ -648,7 +648,7 @@ class operator_impl<
                                  InputProbeIt input_probe_end,
                                  OutputProbeIt output_probe,
                                  OutputMatchIt output_match,
-                                 AtomicCounter& atomic_counter) const
+                                 AtomicCounter* atomic_counter) const
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     ref_.impl_.template retrieve_outer<BlockSize>(

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -831,7 +831,7 @@ class operator_impl<op::retrieve_tag,
                            InputProbeIt input_probe_end,
                            OutputProbeIt output_probe,
                            OutputMatchIt output_match,
-                           AtomicCounter* atomic_counter) const
+                           AtomicCounter& atomic_counter) const
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     ref_.impl_.template retrieve<BlockSize>(


### PR DESCRIPTION
We always pass atomic counter by pointer instead of by reference. This unblocks the mixed join migration with multiset.
