### PR TITLE
 Pass trivial types by value to reduce register usage

### DIFF
--- a/include/cuco/detail/bitwise_compare.cuh
+++ b/include/cuco/detail/bitwise_compare.cuh
@@ -83,7 +83,7 @@ __host__ __device__ constexpr std::size_t alignment()
  * @return If the bits in the object representations of lhs and rhs are identical.
  */
 template <typename T>
-__host__ __device__ constexpr bool bitwise_compare(T const& lhs, T const& rhs)
+__host__ __device__ constexpr bool bitwise_compare(T lhs, T rhs)
 {
   static_assert(
     cuco::is_bitwise_comparable_v<T>,

--- a/include/cuco/detail/open_addressing/functors.cuh
+++ b/include/cuco/detail/open_addressing/functors.cuh
@@ -73,7 +73,7 @@ struct slot_is_filled {
    * @param empty_sentinel Key sentinel indicating an empty slot
    * @param erased_sentinel Key sentinel indicating an erased slot
    */
-  explicit constexpr slot_is_filled(T const& empty_sentinel, T const& erased_sentinel) noexcept
+  explicit constexpr slot_is_filled(T empty_sentinel, T erased_sentinel) noexcept
     : empty_sentinel_{empty_sentinel}, erased_sentinel_{erased_sentinel}
   {
   }
@@ -88,7 +88,7 @@ struct slot_is_filled {
    * @return `true` if slot is filled
    */
   template <typename S>
-  __device__ constexpr bool operator()(S const& slot) const noexcept
+  __device__ constexpr bool operator()(S slot) const noexcept
   {
     auto const key = [&]() {
       if constexpr (HasPayload) {

--- a/include/cuco/detail/open_addressing/kernels.cuh
+++ b/include/cuco/detail/open_addressing/kernels.cuh
@@ -78,8 +78,7 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void insert_if_n(InputIt first,
 
   while (idx < n) {
     if (pred(*(stencil + idx))) {
-      typename cuda::std::iterator_traits<InputIt>::value_type const& insert_element{
-        *(first + idx)};
+      typename cuda::std::iterator_traits<InputIt>::value_type const insert_element{*(first + idx)};
       if constexpr (CGSize == 1) {
         if (ref.insert(insert_element)) { thread_num_successes++; };
       } else {
@@ -137,8 +136,7 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void insert_if_n(
 
   while (idx < n) {
     if (pred(*(stencil + idx))) {
-      typename cuda::std::iterator_traits<InputIt>::value_type const& insert_element{
-        *(first + idx)};
+      typename cuda::std::iterator_traits<InputIt>::value_type const insert_element{*(first + idx)};
       if constexpr (CGSize == 1) {
         ref.insert(insert_element);
       } else {
@@ -173,7 +171,7 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void erase(InputIt first,
   auto idx               = cuco::detail::global_thread_id() / CGSize;
 
   while (idx < n) {
-    typename cuda::std::iterator_traits<InputIt>::value_type const& erase_element{*(first + idx)};
+    typename cuda::std::iterator_traits<InputIt>::value_type const erase_element{*(first + idx)};
     if constexpr (CGSize == 1) {
       ref.erase(erase_element);
     } else {
@@ -213,7 +211,7 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void for_each_n(InputIt first,
   auto idx               = cuco::detail::global_thread_id() / CGSize;
 
   while (idx < n) {
-    typename cuda::std::iterator_traits<InputIt>::value_type const& key{*(first + idx)};
+    typename cuda::std::iterator_traits<InputIt>::value_type const key{*(first + idx)};
     if constexpr (CGSize == 1) {
       ref.for_each(key, callback_op);
     } else {
@@ -276,7 +274,7 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void contains_if_n(InputIt first,
   while ((idx - thread_idx / CGSize) < n) {  // the whole thread block falls into the same iteration
     if constexpr (CGSize == 1) {
       if (idx < n) {
-        typename cuda::std::iterator_traits<InputIt>::value_type const& key = *(first + idx);
+        typename cuda::std::iterator_traits<InputIt>::value_type const key = *(first + idx);
         /*
          * The ld.relaxed.gpu instruction causes L1 to flush more frequently, causing increased
          * sector stores from L2 to global memory. By writing results to shared memory and then
@@ -290,7 +288,7 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void contains_if_n(InputIt first,
     } else {
       auto const tile = cg::tiled_partition<CGSize>(block);
       if (idx < n) {
-        typename cuda::std::iterator_traits<InputIt>::value_type const& key = *(first + idx);
+        typename cuda::std::iterator_traits<InputIt>::value_type const key = *(first + idx);
         auto const found = pred(*(stencil + idx)) ? ref.contains(tile, key) : false;
         if (tile.thread_rank() == 0) { *(output_begin + idx) = found; }
       }
@@ -392,8 +390,8 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void find_if_n(InputIt first,
   while ((idx - thread_idx / CGSize) < n) {  // the whole thread block falls into the same iteration
     if constexpr (CGSize == 1) {
       if (idx < n) {
-        typename cuda::std::iterator_traits<InputIt>::value_type const& key = *(first + idx);
-        auto const found                                                    = ref.find(key);
+        typename cuda::std::iterator_traits<InputIt>::value_type const key = *(first + idx);
+        auto const found                                                   = ref.find(key);
         /*
          * The ld.relaxed.gpu instruction causes L1 to flush more frequently, causing increased
          * sector stores from L2 to global memory. By writing results to shared memory and then
@@ -407,8 +405,8 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void find_if_n(InputIt first,
     } else {
       auto const tile = cg::tiled_partition<CGSize>(block);
       if (idx < n) {
-        typename cuda::std::iterator_traits<InputIt>::value_type const& key = *(first + idx);
-        auto const found                                                    = ref.find(tile, key);
+        typename cuda::std::iterator_traits<InputIt>::value_type const key = *(first + idx);
+        auto const found                                                   = ref.find(tile, key);
 
         if (tile.thread_rank() == 0) {
           *(output_begin + idx) = pred(*(stencil + idx)) ? output(found) : sentinel;
@@ -482,7 +480,7 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void insert_and_find(InputIt first,
   while ((idx - thread_idx / CGSize) < n) {  // the whole thread block falls into the same iteration
     if constexpr (CGSize == 1) {
       if (idx < n) {
-        typename cuda::std::iterator_traits<InputIt>::value_type const& insert_element{
+        typename cuda::std::iterator_traits<InputIt>::value_type const insert_element{
           *(first + idx)};
         auto const [iter, inserted] = ref.insert_and_find(insert_element);
         /*
@@ -502,7 +500,7 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void insert_and_find(InputIt first,
     } else {
       auto const tile = cg::tiled_partition<CGSize>(cg::this_thread_block());
       if (idx < n) {
-        typename cuda::std::iterator_traits<InputIt>::value_type const& insert_element{
+        typename cuda::std::iterator_traits<InputIt>::value_type const insert_element{
           *(first + idx)};
         auto const [iter, inserted] = ref.insert_and_find(tile, insert_element);
         if (tile.thread_rank() == 0) {
@@ -553,7 +551,7 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void count(InputIt first,
   auto idx               = cuco::detail::global_thread_id() / CGSize;
 
   while (idx < n) {
-    typename cuda::std::iterator_traits<InputIt>::value_type const& key = *(first + idx);
+    typename cuda::std::iterator_traits<InputIt>::value_type const key = *(first + idx);
     if constexpr (CGSize == 1) {
       if constexpr (IsOuter) {
         thread_count += max(ref.count(key), outer_min_count);
@@ -612,7 +610,7 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void count_each(InputIt first,
   size_type constexpr outer_min_count = 1;
 
   while (idx < n) {
-    typename cuda::std::iterator_traits<InputIt>::value_type const& key = *(first + idx);
+    typename cuda::std::iterator_traits<InputIt>::value_type const key = *(first + idx);
     if constexpr (CGSize == 1) {
       if constexpr (IsOuter) {
         *(output_begin + idx) = max(ref.count(key), size_type{outer_min_count});

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -372,7 +372,7 @@ class open_addressing_ref_impl {
    * @return True if the given element is successfully inserted
    */
   template <typename Value>
-  __device__ bool insert(Value const& value) noexcept
+  __device__ bool insert(Value value) noexcept
   {
     static_assert(cg_size == 1, "Non-CG operation is incompatible with the current probing scheme");
 
@@ -427,7 +427,7 @@ class open_addressing_ref_impl {
    */
   template <bool SupportsErase, typename Value>
   __device__ bool insert(cooperative_groups::thread_block_tile<cg_size> const& group,
-                         Value const& value) noexcept
+                         Value value) noexcept
   {
     auto const val = this->heterogeneous_value(value);
     auto const key = this->extract_key(val);
@@ -512,7 +512,7 @@ class open_addressing_ref_impl {
    * insertion is successful or not.
    */
   template <typename Value>
-  __device__ cuda::std::pair<iterator, bool> insert_and_find(Value const& value) noexcept
+  __device__ cuda::std::pair<iterator, bool> insert_and_find(Value value) noexcept
   {
     static_assert(cg_size == 1, "Non-CG operation is incompatible with the current probing scheme");
 #if __CUDA_ARCH__ < 700
@@ -587,7 +587,7 @@ class open_addressing_ref_impl {
    */
   template <typename Value>
   __device__ cuda::std::pair<iterator, bool> insert_and_find(
-    cooperative_groups::thread_block_tile<cg_size> const& group, Value const& value) noexcept
+    cooperative_groups::thread_block_tile<cg_size> const& group, Value value) noexcept
   {
 #if __CUDA_ARCH__ < 700
     // Spinning to ensure that the write to the value part took place requires
@@ -678,12 +678,12 @@ class open_addressing_ref_impl {
    *
    * @tparam ProbeKey Input type which is convertible to 'key_type'
    *
-   * @param value The element to erase
+   * @param key The element to erase
    *
    * @return True if the given element is successfully erased
    */
   template <typename ProbeKey>
-  __device__ bool erase(ProbeKey const& key) noexcept
+  __device__ bool erase(ProbeKey key) noexcept
   {
     static_assert(cg_size == 1, "Non-CG operation is incompatible with the current probing scheme");
 
@@ -723,13 +723,13 @@ class open_addressing_ref_impl {
    * @tparam ProbeKey Input type which is convertible to 'key_type'
    *
    * @param group The Cooperative Group used to perform group erase
-   * @param value The element to erase
+   * @param key The element to erase
    *
    * @return True if the given element is successfully erased
    */
   template <typename ProbeKey>
   __device__ bool erase(cooperative_groups::thread_block_tile<cg_size> const& group,
-                        ProbeKey const& key) noexcept
+                        ProbeKey key) noexcept
   {
     auto probing_iter =
       probing_scheme_.template make_iterator<bucket_size>(group, key, storage_ref_.extent());
@@ -787,7 +787,7 @@ class open_addressing_ref_impl {
    * @return A boolean indicating whether the probe key is present
    */
   template <typename ProbeKey>
-  [[nodiscard]] __device__ bool contains(ProbeKey const& key) const noexcept
+  [[nodiscard]] __device__ bool contains(ProbeKey key) const noexcept
   {
     static_assert(cg_size == 1, "Non-CG operation is incompatible with the current probing scheme");
     auto probing_iter =
@@ -826,7 +826,7 @@ class open_addressing_ref_impl {
    */
   template <typename ProbeKey>
   [[nodiscard]] __device__ bool contains(
-    cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey const& key) const noexcept
+    cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey key) const noexcept
   {
     auto probing_iter =
       probing_scheme_.template make_iterator<bucket_size>(group, key, storage_ref_.extent());
@@ -866,7 +866,7 @@ class open_addressing_ref_impl {
    * @return An iterator to the position at which the equivalent key is stored
    */
   template <typename ProbeKey>
-  [[nodiscard]] __device__ iterator find(ProbeKey const& key) const noexcept
+  [[nodiscard]] __device__ iterator find(ProbeKey key) const noexcept
   {
     static_assert(cg_size == 1, "Non-CG operation is incompatible with the current probing scheme");
     auto probing_iter =
@@ -908,8 +908,8 @@ class open_addressing_ref_impl {
    * @return An iterator to the position at which the equivalent key is stored
    */
   template <typename ProbeKey>
-  [[nodiscard]] __device__ iterator find(
-    cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey const& key) const noexcept
+  [[nodiscard]] __device__ iterator
+  find(cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey key) const noexcept
   {
     auto probing_iter =
       probing_scheme_.template make_iterator<bucket_size>(group, key, storage_ref_.extent());
@@ -957,7 +957,7 @@ class open_addressing_ref_impl {
    * @return Number of occurrences found by the current thread
    */
   template <typename ProbeKey>
-  [[nodiscard]] __device__ size_type count(ProbeKey const& key) const noexcept
+  [[nodiscard]] __device__ size_type count(ProbeKey key) const noexcept
   {
     if constexpr (not allows_duplicates) {
       return static_cast<size_type>(this->contains(key));
@@ -1004,8 +1004,8 @@ class open_addressing_ref_impl {
    * @return Number of occurrences found by the current thread
    */
   template <typename ProbeKey>
-  [[nodiscard]] __device__ size_type count(
-    cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey const& key) const noexcept
+  [[nodiscard]] __device__ size_type
+  count(cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey key) const noexcept
   {
     auto probing_iter =
       probing_scheme_.template make_iterator<bucket_size>(group, key, storage_ref_.extent());
@@ -1360,7 +1360,7 @@ class open_addressing_ref_impl {
    * @param callback_op Function to apply to every matched slot
    */
   template <class ProbeKey, class CallbackOp>
-  __device__ void for_each(ProbeKey const& key, CallbackOp&& callback_op) const noexcept
+  __device__ void for_each(ProbeKey key, CallbackOp&& callback_op) const noexcept
   {
     static_assert(cg_size == 1, "Non-CG operation is incompatible with the current probing scheme");
     auto probing_iter =
@@ -1410,7 +1410,7 @@ class open_addressing_ref_impl {
    */
   template <class ProbeKey, class CallbackOp>
   __device__ void for_each(cooperative_groups::thread_block_tile<cg_size> const& group,
-                           ProbeKey const& key,
+                           ProbeKey key,
                            CallbackOp&& callback_op) const noexcept
   {
     auto probing_iter =
@@ -1474,7 +1474,7 @@ class open_addressing_ref_impl {
    */
   template <class ProbeKey, class CallbackOp, class SyncOp>
   __device__ void for_each(cooperative_groups::thread_block_tile<cg_size> const& group,
-                           ProbeKey const& key,
+                           ProbeKey key,
                            CallbackOp&& callback_op,
                            SyncOp&& sync_op) const noexcept
   {
@@ -1534,7 +1534,7 @@ class open_addressing_ref_impl {
    * @return The key
    */
   template <typename Value>
-  [[nodiscard]] __host__ __device__ constexpr auto extract_key(Value const& value) const noexcept
+  [[nodiscard]] __host__ __device__ constexpr auto extract_key(Value value) const noexcept
   {
     if constexpr (has_payload) {
       return thrust::raw_reference_cast(value).first;
@@ -1555,8 +1555,7 @@ class open_addressing_ref_impl {
    * @return The payload
    */
   template <typename Value, typename Enable = cuda::std::enable_if_t<has_payload and sizeof(Value)>>
-  [[nodiscard]] __host__ __device__ constexpr auto extract_payload(
-    Value const& value) const noexcept
+  [[nodiscard]] __host__ __device__ constexpr auto extract_payload(Value value) const noexcept
   {
     return thrust::raw_reference_cast(value).second;
   }
@@ -1571,7 +1570,7 @@ class open_addressing_ref_impl {
    * @return The converted object
    */
   template <typename T>
-  [[nodiscard]] __device__ constexpr value_type native_value(T const& value) const noexcept
+  [[nodiscard]] __device__ constexpr value_type native_value(T value) const noexcept
   {
     if constexpr (has_payload) {
       return {static_cast<key_type>(this->extract_key(value)), this->extract_payload(value)};
@@ -1591,7 +1590,7 @@ class open_addressing_ref_impl {
    * @return The converted object
    */
   template <typename T>
-  [[nodiscard]] __device__ constexpr auto heterogeneous_value(T const& value) const noexcept
+  [[nodiscard]] __device__ constexpr auto heterogeneous_value(T value) const noexcept
   {
     if constexpr (has_payload and not cuda::std::is_same_v<T, value_type>) {
       using mapped_type = decltype(this->empty_value_sentinel());
@@ -1613,7 +1612,7 @@ class open_addressing_ref_impl {
    *
    * @return The sentinel value used to represent an erased slot
    */
-  [[nodiscard]] __device__ constexpr value_type const erased_slot_sentinel() const noexcept
+  [[nodiscard]] __device__ constexpr value_type erased_slot_sentinel() const noexcept
   {
     if constexpr (has_payload) {
       return cuco::pair{this->erased_key_sentinel(), this->empty_value_sentinel()};
@@ -1674,8 +1673,8 @@ class open_addressing_ref_impl {
    */
   template <typename Value>
   [[nodiscard]] __device__ constexpr insert_result back_to_back_cas(value_type* address,
-                                                                    value_type const& expected,
-                                                                    Value const& desired) noexcept
+                                                                    value_type expected,
+                                                                    Value desired) noexcept
   {
     using mapped_type = cuda::std::decay_t<decltype(this->empty_value_sentinel())>;
 
@@ -1725,8 +1724,9 @@ class open_addressing_ref_impl {
    * @return Result of this operation, i.e., success/continue/duplicate
    */
   template <typename Value>
-  [[nodiscard]] __device__ constexpr insert_result cas_dependent_write(
-    value_type* address, value_type const& expected, Value const& desired) noexcept
+  [[nodiscard]] __device__ constexpr insert_result cas_dependent_write(value_type* address,
+                                                                       value_type expected,
+                                                                       Value desired) noexcept
   {
     using mapped_type = cuda::std::decay_t<decltype(this->empty_value_sentinel())>;
 
@@ -1767,8 +1767,8 @@ class open_addressing_ref_impl {
    */
   template <typename Value>
   [[nodiscard]] __device__ insert_result attempt_insert(value_type* address,
-                                                        value_type const& expected,
-                                                        Value const& desired) noexcept
+                                                        value_type expected,
+                                                        Value desired) noexcept
   {
     if constexpr (sizeof(value_type) <= 8) {
       return packed_cas(address, expected, desired);
@@ -1800,8 +1800,8 @@ class open_addressing_ref_impl {
    */
   template <typename Value>
   [[nodiscard]] __device__ insert_result attempt_insert_stable(value_type* address,
-                                                               value_type const& expected,
-                                                               Value const& desired) noexcept
+                                                               value_type expected,
+                                                               Value desired) noexcept
   {
     if constexpr (sizeof(value_type) <= 8) {
       return packed_cas(address, expected, desired);
@@ -1822,7 +1822,7 @@ class open_addressing_ref_impl {
    * @param sentinel The slot sentinel value
    */
   template <typename T>
-  __device__ void wait_for_payload(T& slot, T const& sentinel) const noexcept
+  __device__ void wait_for_payload(T& slot, T sentinel) const noexcept
   {
     auto ref = cuda::atomic_ref<T, Scope>{slot};
     T current;

--- a/include/cuco/detail/probing_scheme/probing_scheme_impl.inl
+++ b/include/cuco/detail/probing_scheme/probing_scheme_impl.inl
@@ -107,7 +107,7 @@ __host__ __device__ constexpr auto linear_probing<CGSize, Hash>::rebind_hash_fun
 template <int32_t CGSize, typename Hash>
 template <int32_t BucketSize, typename ProbeKey, typename Extent>
 __host__ __device__ constexpr auto linear_probing<CGSize, Hash>::make_iterator(
-  ProbeKey const& probe_key, Extent upper_bound) const noexcept
+  ProbeKey probe_key, Extent upper_bound) const noexcept
 {
   using size_type      = typename Extent::value_type;
   size_type const init = cuco::detail::sanitize_hash<size_type>(hash_(probe_key)) %
@@ -119,7 +119,7 @@ template <int32_t CGSize, typename Hash>
 template <int32_t BucketSize, typename ProbeKey, typename Extent>
 __host__ __device__ constexpr auto linear_probing<CGSize, Hash>::make_iterator(
   cooperative_groups::thread_block_tile<cg_size> const& g,
-  ProbeKey const& probe_key,
+  ProbeKey probe_key,
   Extent upper_bound) const noexcept
 {
   using size_type            = typename Extent::value_type;
@@ -168,7 +168,7 @@ __host__ __device__ constexpr auto double_hashing<CGSize, Hash1, Hash2>::rebind_
 template <int32_t CGSize, typename Hash1, typename Hash2>
 template <int32_t BucketSize, typename ProbeKey, typename Extent>
 __host__ __device__ constexpr auto double_hashing<CGSize, Hash1, Hash2>::make_iterator(
-  ProbeKey const& probe_key, Extent upper_bound) const noexcept
+  ProbeKey probe_key, Extent upper_bound) const noexcept
 {
   using size_type = typename Extent::value_type;
   return detail::probing_iterator<Extent>{
@@ -185,7 +185,7 @@ template <int32_t CGSize, typename Hash1, typename Hash2>
 template <int32_t BucketSize, typename ProbeKey, typename Extent>
 __host__ __device__ constexpr auto double_hashing<CGSize, Hash1, Hash2>::make_iterator(
   cooperative_groups::thread_block_tile<cg_size> const& g,
-  ProbeKey const& probe_key,
+  ProbeKey probe_key,
   Extent upper_bound) const noexcept
 {
   int32_t const stride = cg_size * BucketSize;

--- a/include/cuco/detail/static_map/kernels.cuh
+++ b/include/cuco/detail/static_map/kernels.cuh
@@ -56,7 +56,7 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void insert_or_assign(InputIt first,
   auto idx               = cuco::detail::global_thread_id() / CGSize;
 
   while (idx < n) {
-    typename cuda::std::iterator_traits<InputIt>::value_type const& insert_pair = *(first + idx);
+    typename cuda::std::iterator_traits<InputIt>::value_type const insert_pair = *(first + idx);
     if constexpr (CGSize == 1) {
       ref.insert_or_assign(insert_pair);
     } else {
@@ -109,8 +109,8 @@ __global__ void insert_or_apply(
   auto idx               = cuco::detail::global_thread_id() / CGSize;
 
   while (idx < n) {
-    using value_type              = typename cuda::std::iterator_traits<InputIt>::value_type;
-    value_type const& insert_pair = *(first + idx);
+    using value_type             = typename cuda::std::iterator_traits<InputIt>::value_type;
+    value_type const insert_pair = *(first + idx);
     if constexpr (CGSize == 1) {
       if constexpr (HasInit) {
         ref.insert_or_apply(insert_pair, init, op);
@@ -215,7 +215,7 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void insert_or_apply_shmem(
     int32_t warp_cardinality = 0;
     // insert-or-apply into the shared map first
     if (idx < n) {
-      value_type const& insert_pair = *(first + idx);
+      value_type const insert_pair = *(first + idx);
       if constexpr (HasInit) {
         inserted = shared_map_ref.insert_or_apply(insert_pair, init, op);
       } else {
@@ -252,7 +252,7 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void insert_or_apply_shmem(
   if (block_cardinality > BlockSize) {
     idx += loop_stride;
     while (idx < n) {
-      value_type const& insert_pair = *(first + idx);
+      value_type const insert_pair = *(first + idx);
       if constexpr (HasInit) {
         ref.insert_or_apply(insert_pair, init, op);
       } else {

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -449,7 +449,7 @@ class operator_impl<
    * @return True if the given element is successfully inserted
    */
   template <typename Value>
-  __device__ bool insert(Value const& value) noexcept
+  __device__ bool insert(Value value) noexcept
   {
     ref_type& ref_ = static_cast<ref_type&>(*this);
     return ref_.impl_.insert(value);
@@ -467,7 +467,7 @@ class operator_impl<
    */
   template <typename Value>
   __device__ bool insert(cooperative_groups::thread_block_tile<cg_size> const& group,
-                         Value const& value) noexcept
+                         Value value) noexcept
   {
     auto& ref_ = static_cast<ref_type&>(*this);
     if (ref_.erased_key_sentinel() != ref_.empty_key_sentinel()) {
@@ -507,7 +507,7 @@ class operator_impl<
    * @param value The element to insert
    */
   template <typename Value>
-  __device__ void insert_or_assign(Value const& value) noexcept
+  __device__ void insert_or_assign(Value value) noexcept
   {
     static_assert(cg_size == 1, "Non-CG operation is incompatible with the current probing scheme");
 
@@ -558,7 +558,7 @@ class operator_impl<
    */
   template <typename Value>
   __device__ void insert_or_assign(cooperative_groups::thread_block_tile<cg_size> const& group,
-                                   Value const& value) noexcept
+                                   Value value) noexcept
   {
     ref_type& ref_ = static_cast<ref_type&>(*this);
 
@@ -630,7 +630,7 @@ class operator_impl<
    * @return Returns `true` if the given `value` is inserted or `value` has a match in the map.
    */
   template <typename Value>
-  __device__ constexpr bool attempt_insert_or_assign(value_type* slot, Value const& value) noexcept
+  __device__ constexpr bool attempt_insert_or_assign(value_type* slot, Value value) noexcept
   {
     ref_type& ref_    = static_cast<ref_type&>(*this);
     auto expected_key = ref_.impl_.empty_slot_sentinel().first;
@@ -688,7 +688,7 @@ class operator_impl<
    */
 
   template <typename Value, typename Op>
-  __device__ bool insert_or_apply(Value const& value, Op op)
+  __device__ bool insert_or_apply(Value value, Op op)
   {
     static_assert(cg_size == 1, "Non-CG operation is incompatible with the current probing scheme");
 
@@ -724,7 +724,7 @@ class operator_impl<
             typename Init,
             typename Op,
             typename = cuda::std::enable_if_t<std::is_convertible_v<Value, value_type>>>
-  __device__ bool insert_or_apply(Value const& value, Init init, Op op)
+  __device__ bool insert_or_apply(Value value, Init init, Op op)
   {
     static_assert(cg_size == 1, "Non-CG operation is incompatible with the current probing scheme");
 
@@ -755,7 +755,7 @@ class operator_impl<
 
   template <typename Value, typename Op>
   __device__ bool insert_or_apply(cooperative_groups::thread_block_tile<cg_size> const& group,
-                                  Value const& value,
+                                  Value value,
                                   Op op)
   {
     static_assert(
@@ -787,7 +787,7 @@ class operator_impl<
    */
   template <typename Value, typename Init, typename Op>
   __device__ bool insert_or_apply(cooperative_groups::thread_block_tile<cg_size> const& group,
-                                  Value const& value,
+                                  Value value,
                                   Init init,
                                   Op op)
   {
@@ -817,7 +817,7 @@ class operator_impl<
    * @return Returns `true` if the given `value` is inserted successfully.
    */
   template <typename Value, typename Init, typename Op>
-  __device__ bool dispatch_insert_or_apply(Value const& value, Init init, Op op)
+  __device__ bool dispatch_insert_or_apply(Value value, Init init, Op op)
   {
     ref_type& ref_ = static_cast<ref_type&>(*this);
     // if init equals sentinel value, then we can just `apply` op instead of write
@@ -845,10 +845,7 @@ class operator_impl<
    */
   template <typename Value, typename Init, typename Op>
   __device__ bool dispatch_insert_or_apply(
-    cooperative_groups::thread_block_tile<cg_size> const& group,
-    Value const& value,
-    Init init,
-    Op op)
+    cooperative_groups::thread_block_tile<cg_size> const& group, Value value, Init init, Op op)
   {
     ref_type& ref_ = static_cast<ref_type&>(*this);
     // if init equals sentinel value, then we can just `apply` op instead of write
@@ -878,7 +875,7 @@ class operator_impl<
    * @return Returns `true` if the given `value` is inserted successfully.
    */
   template <bool UseDirectApply, typename Value, typename Op>
-  __device__ bool insert_or_apply_impl(Value const& value, Op op)
+  __device__ bool insert_or_apply_impl(Value value, Op op)
   {
     ref_type& ref_ = static_cast<ref_type&>(*this);
 
@@ -955,7 +952,7 @@ class operator_impl<
    */
   template <bool UseDirectApply, typename Value, typename Op>
   __device__ bool insert_or_apply_impl(cooperative_groups::thread_block_tile<cg_size> const& group,
-                                       Value const& value,
+                                       Value value,
                                        Op op)
   {
     ref_type& ref_ = static_cast<ref_type&>(*this);
@@ -1050,10 +1047,8 @@ class operator_impl<
    *  and the element to insert.
    */
   template <bool UseDirectApply, typename Value, typename Op>
-  [[nodiscard]] __device__ insert_result attempt_insert_or_apply(value_type* address,
-                                                                 value_type const& expected,
-                                                                 Value const& desired,
-                                                                 Op op) noexcept
+  [[nodiscard]] __device__ insert_result
+  attempt_insert_or_apply(value_type* address, value_type expected, Value desired, Op op) noexcept
   {
     ref_type& ref_ = static_cast<ref_type&>(*this);
 
@@ -1128,7 +1123,7 @@ class operator_impl<
    * insertion is successful or not.
    */
   template <typename Value>
-  __device__ cuda::std::pair<iterator, bool> insert_and_find(Value const& value) noexcept
+  __device__ cuda::std::pair<iterator, bool> insert_and_find(Value value) noexcept
   {
     ref_type& ref_ = static_cast<ref_type&>(*this);
     return ref_.impl_.insert_and_find(value);
@@ -1151,7 +1146,7 @@ class operator_impl<
    */
   template <typename Value>
   __device__ cuda::std::pair<iterator, bool> insert_and_find(
-    cooperative_groups::thread_block_tile<cg_size> const& group, Value const& value) noexcept
+    cooperative_groups::thread_block_tile<cg_size> const& group, Value value) noexcept
   {
     ref_type& ref_ = static_cast<ref_type&>(*this);
     return ref_.impl_.insert_and_find(group, value);
@@ -1187,7 +1182,7 @@ class operator_impl<
    * @return True if the given element is successfully erased
    */
   template <typename ProbeKey>
-  __device__ bool erase(ProbeKey const& key) noexcept
+  __device__ bool erase(ProbeKey key) noexcept
   {
     ref_type& ref_ = static_cast<ref_type&>(*this);
     return ref_.impl_.erase(key);
@@ -1205,7 +1200,7 @@ class operator_impl<
    */
   template <typename ProbeKey>
   __device__ bool erase(cooperative_groups::thread_block_tile<cg_size> const& group,
-                        ProbeKey const& key) noexcept
+                        ProbeKey key) noexcept
   {
     auto& ref_ = static_cast<ref_type&>(*this);
     return ref_.impl_.erase(group, key);
@@ -1244,7 +1239,7 @@ class operator_impl<
    * @return A boolean indicating whether the probe key is present
    */
   template <typename ProbeKey>
-  [[nodiscard]] __device__ bool contains(ProbeKey const& key) const noexcept
+  [[nodiscard]] __device__ bool contains(ProbeKey key) const noexcept
   {
     // CRTP: cast `this` to the actual ref type
     auto const& ref_ = static_cast<ref_type const&>(*this);
@@ -1266,7 +1261,7 @@ class operator_impl<
    */
   template <typename ProbeKey>
   [[nodiscard]] __device__ bool contains(
-    cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey const& key) const noexcept
+    cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey key) const noexcept
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     return ref_.impl_.contains(group, key);
@@ -1307,7 +1302,7 @@ class operator_impl<
    * @return An iterator to the position at which the equivalent key is stored
    */
   template <typename ProbeKey>
-  [[nodiscard]] __device__ iterator find(ProbeKey const& key) const noexcept
+  [[nodiscard]] __device__ iterator find(ProbeKey key) const noexcept
   {
     // CRTP: cast `this` to the actual ref type
     auto const& ref_ = static_cast<ref_type const&>(*this);
@@ -1328,8 +1323,8 @@ class operator_impl<
    * @return An iterator to the position at which the equivalent key is stored
    */
   template <typename ProbeKey>
-  [[nodiscard]] __device__ iterator find(
-    cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey const& key) const noexcept
+  [[nodiscard]] __device__ iterator
+  find(cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey key) const noexcept
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     return ref_.impl_.find(group, key);
@@ -1370,7 +1365,7 @@ class operator_impl<
    * @param callback_op Function to apply to the copy of the matched key-value pair
    */
   template <class ProbeKey, class CallbackOp>
-  __device__ void for_each(ProbeKey const& key, CallbackOp&& callback_op) const noexcept
+  __device__ void for_each(ProbeKey key, CallbackOp&& callback_op) const noexcept
   {
     // CRTP: cast `this` to the actual ref type
     auto const& ref_ = static_cast<ref_type const&>(*this);
@@ -1397,7 +1392,7 @@ class operator_impl<
    */
   template <class ProbeKey, class CallbackOp>
   __device__ void for_each(cooperative_groups::thread_block_tile<cg_size> const& group,
-                           ProbeKey const& key,
+                           ProbeKey key,
                            CallbackOp&& callback_op) const noexcept
   {
     // CRTP: cast `this` to the actual ref type
@@ -1436,7 +1431,7 @@ class operator_impl<
    * @return Number of occurrences found by the current thread
    */
   template <typename ProbeKey>
-  __device__ size_type count(ProbeKey const& key) const noexcept
+  __device__ size_type count(ProbeKey key) const noexcept
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     return ref_.impl_.count(key);
@@ -1454,7 +1449,7 @@ class operator_impl<
    */
   template <typename ProbeKey>
   __device__ size_type count(cooperative_groups::thread_block_tile<cg_size> const& group,
-                             ProbeKey const& key) const noexcept
+                             ProbeKey key) const noexcept
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     return ref_.impl_.count(group, key);
@@ -1486,8 +1481,9 @@ class operator_impl<
    * @brief Retrieves all the slots corresponding to all keys in the range `[input_probe_begin,
    * input_probe_end)`.
    *
-   * If key `k = *(first + i)` exists in the container, copies `k` to `output_probe` and associated
-   * slot content to `output_match`, respectively. The output order is unspecified.
+   * If key `k = *(first + i)` exists in the container, copies `k` to `
+   * output_probe` and associated slot content to `output_match`, respectively. The output order is
+   * unspecified.
    *
    * Behavior is undefined if the size of the output range exceeds the number of retrieved slots.
    * Use `count()` to determine the size of the output range.

--- a/include/cuco/detail/static_multimap/static_multimap_ref.inl
+++ b/include/cuco/detail/static_multimap/static_multimap_ref.inl
@@ -454,7 +454,7 @@ class operator_impl<
    * @return True if the given element is successfully inserted
    */
   template <typename Value>
-  __device__ bool insert(Value const& value) noexcept
+  __device__ bool insert(Value value) noexcept
   {
     ref_type& ref_ = static_cast<ref_type&>(*this);
     return ref_.impl_.insert(value);
@@ -472,7 +472,7 @@ class operator_impl<
    */
   template <typename Value>
   __device__ bool insert(cooperative_groups::thread_block_tile<cg_size> const& group,
-                         Value const& value) noexcept
+                         Value value) noexcept
   {
     auto& ref_ = static_cast<ref_type&>(*this);
     if (!cuco::detail::bitwise_compare(ref_.erased_key_sentinel(), ref_.empty_key_sentinel())) {
@@ -516,7 +516,7 @@ class operator_impl<
    * @return A boolean indicating whether the probe key is present
    */
   template <typename ProbeKey>
-  [[nodiscard]] __device__ bool contains(ProbeKey const& key) const noexcept
+  [[nodiscard]] __device__ bool contains(ProbeKey key) const noexcept
   {
     // CRTP: cast `this` to the actual ref type
     auto const& ref_ = static_cast<ref_type const&>(*this);
@@ -538,7 +538,7 @@ class operator_impl<
    */
   template <typename ProbeKey>
   [[nodiscard]] __device__ bool contains(
-    cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey const& key) const noexcept
+    cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey key) const noexcept
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     return ref_.impl_.contains(group, key);
@@ -576,7 +576,7 @@ class operator_impl<
    * @param callback_op Function to call on every element found
    */
   template <class ProbeKey, class CallbackOp>
-  __device__ void for_each(ProbeKey const& key, CallbackOp&& callback_op) const noexcept
+  __device__ void for_each(ProbeKey key, CallbackOp&& callback_op) const noexcept
   {
     // CRTP: cast `this` to the actual ref type
     auto const& ref_ = static_cast<ref_type const&>(*this);
@@ -605,7 +605,7 @@ class operator_impl<
    */
   template <class ProbeKey, class CallbackOp>
   __device__ void for_each(cooperative_groups::thread_block_tile<cg_size> const& group,
-                           ProbeKey const& key,
+                           ProbeKey key,
                            CallbackOp&& callback_op) const noexcept
   {
     // CRTP: cast `this` to the actual ref type
@@ -643,7 +643,7 @@ class operator_impl<
    */
   template <class ProbeKey, class CallbackOp, class SyncOp>
   __device__ void for_each(cooperative_groups::thread_block_tile<cg_size> const& group,
-                           ProbeKey const& key,
+                           ProbeKey key,
                            CallbackOp&& callback_op,
                            SyncOp&& sync_op) const noexcept
   {
@@ -689,7 +689,7 @@ class operator_impl<
    * @return An iterator to the position at which the equivalent key is stored
    */
   template <typename ProbeKey>
-  [[nodiscard]] __device__ const_iterator find(ProbeKey const& key) const noexcept
+  [[nodiscard]] __device__ const_iterator find(ProbeKey key) const noexcept
   {
     // CRTP: cast `this` to the actual ref type
     auto const& ref_ = static_cast<ref_type const&>(*this);
@@ -710,8 +710,8 @@ class operator_impl<
    * @return An iterator to the position at which the equivalent key is stored
    */
   template <typename ProbeKey>
-  [[nodiscard]] __device__ const_iterator find(
-    cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey const& key) const noexcept
+  [[nodiscard]] __device__ const_iterator
+  find(cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey key) const noexcept
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     return ref_.impl_.find(group, key);
@@ -749,7 +749,7 @@ class operator_impl<
    * @return Number of occurrences found by the current thread
    */
   template <typename ProbeKey>
-  __device__ size_type count(ProbeKey const& key) const noexcept
+  __device__ size_type count(ProbeKey key) const noexcept
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     return ref_.impl_.count(key);
@@ -767,7 +767,7 @@ class operator_impl<
    */
   template <typename ProbeKey>
   __device__ size_type count(cooperative_groups::thread_block_tile<cg_size> const& group,
-                             ProbeKey const& key) const noexcept
+                             ProbeKey key) const noexcept
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     return ref_.impl_.count(group, key);

--- a/include/cuco/detail/static_multiset/static_multiset_ref.inl
+++ b/include/cuco/detail/static_multiset/static_multiset_ref.inl
@@ -393,7 +393,7 @@ class operator_impl<
    * @return True if the given element is successfully inserted
    */
   template <typename Value>
-  __device__ bool insert(Value const& value) noexcept
+  __device__ bool insert(Value value) noexcept
   {
     ref_type& ref_ = static_cast<ref_type&>(*this);
     return ref_.impl_.insert(value);
@@ -411,7 +411,7 @@ class operator_impl<
    */
   template <typename Value>
   __device__ bool insert(cooperative_groups::thread_block_tile<cg_size> const& group,
-                         Value const& value) noexcept
+                         Value value) noexcept
   {
     auto& ref_ = static_cast<ref_type&>(*this);
     if (!cuco::detail::bitwise_compare(ref_.erased_key_sentinel(), ref_.empty_key_sentinel())) {
@@ -451,7 +451,7 @@ class operator_impl<
    * @return A boolean indicating whether the probe key is present
    */
   template <typename ProbeKey>
-  [[nodiscard]] __device__ bool contains(ProbeKey const& key) const noexcept
+  [[nodiscard]] __device__ bool contains(ProbeKey key) const noexcept
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     return ref_.impl_.contains(key);
@@ -469,7 +469,7 @@ class operator_impl<
    */
   template <typename ProbeKey>
   [[nodiscard]] __device__ bool contains(
-    cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey const& key) const noexcept
+    cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey key) const noexcept
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     return ref_.impl_.contains(group, key);
@@ -510,7 +510,7 @@ class operator_impl<
    * @return An iterator to the position at which the equivalent key is stored
    */
   template <typename ProbeKey>
-  [[nodiscard]] __device__ const_iterator find(ProbeKey const& key) const noexcept
+  [[nodiscard]] __device__ const_iterator find(ProbeKey key) const noexcept
   {
     // CRTP: cast `this` to the actual ref type
     auto const& ref_ = static_cast<ref_type const&>(*this);
@@ -531,8 +531,8 @@ class operator_impl<
    * @return An iterator to the position at which the equivalent key is stored
    */
   template <typename ProbeKey>
-  [[nodiscard]] __device__ const_iterator find(
-    cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey const& key) const noexcept
+  [[nodiscard]] __device__ const_iterator
+  find(cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey key) const noexcept
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     return ref_.impl_.find(group, key);
@@ -686,7 +686,7 @@ class operator_impl<
    * @param callback_op Function to call on every element found
    */
   template <class ProbeKey, class CallbackOp>
-  __device__ void for_each(ProbeKey const& key, CallbackOp&& callback_op) const noexcept
+  __device__ void for_each(ProbeKey key, CallbackOp&& callback_op) const noexcept
   {
     // CRTP: cast `this` to the actual ref type
     auto const& ref_ = static_cast<ref_type const&>(*this);
@@ -715,7 +715,7 @@ class operator_impl<
    */
   template <class ProbeKey, class CallbackOp>
   __device__ void for_each(cooperative_groups::thread_block_tile<cg_size> const& group,
-                           ProbeKey const& key,
+                           ProbeKey key,
                            CallbackOp&& callback_op) const noexcept
   {
     // CRTP: cast `this` to the actual ref type
@@ -753,7 +753,7 @@ class operator_impl<
    */
   template <class ProbeKey, class CallbackOp, class SyncOp>
   __device__ void for_each(cooperative_groups::thread_block_tile<cg_size> const& group,
-                           ProbeKey const& key,
+                           ProbeKey key,
                            CallbackOp&& callback_op,
                            SyncOp&& sync_op) const noexcept
   {
@@ -794,7 +794,7 @@ class operator_impl<
    * @return Number of occurrences found by the current thread
    */
   template <typename ProbeKey>
-  __device__ size_type count(ProbeKey const& key) const noexcept
+  __device__ size_type count(ProbeKey key) const noexcept
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     return ref_.impl_.count(key);
@@ -812,7 +812,7 @@ class operator_impl<
    */
   template <typename ProbeKey>
   __device__ size_type count(cooperative_groups::thread_block_tile<cg_size> const& group,
-                             ProbeKey const& key) const noexcept
+                             ProbeKey key) const noexcept
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     return ref_.impl_.count(group, key);

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -388,7 +388,7 @@ class operator_impl<op::insert_tag,
    * @return True if the given element is successfully inserted
    */
   template <typename Value>
-  __device__ bool insert(Value const& value) noexcept
+  __device__ bool insert(Value value) noexcept
   {
     ref_type& ref_ = static_cast<ref_type&>(*this);
     return ref_.impl_.insert(value);
@@ -406,7 +406,7 @@ class operator_impl<op::insert_tag,
    */
   template <typename Value>
   __device__ bool insert(cooperative_groups::thread_block_tile<cg_size> const& group,
-                         Value const& value) noexcept
+                         Value value) noexcept
   {
     auto& ref_ = static_cast<ref_type&>(*this);
     if (ref_.erased_key_sentinel() != ref_.empty_key_sentinel()) {
@@ -451,7 +451,7 @@ class operator_impl<op::insert_and_find_tag,
    * insertion is successful or not.
    */
   template <typename Value>
-  __device__ cuda::std::pair<iterator, bool> insert_and_find(Value const& value) noexcept
+  __device__ cuda::std::pair<iterator, bool> insert_and_find(Value value) noexcept
   {
     ref_type& ref_ = static_cast<ref_type&>(*this);
     return ref_.impl_.insert_and_find(value);
@@ -474,7 +474,7 @@ class operator_impl<op::insert_and_find_tag,
    */
   template <typename Value>
   __device__ cuda::std::pair<iterator, bool> insert_and_find(
-    cooperative_groups::thread_block_tile<cg_size> const& group, Value const& value) noexcept
+    cooperative_groups::thread_block_tile<cg_size> const& group, Value value) noexcept
   {
     ref_type& ref_ = static_cast<ref_type&>(*this);
     return ref_.impl_.insert_and_find(group, value);
@@ -508,7 +508,7 @@ class operator_impl<op::erase_tag,
    * @return True if the given element is successfully erased
    */
   template <typename ProbeKey>
-  __device__ bool erase(ProbeKey const& key) noexcept
+  __device__ bool erase(ProbeKey key) noexcept
   {
     ref_type& ref_ = static_cast<ref_type&>(*this);
     return ref_.impl_.erase(key);
@@ -526,7 +526,7 @@ class operator_impl<op::erase_tag,
    */
   template <typename ProbeKey>
   __device__ bool erase(cooperative_groups::thread_block_tile<cg_size> const& group,
-                        ProbeKey const& key) noexcept
+                        ProbeKey key) noexcept
   {
     auto& ref_ = static_cast<ref_type&>(*this);
     return ref_.impl_.erase(group, key);
@@ -563,7 +563,7 @@ class operator_impl<op::contains_tag,
    * @return A boolean indicating whether the probe key is present
    */
   template <typename ProbeKey>
-  [[nodiscard]] __device__ bool contains(ProbeKey const& key) const noexcept
+  [[nodiscard]] __device__ bool contains(ProbeKey key) const noexcept
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     return ref_.impl_.contains(key);
@@ -584,7 +584,7 @@ class operator_impl<op::contains_tag,
    */
   template <typename ProbeKey>
   [[nodiscard]] __device__ bool contains(
-    cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey const& key) const noexcept
+    cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey key) const noexcept
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     return ref_.impl_.contains(group, key);
@@ -623,7 +623,7 @@ class operator_impl<op::find_tag,
    * @return An iterator to the position at which the equivalent key is stored
    */
   template <typename ProbeKey>
-  [[nodiscard]] __device__ const_iterator find(ProbeKey const& key) const noexcept
+  [[nodiscard]] __device__ const_iterator find(ProbeKey key) const noexcept
   {
     // CRTP: cast `this` to the actual ref type
     auto const& ref_ = static_cast<ref_type const&>(*this);
@@ -644,8 +644,8 @@ class operator_impl<op::find_tag,
    * @return An iterator to the position at which the equivalent key is stored
    */
   template <typename ProbeKey>
-  [[nodiscard]] __device__ const_iterator find(
-    cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey const& key) const noexcept
+  [[nodiscard]] __device__ const_iterator
+  find(cooperative_groups::thread_block_tile<cg_size> const& group, ProbeKey key) const noexcept
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     return ref_.impl_.find(group, key);
@@ -684,7 +684,7 @@ class operator_impl<op::for_each_tag,
    * @param callback_op Function to apply to the copy of the matched slot
    */
   template <class ProbeKey, class CallbackOp>
-  __device__ void for_each(ProbeKey const& key, CallbackOp&& callback_op) const noexcept
+  __device__ void for_each(ProbeKey key, CallbackOp&& callback_op) const noexcept
   {
     // CRTP: cast `this` to the actual ref type
     auto const& ref_ = static_cast<ref_type const&>(*this);
@@ -711,7 +711,7 @@ class operator_impl<op::for_each_tag,
    */
   template <class ProbeKey, class CallbackOp>
   __device__ void for_each(cooperative_groups::thread_block_tile<cg_size> const& group,
-                           ProbeKey const& key,
+                           ProbeKey key,
                            CallbackOp&& callback_op) const noexcept
   {
     // CRTP: cast `this` to the actual ref type
@@ -748,7 +748,7 @@ class operator_impl<op::count_tag,
    * @return Number of occurrences found by the current thread
    */
   template <typename ProbeKey>
-  __device__ size_type count(ProbeKey const& key) const noexcept
+  __device__ size_type count(ProbeKey key) const noexcept
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     return ref_.impl_.count(key);
@@ -766,7 +766,7 @@ class operator_impl<op::count_tag,
    */
   template <typename ProbeKey>
   __device__ size_type count(cooperative_groups::thread_block_tile<cg_size> const& group,
-                             ProbeKey const& key) const noexcept
+                             ProbeKey key) const noexcept
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
     return ref_.impl_.count(group, key);

--- a/include/cuco/probing_scheme.cuh
+++ b/include/cuco/probing_scheme.cuh
@@ -77,7 +77,7 @@ class linear_probing : private detail::probing_scheme_base<CGSize> {
    * @return An iterator whose value_type is convertible to slot index type
    */
   template <int32_t BucketSize, typename ProbeKey, typename Extent>
-  __host__ __device__ constexpr auto make_iterator(ProbeKey const& probe_key,
+  __host__ __device__ constexpr auto make_iterator(ProbeKey probe_key,
                                                    Extent upper_bound) const noexcept;
 
   /**
@@ -95,7 +95,7 @@ class linear_probing : private detail::probing_scheme_base<CGSize> {
   template <int32_t BucketSize, typename ProbeKey, typename Extent>
   __host__ __device__ constexpr auto make_iterator(
     cooperative_groups::thread_block_tile<cg_size> const& g,
-    ProbeKey const& probe_key,
+    ProbeKey probe_key,
     Extent upper_bound) const noexcept;
 
   /**
@@ -174,7 +174,7 @@ class double_hashing : private detail::probing_scheme_base<CGSize> {
    * @return An iterator whose value_type is convertible to slot index type
    */
   template <int32_t BucketSize, typename ProbeKey, typename Extent>
-  __host__ __device__ constexpr auto make_iterator(ProbeKey const& probe_key,
+  __host__ __device__ constexpr auto make_iterator(ProbeKey probe_key,
                                                    Extent upper_bound) const noexcept;
 
   /**
@@ -192,7 +192,7 @@ class double_hashing : private detail::probing_scheme_base<CGSize> {
   template <int32_t BucketSize, typename ProbeKey, typename Extent>
   __host__ __device__ constexpr auto make_iterator(
     cooperative_groups::thread_block_tile<cg_size> const& g,
-    ProbeKey const& probe_key,
+    ProbeKey probe_key,
     Extent upper_bound) const noexcept;
 
   /**


### PR DESCRIPTION
This PR changes trivial types to be passed by value rather than by const reference, reducing register usage. In the mixed join size kernel, compiling with `-Xptxas -v` shows that this change reduces spill loads from ~300 bytes to ~100 bytes, resulting in about a 7% performance gain on my local RTX8000 (sm_75) GPUs.
