### PR TITLE
Add device `retrieve_if` for all fixed-size hash tables 

### DIFF
--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -28,6 +28,7 @@
 #include <cuda/std/iterator>
 #include <cuda/std/type_traits>
 #include <thrust/execution_policy.h>
+#include <thrust/iterator/constant_iterator.h>
 #include <thrust/logical.h>
 #include <thrust/reduce.h>
 #if defined(CUCO_HAS_CUDA_BARRIER)
@@ -1085,8 +1086,16 @@ class open_addressing_ref_impl {
   {
     auto constexpr is_outer = false;
     auto const n = cuco::detail::distance(input_probe_begin, input_probe_end);  // TODO include
-    this->retrieve_impl<is_outer, BlockSize>(
-      block, input_probe_begin, n, output_probe, output_match, atomic_counter);
+    auto const always_true_stencil = thrust::constant_iterator<bool>(true);
+    auto const identity_predicate  = cuda::std::identity{};
+    this->retrieve_impl<is_outer, BlockSize>(block,
+                                             input_probe_begin,
+                                             n,
+                                             always_true_stencil,
+                                             identity_predicate,
+                                             output_probe,
+                                             output_match,
+                                             atomic_counter);
   }
 
   /**
@@ -1134,8 +1143,74 @@ class open_addressing_ref_impl {
   {
     auto constexpr is_outer = true;
     auto const n = cuco::detail::distance(input_probe_begin, input_probe_end);  // TODO include
-    this->retrieve_impl<is_outer, BlockSize>(
-      block, input_probe_begin, n, output_probe, output_match, atomic_counter);
+    auto const always_true_stencil = thrust::constant_iterator<bool>(true);
+    auto const identity_predicate  = cuda::std::identity{};
+    this->retrieve_impl<is_outer, BlockSize>(block,
+                                             input_probe_begin,
+                                             n,
+                                             always_true_stencil,
+                                             identity_predicate,
+                                             output_probe,
+                                             output_match,
+                                             atomic_counter);
+  }
+
+  /**
+   * @brief Retrieves all the slots corresponding to all keys in the range `[input_probe_begin,
+   * input_probe_end)` if `pred` of the corresponding stencil returns true.
+   *
+   * If key `k = *(first + i)` exists in the container and `pred( *(stencil + i) )` returns true,
+   * copies `k` to `output_probe` and associated slot contents to `output_match`,
+   * respectively. The output order is unspecified.
+   *
+   * Behavior is undefined if the size of the output range exceeds the number of retrieved slots.
+   * Use `count()` to determine the size of the output range.
+   *
+   * @tparam IsOuter Flag indicating if an inner or outer retrieve operation should be performed
+   * @tparam BlockSize Size of the thread block this operation is executed in
+   * @tparam InputProbeIt Device accessible input iterator
+   * @tparam StencilIt Device accessible random access iterator whose value_type is
+   * convertible to Predicate's argument type
+   * @tparam Predicate Unary predicate callable whose return type must be convertible to `bool`
+   * and argument type is convertible from `std::iterator_traits<StencilIt>::value_type`
+   * @tparam OutputProbeIt Device accessible input iterator whose `value_type` is
+   * convertible to the `InputProbeIt`'s `value_type`
+   * @tparam OutputMatchIt Device accessible input iterator whose `value_type` is
+   * convertible to the container's `value_type`
+   * @tparam AtomicCounter Integral atomic counter type that follows the same semantics as
+   * `cuda::(std::)atomic(_ref)`
+   *
+   * @param block Thread block this operation is executed in
+   * @param input_probe_begin Beginning of the input sequence of keys
+   * @param input_probe_end End of the input sequence of keys
+   * @param stencil Beginning of the stencil sequence
+   * @param pred Predicate to test on every element in the range `[stencil, stencil + n)`
+   * @param output_probe Beginning of the sequence of keys corresponding to matching elements in
+   * `output_match`
+   * @param output_match Beginning of the sequence of matching elements
+   * @param atomic_counter Atomic object of integral type that is used to count the
+   * number of output elements
+   */
+  template <bool IsOuter,
+            int32_t BlockSize,
+            class InputProbeIt,
+            class StencilIt,
+            class Predicate,
+            class OutputProbeIt,
+            class OutputMatchIt,
+            class AtomicCounter>
+  __device__ void retrieve_if(cooperative_groups::thread_block const& block,
+                              InputProbeIt input_probe_begin,
+                              InputProbeIt input_probe_end,
+                              StencilIt stencil,
+                              Predicate pred,
+                              OutputProbeIt output_probe,
+                              OutputMatchIt output_match,
+                              AtomicCounter& atomic_counter) const
+  {
+    auto const n = cuco::detail::distance(input_probe_begin, input_probe_end);
+    this->retrieve_impl<IsOuter, BlockSize>(
+      block, input_probe_begin, n, stencil, pred, output_probe, output_match, atomic_counter);
   }
 
   /**
@@ -1154,6 +1229,10 @@ class open_addressing_ref_impl {
    * @tparam IsOuter Flag indicating if an inner or outer retrieve operation should be performed
    * @tparam BlockSize Size of the thread block this operation is executed in
    * @tparam InputProbeIt Device accessible input iterator
+   * @tparam StencilIt Device accessible random access iterator whose value_type is
+   * convertible to Predicate's argument type
+   * @tparam Predicate Unary predicate callable whose return type must be convertible to `bool`
+   * and argument type is convertible from `std::iterator_traits<StencilIt>::value_type`
    * @tparam OutputProbeIt Device accessible input iterator whose `value_type` is
    * convertible to the `InputProbeIt`'s `value_type`
    * @tparam OutputMatchIt Device accessible input iterator whose `value_type` is
@@ -1162,8 +1241,10 @@ class open_addressing_ref_impl {
    * `cuda::(std::)atomic(_ref)`
    *
    * @param block Thread block this operation is executed in
-   * @param input_probe_begin Beginning of the input sequence of keys
-   * @param input_probe_end End of the input sequence of keys
+   * @param input_probe Beginning of the input sequence of keys
+   * @param n Number of input keys
+   * @param stencil Beginning of the stencil sequence
+   * @param pred Predicate to test on every element in the range `[stencil, stencil + n)`
    * @param output_probe Beginning of the sequence of keys corresponding to matching elements in
    * `output_match`
    * @param output_match Beginning of the sequence of matching elements
@@ -1173,12 +1254,16 @@ class open_addressing_ref_impl {
   template <bool IsOuter,
             int32_t BlockSize,
             class InputProbeIt,
+            class StencilIt,
+            class Predicate,
             class OutputProbeIt,
             class OutputMatchIt,
             class AtomicCounter>
   __device__ void retrieve_impl(cooperative_groups::thread_block const& block,
                                 InputProbeIt input_probe,
                                 cuco::detail::index_type n,
+                                StencilIt stencil,
+                                Predicate pred,
                                 OutputProbeIt output_probe,
                                 OutputMatchIt output_match,
                                 AtomicCounter& atomic_counter) const
@@ -1236,8 +1321,11 @@ class open_addressing_ref_impl {
       if (active_flag) {
         // perform probing
         // make sure the flushing_tile is converged at this point to get a coalesced load
-        auto const probe_key = *(input_probe + idx);
-        auto probing_iter    = probing_scheme_.template make_iterator<bucket_size>(
+        auto const probe_key       = *(input_probe + idx);
+        auto const predicate_value = pred(*(stencil + idx));
+        // TODO: skip probing if predicate_value is false
+
+        auto probing_iter = probing_scheme_.template make_iterator<bucket_size>(
           probing_tile, probe_key, storage_ref_.extent());
         auto const init_idx = *probing_iter;
 

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -1166,7 +1166,6 @@ class open_addressing_ref_impl {
    * Behavior is undefined if the size of the output range exceeds the number of retrieved slots.
    * Use `count()` to determine the size of the output range.
    *
-   * @tparam IsOuter Flag indicating if an inner or outer retrieve operation should be performed
    * @tparam BlockSize Size of the thread block this operation is executed in
    * @tparam InputProbeIt Device accessible input iterator
    * @tparam StencilIt Device accessible random access iterator whose value_type is
@@ -1191,8 +1190,7 @@ class open_addressing_ref_impl {
    * @param atomic_counter Atomic object of integral type that is used to count the
    * number of output elements
    */
-  template <bool IsOuter,
-            int32_t BlockSize,
+  template <int BlockSize,
             class InputProbeIt,
             class StencilIt,
             class Predicate,
@@ -1208,8 +1206,9 @@ class open_addressing_ref_impl {
                               OutputMatchIt output_match,
                               AtomicCounter& atomic_counter) const
   {
-    auto const n = cuco::detail::distance(input_probe_begin, input_probe_end);
-    this->retrieve_impl<IsOuter, BlockSize>(
+    auto constexpr is_outer = false;
+    auto const n            = cuco::detail::distance(input_probe_begin, input_probe_end);
+    this->retrieve_impl<is_outer, BlockSize>(
       block, input_probe_begin, n, stencil, pred, output_probe, output_match, atomic_counter);
   }
 
@@ -1314,16 +1313,14 @@ class open_addressing_ref_impl {
     };
 
     while (flushing_tile.any(idx < n)) {
-      bool active_flag = idx < n;
+      bool active_flag = idx < n and pred(*(stencil + idx));
       auto const active_flushing_tile =
         cg::binary_partition<flushing_tile_size>(flushing_tile, active_flag);
 
       if (active_flag) {
         // perform probing
         // make sure the flushing_tile is converged at this point to get a coalesced load
-        auto const probe_key       = *(input_probe + idx);
-        auto const predicate_value = pred(*(stencil + idx));
-        // TODO: skip probing if predicate_value is false
+        auto const probe_key = *(input_probe + idx);
 
         auto probing_iter = probing_scheme_.template make_iterator<bucket_size>(
           probing_tile, probe_key, storage_ref_.extent());

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -1571,7 +1571,7 @@ class operator_impl<
    * @param atomic_counter Counter that is used to determine the next free position in the output
    * sequences
    */
-  template <int32_t BlockSize,
+  template <int BlockSize,
             class InputProbeIt,
             class StencilIt,
             class Predicate,

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -1535,5 +1535,6 @@ class operator_impl<
       block, input_probe_begin, input_probe_end, output_probe, output_match, atomic_counter);
   }
 };
+
 }  // namespace detail
 }  // namespace cuco

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -1534,6 +1534,69 @@ class operator_impl<
     ref_.impl_.template retrieve<BlockSize>(
       block, input_probe_begin, input_probe_end, output_probe, output_match, atomic_counter);
   }
+
+  /**
+   * @brief Retrieves all the slots corresponding to all keys in the range `[input_probe_begin,
+   * input_probe_end)` if `pred` of the corresponding stencil returns true.
+   *
+   * If key `k = *(first + i)` exists in the container and `pred( *(stencil + i) )` returns true,
+   * copies `k` to `output_probe` and associated slot content to `output_match`, respectively.
+   * The output order is unspecified.
+   *
+   * Behavior is undefined if the size of the output range exceeds the number of retrieved slots.
+   * Use `count()` to determine the size of the output range.
+   *
+   * @tparam BlockSize Size of the thread block this operation is executed in
+   * @tparam InputProbeIt Device accessible input iterator whose `value_type` is
+   * convertible to the container's `key_type`
+   * @tparam StencilIt Device accessible random access iterator whose value_type is
+   * convertible to Predicate's argument type
+   * @tparam Predicate Unary predicate callable whose return type must be convertible to `bool`
+   * and argument type is convertible from `std::iterator_traits<StencilIt>::value_type`
+   * @tparam OutputProbeIt Device accessible input iterator whose `value_type` is
+   * convertible to the container's `key_type`
+   * @tparam OutputMatchIt Device accessible input iterator whose `value_type` is
+   * convertible to the container's `value_type`
+   * @tparam AtomicCounter Atomic counter type that follows the same semantics as
+   * `cuda::atomic(_ref)`
+   *
+   * @param block Thread block this operation is executed in
+   * @param input_probe_begin Beginning of the input sequence of keys
+   * @param input_probe_end End of the input sequence of keys
+   * @param stencil Beginning of the stencil sequence
+   * @param pred Predicate to test on every element in the range `[stencil, stencil + n)`
+   * @param output_probe Beginning of the sequence of keys corresponding to matching elements in
+   * `output_match`
+   * @param output_match Beginning of the sequence of matching elements
+   * @param atomic_counter Counter that is used to determine the next free position in the output
+   * sequences
+   */
+  template <int32_t BlockSize,
+            class InputProbeIt,
+            class StencilIt,
+            class Predicate,
+            class OutputProbeIt,
+            class OutputMatchIt,
+            class AtomicCounter>
+  __device__ void retrieve_if(cooperative_groups::thread_block const& block,
+                              InputProbeIt input_probe_begin,
+                              InputProbeIt input_probe_end,
+                              StencilIt stencil,
+                              Predicate pred,
+                              OutputProbeIt output_probe,
+                              OutputMatchIt output_match,
+                              AtomicCounter& atomic_counter) const
+  {
+    auto const& ref_ = static_cast<ref_type const&>(*this);
+    ref_.impl_.template retrieve_if<BlockSize>(block,
+                                               input_probe_begin,
+                                               input_probe_end,
+                                               stencil,
+                                               pred,
+                                               output_probe,
+                                               output_match,
+                                               atomic_counter);
+  }
 };
 
 }  // namespace detail

--- a/include/cuco/detail/static_multimap/static_multimap_ref.inl
+++ b/include/cuco/detail/static_multimap/static_multimap_ref.inl
@@ -845,41 +845,7 @@ class operator_impl<
     ref_.impl_.template retrieve<BlockSize>(
       block, input_probe_begin, input_probe_end, output_probe, output_match, atomic_counter);
   }
-};
 
-/**
- * @brief Mixin to augment `static_multimap_ref` with `retrieve_if` operator
- *
- * @tparam Key Key type
- * @tparam T Mapped type
- * @tparam Scope The scope in which operations will be performed by individual threads.
- * @tparam KeyEqual Binary callable type used to compare two keys for equality
- * @tparam ProbingScheme Probing scheme (see `include/cuco/probing_scheme.cuh` for options)
- * @tparam StorageRef Storage ref type
- * @tparam Operators List of operators provided by the ref
- */
-template <typename Key,
-          typename T,
-          cuda::thread_scope Scope,
-          typename KeyEqual,
-          typename ProbingScheme,
-          typename StorageRef,
-          typename... Operators>
-class operator_impl<
-  op::retrieve_if_tag,
-  static_multimap_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>> {
-  using base_type = static_multimap_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef>;
-  using ref_type =
-    static_multimap_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>;
-  using key_type       = typename base_type::key_type;
-  using value_type     = typename base_type::value_type;
-  using iterator       = typename base_type::iterator;
-  using const_iterator = typename base_type::const_iterator;
-
-  static constexpr auto cg_size     = base_type::cg_size;
-  static constexpr auto bucket_size = base_type::bucket_size;
-
- public:
   /**
    * @brief Retrieves all the slots corresponding to all keys in the range `[input_probe_begin,
    * input_probe_end)` if `pred` of the corresponding stencil returns true.
@@ -891,7 +857,6 @@ class operator_impl<
    * Behavior is undefined if the size of the output range exceeds the number of retrieved slots.
    * Use `count()` to determine the size of the output range.
    *
-   * @tparam IsOuter Flag indicating if an inner or outer retrieve operation should be performed
    * @tparam BlockSize Size of the thread block this operation is executed in
    * @tparam InputProbeIt Device accessible input iterator whose `value_type` is
    * convertible to the container's `key_type`
@@ -917,8 +882,7 @@ class operator_impl<
    * @param atomic_counter Counter that is used to determine the next free position in the output
    * sequences
    */
-  template <bool IsOuter,
-            int32_t BlockSize,
+  template <int32_t BlockSize,
             class InputProbeIt,
             class StencilIt,
             class Predicate,
@@ -935,14 +899,14 @@ class operator_impl<
                               AtomicCounter& atomic_counter) const
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
-    ref_.impl_.template retrieve_if<IsOuter, BlockSize>(block,
-                                                        input_probe_begin,
-                                                        input_probe_end,
-                                                        stencil,
-                                                        pred,
-                                                        output_probe,
-                                                        output_match,
-                                                        atomic_counter);
+    ref_.impl_.template retrieve_if<BlockSize>(block,
+                                               input_probe_begin,
+                                               input_probe_end,
+                                               stencil,
+                                               pred,
+                                               output_probe,
+                                               output_match,
+                                               atomic_counter);
   }
 };
 }  // namespace detail

--- a/include/cuco/detail/static_multimap/static_multimap_ref.inl
+++ b/include/cuco/detail/static_multimap/static_multimap_ref.inl
@@ -882,7 +882,7 @@ class operator_impl<
    * @param atomic_counter Counter that is used to determine the next free position in the output
    * sequences
    */
-  template <int32_t BlockSize,
+  template <int BlockSize,
             class InputProbeIt,
             class StencilIt,
             class Predicate,

--- a/include/cuco/detail/static_multimap/static_multimap_ref.inl
+++ b/include/cuco/detail/static_multimap/static_multimap_ref.inl
@@ -846,5 +846,104 @@ class operator_impl<
       block, input_probe_begin, input_probe_end, output_probe, output_match, atomic_counter);
   }
 };
+
+/**
+ * @brief Mixin to augment `static_multimap_ref` with `retrieve_if` operator
+ *
+ * @tparam Key Key type
+ * @tparam T Mapped type
+ * @tparam Scope The scope in which operations will be performed by individual threads.
+ * @tparam KeyEqual Binary callable type used to compare two keys for equality
+ * @tparam ProbingScheme Probing scheme (see `include/cuco/probing_scheme.cuh` for options)
+ * @tparam StorageRef Storage ref type
+ * @tparam Operators List of operators provided by the ref
+ */
+template <typename Key,
+          typename T,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
+class operator_impl<
+  op::retrieve_if_tag,
+  static_multimap_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>> {
+  using base_type = static_multimap_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef>;
+  using ref_type =
+    static_multimap_ref<Key, T, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>;
+  using key_type       = typename base_type::key_type;
+  using value_type     = typename base_type::value_type;
+  using iterator       = typename base_type::iterator;
+  using const_iterator = typename base_type::const_iterator;
+
+  static constexpr auto cg_size     = base_type::cg_size;
+  static constexpr auto bucket_size = base_type::bucket_size;
+
+ public:
+  /**
+   * @brief Retrieves all the slots corresponding to all keys in the range `[input_probe_begin,
+   * input_probe_end)` if `pred` of the corresponding stencil returns true.
+   *
+   * If key `k = *(first + i)` exists in the container and `pred( *(stencil + i) )` returns true,
+   * copies `k` to `output_probe` and associated slot content to `output_match`, respectively.
+   * The output order is unspecified.
+   *
+   * Behavior is undefined if the size of the output range exceeds the number of retrieved slots.
+   * Use `count()` to determine the size of the output range.
+   *
+   * @tparam IsOuter Flag indicating if an inner or outer retrieve operation should be performed
+   * @tparam BlockSize Size of the thread block this operation is executed in
+   * @tparam InputProbeIt Device accessible input iterator whose `value_type` is
+   * convertible to the container's `key_type`
+   * @tparam StencilIt Device accessible random access iterator whose value_type is
+   * convertible to Predicate's argument type
+   * @tparam Predicate Unary predicate callable whose return type must be convertible to `bool`
+   * and argument type is convertible from `std::iterator_traits<StencilIt>::value_type`
+   * @tparam OutputProbeIt Device accessible input iterator whose `value_type` is
+   * convertible to the container's `key_type`
+   * @tparam OutputMatchIt Device accessible input iterator whose `value_type` is
+   * convertible to the container's `value_type`
+   * @tparam AtomicCounter Atomic counter type that follows the same semantics as
+   * `cuda::atomic(_ref)`
+   *
+   * @param block Thread block this operation is executed in
+   * @param input_probe_begin Beginning of the input sequence of keys
+   * @param input_probe_end End of the input sequence of keys
+   * @param stencil Beginning of the stencil sequence
+   * @param pred Predicate to test on every element in the range `[stencil, stencil + n)`
+   * @param output_probe Beginning of the sequence of keys corresponding to matching elements in
+   * `output_match`
+   * @param output_match Beginning of the sequence of matching elements
+   * @param atomic_counter Counter that is used to determine the next free position in the output
+   * sequences
+   */
+  template <bool IsOuter,
+            int32_t BlockSize,
+            class InputProbeIt,
+            class StencilIt,
+            class Predicate,
+            class OutputProbeIt,
+            class OutputMatchIt,
+            class AtomicCounter>
+  __device__ void retrieve_if(cooperative_groups::thread_block const& block,
+                              InputProbeIt input_probe_begin,
+                              InputProbeIt input_probe_end,
+                              StencilIt stencil,
+                              Predicate pred,
+                              OutputProbeIt output_probe,
+                              OutputMatchIt output_match,
+                              AtomicCounter& atomic_counter) const
+  {
+    auto const& ref_ = static_cast<ref_type const&>(*this);
+    ref_.impl_.template retrieve_if<IsOuter, BlockSize>(block,
+                                                        input_probe_begin,
+                                                        input_probe_end,
+                                                        stencil,
+                                                        pred,
+                                                        output_probe,
+                                                        output_match,
+                                                        atomic_counter);
+  }
+};
 }  // namespace detail
 }  // namespace cuco

--- a/include/cuco/detail/static_multiset/static_multiset_ref.inl
+++ b/include/cuco/detail/static_multiset/static_multiset_ref.inl
@@ -657,6 +657,103 @@ class operator_impl<
   }
 };
 
+/**
+ * @brief Mixin to augment `static_multiset_ref` with `retrieve_if` operator
+ *
+ * @tparam Key Key type
+ * @tparam Scope The scope in which operations will be performed by individual threads.
+ * @tparam KeyEqual Binary callable type used to compare two keys for equality
+ * @tparam ProbingScheme Probing scheme (see `include/cuco/probing_scheme.cuh` for options)
+ * @tparam StorageRef Storage ref type
+ * @tparam Operators List of operators provided by the ref
+ */
+template <typename Key,
+          cuda::thread_scope Scope,
+          typename KeyEqual,
+          typename ProbingScheme,
+          typename StorageRef,
+          typename... Operators>
+class operator_impl<
+  op::retrieve_if_tag,
+  static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>> {
+  using base_type = static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef>;
+  using ref_type =
+    static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>;
+  using key_type       = typename base_type::key_type;
+  using value_type     = typename base_type::value_type;
+  using iterator       = typename base_type::iterator;
+  using const_iterator = typename base_type::const_iterator;
+
+  static constexpr auto cg_size     = base_type::cg_size;
+  static constexpr auto bucket_size = base_type::bucket_size;
+
+ public:
+  /**
+   * @brief Retrieves all the slots corresponding to all keys in the range `[input_probe_begin,
+   * input_probe_end)` if `pred` of the corresponding stencil returns true.
+   *
+   * If key `k = *(first + i)` exists in the container and `pred( *(stencil + i) )` returns true,
+   * copies `k` to `output_probe` and associated slot content to `output_match`, respectively.
+   * The output order is unspecified.
+   *
+   * Behavior is undefined if the size of the output range exceeds the number of retrieved slots.
+   * Use `count()` to determine the size of the output range.
+   *
+   * @tparam IsOuter Flag indicating if an inner or outer retrieve operation should be performed
+   * @tparam BlockSize Size of the thread block this operation is executed in
+   * @tparam InputProbeIt Device accessible input iterator whose `value_type` is
+   * convertible to the container's `key_type`
+   * @tparam StencilIt Device accessible random access iterator whose value_type is
+   * convertible to Predicate's argument type
+   * @tparam Predicate Unary predicate callable whose return type must be convertible to `bool`
+   * and argument type is convertible from `std::iterator_traits<StencilIt>::value_type`
+   * @tparam OutputProbeIt Device accessible input iterator whose `value_type` is
+   * convertible to the container's `key_type`
+   * @tparam OutputMatchIt Device accessible input iterator whose `value_type` is
+   * convertible to the container's `value_type`
+   * @tparam AtomicCounter Atomic counter type that follows the same semantics as
+   * `cuda::atomic(_ref)`
+   *
+   * @param block Thread block this operation is executed in
+   * @param input_probe_begin Beginning of the input sequence of keys
+   * @param input_probe_end End of the input sequence of keys
+   * @param stencil Beginning of the stencil sequence
+   * @param pred Predicate to test on every element in the range `[stencil, stencil + n)`
+   * @param output_probe Beginning of the sequence of keys corresponding to matching elements in
+   * `output_match`
+   * @param output_match Beginning of the sequence of matching elements
+   * @param atomic_counter Counter that is used to determine the next free position in the output
+   * sequences
+   */
+  template <bool IsOuter,
+            int32_t BlockSize,
+            class InputProbeIt,
+            class StencilIt,
+            class Predicate,
+            class OutputProbeIt,
+            class OutputMatchIt,
+            class AtomicCounter>
+  __device__ void retrieve_if(cooperative_groups::thread_block const& block,
+                              InputProbeIt input_probe_begin,
+                              InputProbeIt input_probe_end,
+                              StencilIt stencil,
+                              Predicate pred,
+                              OutputProbeIt output_probe,
+                              OutputMatchIt output_match,
+                              AtomicCounter& atomic_counter) const
+  {
+    auto const& ref_ = static_cast<ref_type const&>(*this);
+    ref_.impl_.template retrieve_if<IsOuter, BlockSize>(block,
+                                                        input_probe_begin,
+                                                        input_probe_end,
+                                                        stencil,
+                                                        pred,
+                                                        output_probe,
+                                                        output_match,
+                                                        atomic_counter);
+  }
+};
+
 template <typename Key,
           cuda::thread_scope Scope,
           typename KeyEqual,

--- a/include/cuco/detail/static_multiset/static_multiset_ref.inl
+++ b/include/cuco/detail/static_multiset/static_multiset_ref.inl
@@ -655,39 +655,7 @@ class operator_impl<
     ref_.impl_.template retrieve_outer<BlockSize>(
       block, input_probe_begin, input_probe_end, output_probe, output_match, atomic_counter);
   }
-};
 
-/**
- * @brief Mixin to augment `static_multiset_ref` with `retrieve_if` operator
- *
- * @tparam Key Key type
- * @tparam Scope The scope in which operations will be performed by individual threads.
- * @tparam KeyEqual Binary callable type used to compare two keys for equality
- * @tparam ProbingScheme Probing scheme (see `include/cuco/probing_scheme.cuh` for options)
- * @tparam StorageRef Storage ref type
- * @tparam Operators List of operators provided by the ref
- */
-template <typename Key,
-          cuda::thread_scope Scope,
-          typename KeyEqual,
-          typename ProbingScheme,
-          typename StorageRef,
-          typename... Operators>
-class operator_impl<
-  op::retrieve_if_tag,
-  static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>> {
-  using base_type = static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef>;
-  using ref_type =
-    static_multiset_ref<Key, Scope, KeyEqual, ProbingScheme, StorageRef, Operators...>;
-  using key_type       = typename base_type::key_type;
-  using value_type     = typename base_type::value_type;
-  using iterator       = typename base_type::iterator;
-  using const_iterator = typename base_type::const_iterator;
-
-  static constexpr auto cg_size     = base_type::cg_size;
-  static constexpr auto bucket_size = base_type::bucket_size;
-
- public:
   /**
    * @brief Retrieves all the slots corresponding to all keys in the range `[input_probe_begin,
    * input_probe_end)` if `pred` of the corresponding stencil returns true.
@@ -699,7 +667,6 @@ class operator_impl<
    * Behavior is undefined if the size of the output range exceeds the number of retrieved slots.
    * Use `count()` to determine the size of the output range.
    *
-   * @tparam IsOuter Flag indicating if an inner or outer retrieve operation should be performed
    * @tparam BlockSize Size of the thread block this operation is executed in
    * @tparam InputProbeIt Device accessible input iterator whose `value_type` is
    * convertible to the container's `key_type`
@@ -725,8 +692,7 @@ class operator_impl<
    * @param atomic_counter Counter that is used to determine the next free position in the output
    * sequences
    */
-  template <bool IsOuter,
-            int32_t BlockSize,
+  template <int32_t BlockSize,
             class InputProbeIt,
             class StencilIt,
             class Predicate,
@@ -743,14 +709,14 @@ class operator_impl<
                               AtomicCounter& atomic_counter) const
   {
     auto const& ref_ = static_cast<ref_type const&>(*this);
-    ref_.impl_.template retrieve_if<IsOuter, BlockSize>(block,
-                                                        input_probe_begin,
-                                                        input_probe_end,
-                                                        stencil,
-                                                        pred,
-                                                        output_probe,
-                                                        output_match,
-                                                        atomic_counter);
+    ref_.impl_.template retrieve_if<BlockSize>(block,
+                                               input_probe_begin,
+                                               input_probe_end,
+                                               stencil,
+                                               pred,
+                                               output_probe,
+                                               output_match,
+                                               atomic_counter);
   }
 };
 

--- a/include/cuco/detail/static_multiset/static_multiset_ref.inl
+++ b/include/cuco/detail/static_multiset/static_multiset_ref.inl
@@ -692,7 +692,7 @@ class operator_impl<
    * @param atomic_counter Counter that is used to determine the next free position in the output
    * sequences
    */
-  template <int32_t BlockSize,
+  template <int BlockSize,
             class InputProbeIt,
             class StencilIt,
             class Predicate,

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -844,6 +844,69 @@ class operator_impl<op::retrieve_tag,
     ref_.impl_.template retrieve<BlockSize>(
       block, input_probe_begin, input_probe_end, output_probe, output_match, atomic_counter);
   }
+
+  /**
+   * @brief Retrieves all the slots corresponding to all keys in the range `[input_probe_begin,
+   * input_probe_end)` if `pred` of the corresponding stencil returns true.
+   *
+   * If key `k = *(first + i)` exists in the container and `pred( *(stencil + i) )` returns true,
+   * copies `k` to `output_probe` and associated slot content to `output_match`, respectively.
+   * The output order is unspecified.
+   *
+   * Behavior is undefined if the size of the output range exceeds the number of retrieved slots.
+   * Use `count()` to determine the size of the output range.
+   *
+   * @tparam BlockSize Size of the thread block this operation is executed in
+   * @tparam InputProbeIt Device accessible input iterator whose `value_type` is
+   * convertible to the container's `key_type`
+   * @tparam StencilIt Device accessible random access iterator whose value_type is
+   * convertible to Predicate's argument type
+   * @tparam Predicate Unary predicate callable whose return type must be convertible to `bool`
+   * and argument type is convertible from `std::iterator_traits<StencilIt>::value_type`
+   * @tparam OutputProbeIt Device accessible input iterator whose `value_type` is
+   * convertible to the container's `key_type`
+   * @tparam OutputMatchIt Device accessible input iterator whose `value_type` is
+   * convertible to the container's `value_type`
+   * @tparam AtomicCounter Atomic counter type that follows the same semantics as
+   * `cuda::atomic(_ref)`
+   *
+   * @param block Thread block this operation is executed in
+   * @param input_probe_begin Beginning of the input sequence of keys
+   * @param input_probe_end End of the input sequence of keys
+   * @param stencil Beginning of the stencil sequence
+   * @param pred Predicate to test on every element in the range `[stencil, stencil + n)`
+   * @param output_probe Beginning of the sequence of keys corresponding to matching elements in
+   * `output_match`
+   * @param output_match Beginning of the sequence of matching elements
+   * @param atomic_counter Counter that is used to determine the next free position in the output
+   * sequences
+   */
+  template <int32_t BlockSize,
+            class InputProbeIt,
+            class StencilIt,
+            class Predicate,
+            class OutputProbeIt,
+            class OutputMatchIt,
+            class AtomicCounter>
+  __device__ void retrieve_if(cooperative_groups::thread_block const& block,
+                              InputProbeIt input_probe_begin,
+                              InputProbeIt input_probe_end,
+                              StencilIt stencil,
+                              Predicate pred,
+                              OutputProbeIt output_probe,
+                              OutputMatchIt output_match,
+                              AtomicCounter& atomic_counter) const
+  {
+    auto const& ref_ = static_cast<ref_type const&>(*this);
+    ref_.impl_.template retrieve_if<BlockSize>(block,
+                                               input_probe_begin,
+                                               input_probe_end,
+                                               stencil,
+                                               pred,
+                                               output_probe,
+                                               output_match,
+                                               atomic_counter);
+  }
 };
 
 }  // namespace detail

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -881,7 +881,7 @@ class operator_impl<op::retrieve_tag,
    * @param atomic_counter Counter that is used to determine the next free position in the output
    * sequences
    */
-  template <int32_t BlockSize,
+  template <int BlockSize,
             class InputProbeIt,
             class StencilIt,
             class Predicate,

--- a/include/cuco/detail/static_set/static_set_ref.inl
+++ b/include/cuco/detail/static_set/static_set_ref.inl
@@ -845,5 +845,6 @@ class operator_impl<op::retrieve_tag,
       block, input_probe_begin, input_probe_end, output_probe, output_match, atomic_counter);
   }
 };
+
 }  // namespace detail
 }  // namespace cuco

--- a/include/cuco/operator.hpp
+++ b/include/cuco/operator.hpp
@@ -42,7 +42,6 @@ namespace cuco {
  * - `count`: For a given key, returns the number of matching elements in the container
  * - `find`: Locates an element in the container
  * - `retrieve`: Retrieves all matching elements in the container for a given key
- * - `retrieve_if`: Retrieves all matching elements in the container if a predicate condition is met
  * - `for_each`: Applies a user-defined function to each element in the container (or for a given
  * key)
  *
@@ -296,8 +295,9 @@ struct find_tag {
  * Behavior is undefined if the size of the output range exceeds the number of retrieved slots.
  * Use `count()` to determine the size of the output range.
  *
- * API Signature:
+ * API Signatures:
  * ```cpp
+ * // Basic retrieve
  * template <int32_t BlockSize,
  *           class InputProbeIt,
  *           class OutputProbeIt,
@@ -309,49 +309,9 @@ struct find_tag {
  *                          OutputProbeIt output_probe,
  *                          OutputMatchIt output_match,
  *                          AtomicCounter* atomic_counter) const
- * ```
  *
- * Where:
- * @see @tparam BlockSize Size of the thread block this operation is executed in
- * @see @tparam InputProbeIt Device accessible input iterator whose `value_type` is
- * convertible to the container's `key_type`
- * @see @tparam OutputProbeIt Device accessible input iterator whose `value_type` is
- * convertible to the container's `key_type`
- * @see @tparam OutputMatchIt Device accessible input iterator whose `value_type` is
- * convertible to the container's `value_type`
- * @see @tparam AtomicCounter Atomic counter type that follows the same semantics as
- * `cuda::atomic(_ref)`
- *
- * @see @param block Thread block this operation is executed in
- * @see @param input_probe_begin Beginning of the input sequence of keys
- * @see @param input_probe_end End of the input sequence of keys
- * @see @param output_probe Beginning of the sequence of keys corresponding to matching elements in
- * `output_match`
- * @see @param output_match Beginning of the sequence of matching elements
- * @see @param atomic_counter Counter that is used to determine the next free position in the output
- * sequences
- *
- */
-struct retrieve_tag {
-} inline constexpr retrieve;  ///< `cuco::retrieve` operator
-
-/**
- * @brief Tag type for `retrieve_if` operator
- *
- * Retrieves all the matching elements corresponding to all keys in the range `[input_probe_begin,
- * input_probe_end)` if `pred` of the corresponding stencil returns true.
- *
- * If key `k = *(first + i)` exists in the container and `pred( *(stencil + i) )` returns true,
- * copies `k` to `output_probe` and associated slot content to `output_match`, respectively.
- * The output order is unspecified.
- *
- * Behavior is undefined if the size of the output range exceeds the number of retrieved slots.
- * Use `count()` to determine the size of the output range.
- *
- * API Signature:
- * ```cpp
- * template <bool IsOuter,
- *           int32_t BlockSize,
+ * // Conditional retrieve with predicate
+ * template <int32_t BlockSize,
  *           class InputProbeIt,
  *           class StencilIt,
  *           class Predicate,
@@ -369,14 +329,15 @@ struct retrieve_tag {
  * ```
  *
  * Where:
- * @see @tparam IsOuter Flag indicating if an inner or outer retrieve operation should be performed
+
  * @see @tparam BlockSize Size of the thread block this operation is executed in
  * @see @tparam InputProbeIt Device accessible input iterator whose `value_type` is
  * convertible to the container's `key_type`
  * @see @tparam StencilIt Device accessible random access iterator whose value_type is
- * convertible to Predicate's argument type
+ * convertible to Predicate's argument type (retrieve_if only)
  * @see @tparam Predicate Unary predicate callable whose return type must be convertible to `bool`
- * and argument type is convertible from `std::iterator_traits<StencilIt>::value_type`
+ * and argument type is convertible from `std::iterator_traits<StencilIt>::value_type` (retrieve_if
+ only)
  * @see @tparam OutputProbeIt Device accessible input iterator whose `value_type` is
  * convertible to the container's `key_type`
  * @see @tparam OutputMatchIt Device accessible input iterator whose `value_type` is
@@ -387,8 +348,9 @@ struct retrieve_tag {
  * @see @param block Thread block this operation is executed in
  * @see @param input_probe_begin Beginning of the input sequence of keys
  * @see @param input_probe_end End of the input sequence of keys
- * @see @param stencil Beginning of the stencil sequence
+ * @see @param stencil Beginning of the stencil sequence (retrieve_if only)
  * @see @param pred Predicate to test on every element in the range `[stencil, stencil + n)`
+ (retrieve_if only)
  * @see @param output_probe Beginning of the sequence of keys corresponding to matching elements in
  * `output_match`
  * @see @param output_match Beginning of the sequence of matching elements
@@ -396,8 +358,8 @@ struct retrieve_tag {
  * sequences
  *
  */
-struct retrieve_if_tag {
-} inline constexpr retrieve_if;  ///< `cuco::retrieve_if` operator
+struct retrieve_tag {
+} inline constexpr retrieve;  ///< `cuco::retrieve` operator
 
 /**
  * @brief Tag type for `for_each` operator

--- a/include/cuco/operator.hpp
+++ b/include/cuco/operator.hpp
@@ -42,6 +42,7 @@ namespace cuco {
  * - `count`: For a given key, returns the number of matching elements in the container
  * - `find`: Locates an element in the container
  * - `retrieve`: Retrieves all matching elements in the container for a given key
+ * - `retrieve_if`: Retrieves all matching elements in the container if a predicate condition is met
  * - `for_each`: Applies a user-defined function to each element in the container (or for a given
  * key)
  *
@@ -333,6 +334,70 @@ struct find_tag {
  */
 struct retrieve_tag {
 } inline constexpr retrieve;  ///< `cuco::retrieve` operator
+
+/**
+ * @brief Tag type for `retrieve_if` operator
+ *
+ * Retrieves all the matching elements corresponding to all keys in the range `[input_probe_begin,
+ * input_probe_end)` if `pred` of the corresponding stencil returns true.
+ *
+ * If key `k = *(first + i)` exists in the container and `pred( *(stencil + i) )` returns true,
+ * copies `k` to `output_probe` and associated slot content to `output_match`, respectively.
+ * The output order is unspecified.
+ *
+ * Behavior is undefined if the size of the output range exceeds the number of retrieved slots.
+ * Use `count()` to determine the size of the output range.
+ *
+ * API Signature:
+ * ```cpp
+ * template <bool IsOuter,
+ *           int32_t BlockSize,
+ *           class InputProbeIt,
+ *           class StencilIt,
+ *           class Predicate,
+ *           class OutputProbeIt,
+ *           class OutputMatchIt,
+ *           class AtomicCounter>
+ * __device__ void retrieve_if(cooperative_groups::thread_block  const& block,
+ *                             InputProbeIt input_probe_begin,
+ *                             InputProbeIt input_probe_end,
+ *                             StencilIt stencil,
+ *                             Predicate pred,
+ *                             OutputProbeIt output_probe,
+ *                             OutputMatchIt output_match,
+ *                             AtomicCounter* atomic_counter) const
+ * ```
+ *
+ * Where:
+ * @see @tparam IsOuter Flag indicating if an inner or outer retrieve operation should be performed
+ * @see @tparam BlockSize Size of the thread block this operation is executed in
+ * @see @tparam InputProbeIt Device accessible input iterator whose `value_type` is
+ * convertible to the container's `key_type`
+ * @see @tparam StencilIt Device accessible random access iterator whose value_type is
+ * convertible to Predicate's argument type
+ * @see @tparam Predicate Unary predicate callable whose return type must be convertible to `bool`
+ * and argument type is convertible from `std::iterator_traits<StencilIt>::value_type`
+ * @see @tparam OutputProbeIt Device accessible input iterator whose `value_type` is
+ * convertible to the container's `key_type`
+ * @see @tparam OutputMatchIt Device accessible input iterator whose `value_type` is
+ * convertible to the container's `value_type`
+ * @see @tparam AtomicCounter Atomic counter type that follows the same semantics as
+ * `cuda::atomic(_ref)`
+ *
+ * @see @param block Thread block this operation is executed in
+ * @see @param input_probe_begin Beginning of the input sequence of keys
+ * @see @param input_probe_end End of the input sequence of keys
+ * @see @param stencil Beginning of the stencil sequence
+ * @see @param pred Predicate to test on every element in the range `[stencil, stencil + n)`
+ * @see @param output_probe Beginning of the sequence of keys corresponding to matching elements in
+ * `output_match`
+ * @see @param output_match Beginning of the sequence of matching elements
+ * @see @param atomic_counter Counter that is used to determine the next free position in the output
+ * sequences
+ *
+ */
+struct retrieve_if_tag {
+} inline constexpr retrieve_if;  ///< `cuco::retrieve_if` operator
 
 /**
  * @brief Tag type for `for_each` operator

--- a/include/cuco/operator.hpp
+++ b/include/cuco/operator.hpp
@@ -298,7 +298,7 @@ struct find_tag {
  * API Signatures:
  * ```cpp
  * // Basic retrieve
- * template <int32_t BlockSize,
+ * template <int BlockSize,
  *           class InputProbeIt,
  *           class OutputProbeIt,
  *           class OutputMatchIt,
@@ -311,7 +311,7 @@ struct find_tag {
  *                          AtomicCounter* atomic_counter) const
  *
  * // Conditional retrieve with predicate
- * template <int32_t BlockSize,
+ * template <int BlockSize,
  *           class InputProbeIt,
  *           class StencilIt,
  *           class Predicate,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -115,6 +115,7 @@ ConfigureTest(STATIC_MULTISET_TEST
     static_multiset/insert_test.cu
     static_multiset/for_each_test.cu
     static_multiset/retrieve_test.cu
+    static_multiset/retrieve_if_test.cu
     static_multiset/large_input_test.cu
     static_multiset/load_factor_test.cu)
 
@@ -128,7 +129,8 @@ ConfigureTest(STATIC_MULTIMAP_TEST
     static_multimap/insert_if_test.cu
     static_multimap/multiplicity_test.cu
     static_multimap/for_each_test.cu
-    static_multimap/retrieve_test.cu)
+    static_multimap/retrieve_test.cu
+    static_multimap/retrieve_if_test.cu)
 
 ###################################################################################################
 # - dynamic_bitset tests --------------------------------------------------------------------------

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,6 +71,7 @@ ConfigureTest(STATIC_SET_TEST
     static_set/large_input_test.cu
     static_set/retrieve_test.cu
     static_set/retrieve_all_test.cu
+    static_set/retrieve_if_test.cu
     static_set/rehash_test.cu
     static_set/size_test.cu
     static_set/shared_memory_test.cu
@@ -95,7 +96,8 @@ ConfigureTest(STATIC_MAP_TEST
     static_map/shared_memory_test.cu
     static_map/stream_test.cu
     static_map/rehash_test.cu
-    static_map/retrieve_test.cu)
+    static_map/retrieve_test.cu
+    static_map/retrieve_if_test.cu)
 
 ###################################################################################################
 # - dynamic_map tests -----------------------------------------------------------------------------

--- a/tests/static_map/retrieve_if_test.cu
+++ b/tests/static_map/retrieve_if_test.cu
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <test_utils.hpp>
+
+#include <cuco/static_map.cuh>
+
+#include <cuda/functional>
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+#include <thrust/sequence.h>
+
+#include <catch2/catch_template_test_macros.hpp>
+
+using size_type = std::size_t;
+
+template <class Container>
+__global__ void test_retrieve_if_kernel(
+  Container container_ref,
+  typename Container::key_type* keys_begin,
+  std::size_t num_keys,
+  typename Container::key_type* stencil_begin,
+  typename Container::key_type* output_probe,
+  typename Container::value_type* output_match,
+  cuda::atomic<int, cuda::thread_scope_device>* atomic_counter)
+{
+  using key_type = typename Container::key_type;
+  namespace cg   = cooperative_groups;
+
+  auto const block = cg::this_thread_block();
+  auto const pred  = [] __device__(key_type k) { return k % 2 == 0; };
+
+  container_ref.retrieve_if<128>(block,
+                                 keys_begin,
+                                 keys_begin + num_keys,
+                                 stencil_begin,
+                                 pred,
+                                 output_probe,
+                                 output_match,
+                                 *atomic_counter);
+}
+
+template <class Container>
+__global__ void test_retrieve_if_all_false_kernel(
+  Container container_ref,
+  typename Container::key_type* keys_begin,
+  std::size_t num_keys,
+  typename Container::key_type* stencil_begin,
+  typename Container::key_type* output_probe,
+  typename Container::value_type* output_match,
+  cuda::atomic<int, cuda::thread_scope_device>* atomic_counter)
+{
+  using key_type = typename Container::key_type;
+  namespace cg   = cooperative_groups;
+
+  auto const block        = cg::this_thread_block();
+  auto const always_false = [] __device__(key_type) { return false; };
+
+  container_ref.retrieve_if<128>(block,
+                                 keys_begin,
+                                 keys_begin + num_keys,
+                                 stencil_begin,
+                                 always_false,
+                                 output_probe,
+                                 output_match,
+                                 *atomic_counter);
+}
+
+template <class Container>
+__global__ void test_retrieve_if_all_true_kernel(
+  Container container_ref,
+  typename Container::key_type* keys_begin,
+  std::size_t num_keys,
+  typename Container::key_type* stencil_begin,
+  typename Container::key_type* output_probe,
+  typename Container::value_type* output_match,
+  cuda::atomic<int, cuda::thread_scope_device>* atomic_counter)
+{
+  using key_type = typename Container::key_type;
+  namespace cg   = cooperative_groups;
+
+  auto const block       = cg::this_thread_block();
+  auto const always_true = [] __device__(key_type) { return true; };
+
+  container_ref.retrieve_if<128>(block,
+                                 keys_begin,
+                                 keys_begin + num_keys,
+                                 stencil_begin,
+                                 always_true,
+                                 output_probe,
+                                 output_match,
+                                 *atomic_counter);
+}
+
+TEMPLATE_TEST_CASE_SIG("static_map retrieve_if",
+                       "",
+                       ((typename Key, typename T), Key, T),
+                       (int32_t, int32_t),
+                       (int64_t, int64_t))
+{
+  constexpr size_type num_keys{400};
+
+  using container_type = cuco::static_map<Key, T>;
+  using value_type     = typename container_type::value_type;
+
+  container_type container{num_keys * 2, cuco::empty_key<Key>{-1}, cuco::empty_value<T>{-1}};
+
+  auto keys_begin  = thrust::counting_iterator<Key>(1);
+  auto vals_begin  = thrust::counting_iterator<T>(1);
+  auto pairs_begin = thrust::make_zip_iterator(thrust::make_tuple(keys_begin, vals_begin));
+
+  container.insert(pairs_begin, pairs_begin + num_keys);
+
+  SECTION("Testing retrieve_if with even predicate")
+  {
+    thrust::device_vector<Key> input_keys(keys_begin, keys_begin + num_keys);
+    thrust::device_vector<Key> stencil_values(keys_begin, keys_begin + num_keys);
+    thrust::device_vector<Key> probed_keys(num_keys);
+    thrust::device_vector<value_type> matched_pairs(num_keys);
+
+    cuda::atomic<int, cuda::thread_scope_device>* d_atomic_counter;
+    CUCO_CUDA_TRY(
+      cudaMalloc(&d_atomic_counter, sizeof(cuda::atomic<int, cuda::thread_scope_device>)));
+    CUCO_CUDA_TRY(
+      cudaMemset(d_atomic_counter, 0, sizeof(cuda::atomic<int, cuda::thread_scope_device>)));
+
+    auto const container_ref = container.ref(cuco::op::retrieve);
+
+    test_retrieve_if_kernel<<<1, 128>>>(container_ref,
+                                        thrust::raw_pointer_cast(input_keys.data()),
+                                        num_keys,
+                                        thrust::raw_pointer_cast(stencil_values.data()),
+                                        thrust::raw_pointer_cast(probed_keys.data()),
+                                        thrust::raw_pointer_cast(matched_pairs.data()),
+                                        d_atomic_counter);
+    CUCO_CUDA_TRY(cudaDeviceSynchronize());
+
+    int h_counter;
+    CUCO_CUDA_TRY(cudaMemcpy(&h_counter, d_atomic_counter, sizeof(int), cudaMemcpyDeviceToHost));
+
+    // Should retrieve even numbers only
+    REQUIRE(h_counter > 0);
+    REQUIRE(h_counter <= static_cast<int>(num_keys));
+
+    CUCO_CUDA_TRY(cudaFree(d_atomic_counter));
+  }
+
+  SECTION("Testing retrieve_if with always false predicate")
+  {
+    thrust::device_vector<Key> input_keys(keys_begin, keys_begin + num_keys);
+    thrust::device_vector<Key> stencil_values(keys_begin, keys_begin + num_keys);
+    thrust::device_vector<Key> probed_keys(num_keys);
+    thrust::device_vector<value_type> matched_pairs(num_keys);
+
+    cuda::atomic<int, cuda::thread_scope_device>* d_atomic_counter;
+    CUCO_CUDA_TRY(
+      cudaMalloc(&d_atomic_counter, sizeof(cuda::atomic<int, cuda::thread_scope_device>)));
+    CUCO_CUDA_TRY(
+      cudaMemset(d_atomic_counter, 0, sizeof(cuda::atomic<int, cuda::thread_scope_device>)));
+
+    auto const container_ref = container.ref(cuco::op::retrieve);
+
+    test_retrieve_if_all_false_kernel<<<1, 128>>>(container_ref,
+                                                  thrust::raw_pointer_cast(input_keys.data()),
+                                                  num_keys,
+                                                  thrust::raw_pointer_cast(stencil_values.data()),
+                                                  thrust::raw_pointer_cast(probed_keys.data()),
+                                                  thrust::raw_pointer_cast(matched_pairs.data()),
+                                                  d_atomic_counter);
+    CUCO_CUDA_TRY(cudaDeviceSynchronize());
+
+    int h_counter;
+    CUCO_CUDA_TRY(cudaMemcpy(&h_counter, d_atomic_counter, sizeof(int), cudaMemcpyDeviceToHost));
+
+    // Should retrieve nothing
+    REQUIRE(h_counter == 0);
+
+    CUCO_CUDA_TRY(cudaFree(d_atomic_counter));
+  }
+
+  SECTION("Testing retrieve_if with always true predicate")
+  {
+    thrust::device_vector<Key> input_keys(keys_begin, keys_begin + num_keys);
+    thrust::device_vector<Key> stencil_values(keys_begin, keys_begin + num_keys);
+    thrust::device_vector<Key> probed_keys(num_keys);
+    thrust::device_vector<value_type> matched_pairs(num_keys);
+
+    cuda::atomic<int, cuda::thread_scope_device>* d_atomic_counter;
+    CUCO_CUDA_TRY(
+      cudaMalloc(&d_atomic_counter, sizeof(cuda::atomic<int, cuda::thread_scope_device>)));
+    CUCO_CUDA_TRY(
+      cudaMemset(d_atomic_counter, 0, sizeof(cuda::atomic<int, cuda::thread_scope_device>)));
+
+    auto const container_ref = container.ref(cuco::op::retrieve);
+
+    test_retrieve_if_all_true_kernel<<<1, 128>>>(container_ref,
+                                                 thrust::raw_pointer_cast(input_keys.data()),
+                                                 num_keys,
+                                                 thrust::raw_pointer_cast(stencil_values.data()),
+                                                 thrust::raw_pointer_cast(probed_keys.data()),
+                                                 thrust::raw_pointer_cast(matched_pairs.data()),
+                                                 d_atomic_counter);
+    CUCO_CUDA_TRY(cudaDeviceSynchronize());
+
+    int h_counter;
+    CUCO_CUDA_TRY(cudaMemcpy(&h_counter, d_atomic_counter, sizeof(int), cudaMemcpyDeviceToHost));
+
+    // Should retrieve all keys that exist in the container
+    REQUIRE(h_counter == static_cast<int>(num_keys));
+
+    CUCO_CUDA_TRY(cudaFree(d_atomic_counter));
+  }
+}

--- a/tests/static_multimap/retrieve_if_test.cu
+++ b/tests/static_multimap/retrieve_if_test.cu
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <test_utils.hpp>
+
+#include <cuco/static_multimap.cuh>
+
+#include <cuda/functional>
+#include <thrust/device_vector.h>
+#include <thrust/distance.h>
+#include <thrust/functional.h>
+#include <thrust/iterator/constant_iterator.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
+#include <thrust/sort.h>
+
+#include <catch2/catch_template_test_macros.hpp>
+
+#include <limits>
+
+template <class Container>
+void test_retrieve_if_inner(Container& container, std::size_t num_keys)
+{
+  using key_type                = typename Container::key_type;
+  using mapped_type             = typename Container::mapped_type;
+  using value_type              = typename Container::value_type;
+  auto const empty_key_sentinel = container.empty_key_sentinel();
+
+  container.clear();
+
+  // Insert key-value pairs: (0,0), (1,1), (2,2), ... (num_keys-1, num_keys-1)
+  auto const pairs_begin =
+    thrust::make_transform_iterator(thrust::counting_iterator<key_type>{0},
+                                    cuda::proclaim_return_type<value_type>([] __device__(auto i) {
+                                      return cuco::pair<key_type, mapped_type>{i, i};
+                                    }));
+
+  container.insert(pairs_begin, pairs_begin + num_keys);
+  REQUIRE(container.size() == num_keys);
+
+  // Create stencil and predicate for 25% filtering (keys divisible by 4)
+  auto const stencil_begin = thrust::counting_iterator<key_type>{0};
+  auto const pred          = [] __device__(key_type k) { return k % 4 == 0; };
+
+  thrust::device_vector<key_type> probed_keys(num_keys);
+  thrust::device_vector<value_type> matched_pairs(num_keys);
+
+  SECTION("Inner retrieve_if should only return key-value pairs where predicate is true.")
+  {
+    auto const [probed_end, matched_end] = container.retrieve_if<false>(stencil_begin,
+                                                                        stencil_begin + num_keys,
+                                                                        stencil_begin,
+                                                                        pred,
+                                                                        probed_keys.begin(),
+                                                                        matched_pairs.begin());
+
+    auto const num_retrieved  = std::distance(probed_keys.begin(), probed_end);
+    auto const expected_count = (num_keys + 3) / 4;  // ceiling of num_keys/4 for keys 0, 4, 8, ...
+
+    REQUIRE(num_retrieved == expected_count);
+    REQUIRE(std::distance(matched_pairs.begin(), matched_end) == expected_count);
+
+    // Sort results for comparison
+    thrust::sort_by_key(probed_keys.begin(), probed_end, matched_pairs.begin());
+
+    // Check that all retrieved keys are divisible by 4
+    for (std::size_t i = 0; i < expected_count; ++i) {
+      auto expected_key = static_cast<key_type>(i * 4);
+      REQUIRE(probed_keys[i] == expected_key);
+      REQUIRE(matched_pairs[i].first == expected_key);
+      REQUIRE(matched_pairs[i].second == expected_key);  // value equals key in our test
+    }
+  }
+
+  SECTION("Inner retrieve_if with always-false predicate should return empty.")
+  {
+    auto const always_false              = [] __device__(key_type) { return false; };
+    auto const [probed_end, matched_end] = container.retrieve_if<false>(stencil_begin,
+                                                                        stencil_begin + num_keys,
+                                                                        stencil_begin,
+                                                                        always_false,
+                                                                        probed_keys.begin(),
+                                                                        matched_pairs.begin());
+
+    REQUIRE(std::distance(probed_keys.begin(), probed_end) == 0);
+    REQUIRE(std::distance(matched_pairs.begin(), matched_end) == 0);
+  }
+
+  SECTION("Inner retrieve_if with always-true predicate should return all pairs.")
+  {
+    auto const always_true               = [] __device__(key_type) { return true; };
+    auto const [probed_end, matched_end] = container.retrieve_if<false>(stencil_begin,
+                                                                        stencil_begin + num_keys,
+                                                                        stencil_begin,
+                                                                        always_true,
+                                                                        probed_keys.begin(),
+                                                                        matched_pairs.begin());
+
+    REQUIRE(std::distance(probed_keys.begin(), probed_end) == num_keys);
+    REQUIRE(std::distance(matched_pairs.begin(), matched_end) == num_keys);
+
+    thrust::sort_by_key(probed_keys.begin(), probed_end, matched_pairs.begin());
+
+    for (std::size_t i = 0; i < num_keys; ++i) {
+      auto expected_key = static_cast<key_type>(i);
+      REQUIRE(probed_keys[i] == expected_key);
+      REQUIRE(matched_pairs[i].first == expected_key);
+      REQUIRE(matched_pairs[i].second == expected_key);
+    }
+  }
+}
+
+template <class Container>
+void test_retrieve_if_outer(Container& container, std::size_t num_keys)
+{
+  using key_type                  = typename Container::key_type;
+  using mapped_type               = typename Container::mapped_type;
+  using value_type                = typename Container::value_type;
+  auto const empty_key_sentinel   = container.empty_key_sentinel();
+  auto const empty_value_sentinel = container.empty_value_sentinel();
+
+  container.clear();
+
+  // Insert only even-indexed key-value pairs: (0,0), (2,2), (4,4), ...
+  auto const even_pairs_begin =
+    thrust::make_transform_iterator(thrust::counting_iterator<key_type>{0},
+                                    cuda::proclaim_return_type<value_type>([] __device__(auto i) {
+                                      return cuco::pair<key_type, mapped_type>{i * 2, i * 2};
+                                    }));
+  container.insert(even_pairs_begin, even_pairs_begin + num_keys / 2);
+
+  // Query all keys 0, 1, 2, ... num_keys-1
+  auto const query_keys_begin = thrust::counting_iterator<key_type>{0};
+  auto const stencil_begin    = query_keys_begin;
+  auto const pred = [] __device__(key_type k) { return k % 6 == 0; };  // keys 0, 6, 12, ...
+
+  thrust::device_vector<key_type> probed_keys(num_keys);
+  thrust::device_vector<value_type> matched_pairs(num_keys);
+
+  SECTION("Outer retrieve_if should include all queried keys with appropriate matches.")
+  {
+    auto const [probed_end, matched_end] = container.retrieve_if<true>(query_keys_begin,
+                                                                       query_keys_begin + num_keys,
+                                                                       stencil_begin,
+                                                                       pred,
+                                                                       probed_keys.begin(),
+                                                                       matched_pairs.begin());
+
+    // Should return entries for all queried keys
+    REQUIRE(std::distance(probed_keys.begin(), probed_end) == num_keys);
+    REQUIRE(std::distance(matched_pairs.begin(), matched_end) == num_keys);
+
+    // Sort by probed keys for easier verification
+    thrust::sort_by_key(probed_keys.begin(), probed_end, matched_pairs.begin());
+
+    // Check that all queried keys are present
+    for (std::size_t i = 0; i < num_keys; ++i) {
+      auto key = static_cast<key_type>(i);
+      REQUIRE(probed_keys[i] == key);
+
+      if (key % 6 == 0 && key % 2 == 0) {
+        // Predicate true and key exists in container -> should match
+        REQUIRE(matched_pairs[i].first == key);
+        REQUIRE(matched_pairs[i].second == key);
+      } else {
+        // Either predicate false or key doesn't exist -> empty sentinel
+        REQUIRE(matched_pairs[i].first == empty_key_sentinel);
+        REQUIRE(matched_pairs[i].second == empty_value_sentinel);
+      }
+    }
+  }
+}
+
+template <class Container>
+void test_retrieve_if_multiplicity(Container& container,
+                                   std::size_t num_keys,
+                                   std::size_t multiplicity)
+{
+  using key_type    = typename Container::key_type;
+  using mapped_type = typename Container::mapped_type;
+  using value_type  = typename Container::value_type;
+
+  container.clear();
+
+  auto const num_unique_keys = num_keys / multiplicity;
+  REQUIRE(num_unique_keys > 0);
+  auto const num_actual_pairs = num_unique_keys * multiplicity;
+
+  // Insert multiple instances of each key with different values
+  auto const pairs_begin = thrust::make_transform_iterator(
+    thrust::counting_iterator<key_type>{0},
+    cuda::proclaim_return_type<value_type>([multiplicity] __device__(auto i) {
+      auto key   = static_cast<key_type>(i / multiplicity);
+      auto value = static_cast<mapped_type>(i);  // unique value for each pair
+      return cuco::pair<key_type, mapped_type>{key, value};
+    }));
+
+  container.insert(pairs_begin, pairs_begin + num_actual_pairs);
+  REQUIRE(container.size() == num_actual_pairs);
+
+  // Use stencil based on key index, predicate for 50% of keys (even keys)
+  auto const stencil_begin = thrust::make_transform_iterator(
+    thrust::counting_iterator<key_type>{0},
+    [] __device__(key_type i) { return i / multiplicity; });  // extract key from index
+  auto const pred = [] __device__(key_type k) { return k % 2 == 0; };
+
+  thrust::device_vector<key_type> probed_keys(num_actual_pairs);
+  thrust::device_vector<value_type> matched_pairs(num_actual_pairs);
+
+  SECTION("retrieve_if should return all instances of keys that satisfy predicate.")
+  {
+    auto const [probed_end, matched_end] =
+      container.retrieve_if<false>(pairs_begin,
+                                   pairs_begin + num_actual_pairs,
+                                   stencil_begin,
+                                   pred,
+                                   probed_keys.begin(),
+                                   matched_pairs.begin());
+
+    // Should return all instances of even keys
+    auto const expected_unique_keys = (num_unique_keys + 1) / 2;  // ceiling for even keys
+    auto const expected_total_pairs = expected_unique_keys * multiplicity;
+
+    REQUIRE(std::distance(probed_keys.begin(), probed_end) == expected_total_pairs);
+    REQUIRE(std::distance(matched_pairs.begin(), matched_end) == expected_total_pairs);
+
+    // Sort results for verification
+    thrust::sort_by_key(probed_keys.begin(), probed_end, matched_pairs.begin());
+
+    // Verify all returned keys are even and all instances are present
+    for (std::size_t i = 0; i < expected_total_pairs; ++i) {
+      auto expected_key = static_cast<key_type>((i / multiplicity) * 2);
+      REQUIRE(probed_keys[i] == expected_key);
+      REQUIRE(matched_pairs[i].first == expected_key);
+      // Values should be unique but we don't need to verify exact order
+      REQUIRE(matched_pairs[i].second >= 0);
+    }
+  }
+}
+
+TEMPLATE_TEST_CASE_SIG(
+  "static_multimap retrieve_if tests",
+  "",
+  ((typename Key, typename Value, cuco::test::probe_sequence Probe, int CGSize),
+   Key,
+   Value,
+   Probe,
+   CGSize),
+  (int32_t, int32_t, cuco::test::probe_sequence::double_hashing, 1),
+  (int32_t, int64_t, cuco::test::probe_sequence::double_hashing, 1),
+  (int32_t, int32_t, cuco::test::probe_sequence::double_hashing, 2),
+  (int32_t, int64_t, cuco::test::probe_sequence::double_hashing, 2),
+  (int64_t, int32_t, cuco::test::probe_sequence::double_hashing, 1),
+  (int64_t, int64_t, cuco::test::probe_sequence::double_hashing, 1),
+  (int64_t, int32_t, cuco::test::probe_sequence::double_hashing, 2),
+  (int64_t, int64_t, cuco::test::probe_sequence::double_hashing, 2),
+  (int32_t, int32_t, cuco::test::probe_sequence::linear_probing, 1),
+  (int32_t, int64_t, cuco::test::probe_sequence::linear_probing, 1),
+  (int32_t, int32_t, cuco::test::probe_sequence::linear_probing, 2),
+  (int32_t, int64_t, cuco::test::probe_sequence::linear_probing, 2),
+  (int64_t, int32_t, cuco::test::probe_sequence::linear_probing, 1),
+  (int64_t, int64_t, cuco::test::probe_sequence::linear_probing, 1),
+  (int64_t, int32_t, cuco::test::probe_sequence::linear_probing, 2),
+  (int64_t, int64_t, cuco::test::probe_sequence::linear_probing, 2))
+{
+  constexpr std::size_t num_keys{400};
+  constexpr double desired_load_factor = 0.5;
+  constexpr auto empty_key_sentinel    = std::numeric_limits<Key>::max();
+  constexpr auto empty_value_sentinel  = std::numeric_limits<Value>::max();
+
+  using extent_type = cuco::extent<std::size_t>;
+  using probe       = std::conditional_t<
+          Probe == cuco::test::probe_sequence::linear_probing,
+          cuco::linear_probing<CGSize, cuco::murmurhash3_32<Key>>,
+          cuco::double_hashing<CGSize, cuco::murmurhash3_32<Key>, cuco::murmurhash3_32<Key>>>;
+
+  auto map = cuco::experimental::static_multimap<Key,
+                                                 Value,
+                                                 extent_type,
+                                                 cuda::thread_scope_device,
+                                                 cuda::std::equal_to<Key>,
+                                                 probe,
+                                                 cuco::cuda_allocator<cuda::std::byte>,
+                                                 cuco::storage<2>>{
+    num_keys * 2,
+    cuco::empty_key<Key>{empty_key_sentinel},
+    cuco::empty_value<Value>{empty_value_sentinel}};
+
+  test_retrieve_if_inner(map, num_keys);
+  test_retrieve_if_outer(map, num_keys);
+  test_retrieve_if_multiplicity(map, num_keys, 3);  // Each key appears 3 times
+}

--- a/tests/static_multimap/retrieve_if_test.cu
+++ b/tests/static_multimap/retrieve_if_test.cu
@@ -20,286 +20,211 @@
 
 #include <cuda/functional>
 #include <thrust/device_vector.h>
-#include <thrust/distance.h>
-#include <thrust/functional.h>
-#include <thrust/iterator/constant_iterator.h>
+#include <thrust/host_vector.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
-#include <thrust/sort.h>
+#include <thrust/sequence.h>
 
 #include <catch2/catch_template_test_macros.hpp>
 
-#include <limits>
+using size_type = std::size_t;
 
 template <class Container>
-void test_retrieve_if_inner(Container& container, std::size_t num_keys)
+__global__ void test_retrieve_if_kernel(
+  Container container_ref,
+  typename Container::key_type* keys_begin,
+  std::size_t num_keys,
+  typename Container::key_type* stencil_begin,
+  typename Container::key_type* output_probe,
+  typename Container::value_type* output_match,
+  cuda::atomic<int, cuda::thread_scope_device>* atomic_counter)
 {
-  using key_type                = typename Container::key_type;
-  using mapped_type             = typename Container::mapped_type;
-  using value_type              = typename Container::value_type;
-  auto const empty_key_sentinel = container.empty_key_sentinel();
+  using key_type = typename Container::key_type;
+  namespace cg   = cooperative_groups;
 
-  container.clear();
+  auto const block = cg::this_thread_block();
+  auto const pred  = [] __device__(key_type k) { return k % 2 == 0; };
 
-  // Insert key-value pairs: (0,0), (1,1), (2,2), ... (num_keys-1, num_keys-1)
-  auto const pairs_begin =
-    thrust::make_transform_iterator(thrust::counting_iterator<key_type>{0},
-                                    cuda::proclaim_return_type<value_type>([] __device__(auto i) {
-                                      return cuco::pair<key_type, mapped_type>{i, i};
-                                    }));
+  container_ref.retrieve_if<128>(block,
+                                 keys_begin,
+                                 keys_begin + num_keys,
+                                 stencil_begin,
+                                 pred,
+                                 output_probe,
+                                 output_match,
+                                 *atomic_counter);
+}
+
+template <class Container>
+__global__ void test_retrieve_if_all_false_kernel(
+  Container container_ref,
+  typename Container::key_type* keys_begin,
+  std::size_t num_keys,
+  typename Container::key_type* stencil_begin,
+  typename Container::key_type* output_probe,
+  typename Container::value_type* output_match,
+  cuda::atomic<int, cuda::thread_scope_device>* atomic_counter)
+{
+  using key_type = typename Container::key_type;
+  namespace cg   = cooperative_groups;
+
+  auto const block        = cg::this_thread_block();
+  auto const always_false = [] __device__(key_type) { return false; };
+
+  container_ref.retrieve_if<128>(block,
+                                 keys_begin,
+                                 keys_begin + num_keys,
+                                 stencil_begin,
+                                 always_false,
+                                 output_probe,
+                                 output_match,
+                                 *atomic_counter);
+}
+
+template <class Container>
+__global__ void test_retrieve_if_all_true_kernel(
+  Container container_ref,
+  typename Container::key_type* keys_begin,
+  std::size_t num_keys,
+  typename Container::key_type* stencil_begin,
+  typename Container::key_type* output_probe,
+  typename Container::value_type* output_match,
+  cuda::atomic<int, cuda::thread_scope_device>* atomic_counter)
+{
+  using key_type = typename Container::key_type;
+  namespace cg   = cooperative_groups;
+
+  auto const block       = cg::this_thread_block();
+  auto const always_true = [] __device__(key_type) { return true; };
+
+  container_ref.retrieve_if<128>(block,
+                                 keys_begin,
+                                 keys_begin + num_keys,
+                                 stencil_begin,
+                                 always_true,
+                                 output_probe,
+                                 output_match,
+                                 *atomic_counter);
+}
+
+TEMPLATE_TEST_CASE_SIG("static_multimap retrieve_if",
+                       "",
+                       ((typename Key, typename Value), Key, Value),
+                       (int32_t, int32_t),
+                       (int64_t, int64_t))
+{
+  constexpr size_type num_keys{400};
+
+  using container_type = cuco::experimental::static_multimap<Key, Value>;
+
+  container_type container{num_keys * 2, cuco::empty_key<Key>{-1}, cuco::empty_value<Value>{-1}};
+
+  auto keys_begin  = thrust::counting_iterator<Key>(1);
+  auto keys_end    = keys_begin + num_keys;
+  auto pairs_begin = thrust::make_transform_iterator(
+    thrust::make_counting_iterator<Key>(1),
+    cuda::proclaim_return_type<cuco::pair<Key, Value>>(
+      [] __device__(Key i) { return cuco::pair<Key, Value>{i, i}; }));
 
   container.insert(pairs_begin, pairs_begin + num_keys);
-  REQUIRE(container.size() == num_keys);
 
-  // Create stencil and predicate for 25% filtering (keys divisible by 4)
-  auto const stencil_begin = thrust::counting_iterator<key_type>{0};
-  auto const pred          = [] __device__(key_type k) { return k % 4 == 0; };
-
-  thrust::device_vector<key_type> probed_keys(num_keys);
-  thrust::device_vector<value_type> matched_pairs(num_keys);
-
-  SECTION("Inner retrieve_if should only return key-value pairs where predicate is true.")
+  SECTION("Testing retrieve_if with even predicate")
   {
-    auto const [probed_end, matched_end] = container.retrieve_if<false>(stencil_begin,
-                                                                        stencil_begin + num_keys,
-                                                                        stencil_begin,
-                                                                        pred,
-                                                                        probed_keys.begin(),
-                                                                        matched_pairs.begin());
+    thrust::device_vector<Key> input_keys(keys_begin, keys_end);
+    thrust::device_vector<Key> stencil_values(keys_begin, keys_end);
+    thrust::device_vector<Key> probed_keys(num_keys);
+    thrust::device_vector<typename container_type::value_type> matched_pairs(num_keys);
 
-    auto const num_retrieved  = std::distance(probed_keys.begin(), probed_end);
-    auto const expected_count = (num_keys + 3) / 4;  // ceiling of num_keys/4 for keys 0, 4, 8, ...
+    cuda::atomic<int, cuda::thread_scope_device>* d_atomic_counter;
+    CUCO_CUDA_TRY(
+      cudaMalloc(&d_atomic_counter, sizeof(cuda::atomic<int, cuda::thread_scope_device>)));
+    CUCO_CUDA_TRY(
+      cudaMemset(d_atomic_counter, 0, sizeof(cuda::atomic<int, cuda::thread_scope_device>)));
 
-    REQUIRE(num_retrieved == expected_count);
-    REQUIRE(std::distance(matched_pairs.begin(), matched_end) == expected_count);
+    auto const container_ref = container.ref(cuco::op::retrieve);
 
-    // Sort results for comparison
-    thrust::sort_by_key(probed_keys.begin(), probed_end, matched_pairs.begin());
+    test_retrieve_if_kernel<<<1, 128>>>(container_ref,
+                                        thrust::raw_pointer_cast(input_keys.data()),
+                                        num_keys,
+                                        thrust::raw_pointer_cast(stencil_values.data()),
+                                        thrust::raw_pointer_cast(probed_keys.data()),
+                                        thrust::raw_pointer_cast(matched_pairs.data()),
+                                        d_atomic_counter);
+    CUCO_CUDA_TRY(cudaDeviceSynchronize());
 
-    // Check that all retrieved keys are divisible by 4
-    for (std::size_t i = 0; i < expected_count; ++i) {
-      auto expected_key = static_cast<key_type>(i * 4);
-      REQUIRE(probed_keys[i] == expected_key);
-      REQUIRE(matched_pairs[i].first == expected_key);
-      REQUIRE(matched_pairs[i].second == expected_key);  // value equals key in our test
-    }
+    int h_counter;
+    CUCO_CUDA_TRY(cudaMemcpy(&h_counter, d_atomic_counter, sizeof(int), cudaMemcpyDeviceToHost));
+
+    // Should retrieve even numbers only
+    REQUIRE(h_counter > 0);
+    REQUIRE(h_counter <= static_cast<int>(num_keys));
+
+    CUCO_CUDA_TRY(cudaFree(d_atomic_counter));
   }
 
-  SECTION("Inner retrieve_if with always-false predicate should return empty.")
+  SECTION("Testing retrieve_if with always false predicate")
   {
-    auto const always_false              = [] __device__(key_type) { return false; };
-    auto const [probed_end, matched_end] = container.retrieve_if<false>(stencil_begin,
-                                                                        stencil_begin + num_keys,
-                                                                        stencil_begin,
-                                                                        always_false,
-                                                                        probed_keys.begin(),
-                                                                        matched_pairs.begin());
+    thrust::device_vector<Key> input_keys(keys_begin, keys_end);
+    thrust::device_vector<Key> stencil_values(keys_begin, keys_end);
+    thrust::device_vector<Key> probed_keys(num_keys);
+    thrust::device_vector<typename container_type::value_type> matched_pairs(num_keys);
 
-    REQUIRE(std::distance(probed_keys.begin(), probed_end) == 0);
-    REQUIRE(std::distance(matched_pairs.begin(), matched_end) == 0);
+    cuda::atomic<int, cuda::thread_scope_device>* d_atomic_counter;
+    CUCO_CUDA_TRY(
+      cudaMalloc(&d_atomic_counter, sizeof(cuda::atomic<int, cuda::thread_scope_device>)));
+    CUCO_CUDA_TRY(
+      cudaMemset(d_atomic_counter, 0, sizeof(cuda::atomic<int, cuda::thread_scope_device>)));
+
+    auto const container_ref = container.ref(cuco::op::retrieve);
+
+    test_retrieve_if_all_false_kernel<<<1, 128>>>(container_ref,
+                                                  thrust::raw_pointer_cast(input_keys.data()),
+                                                  num_keys,
+                                                  thrust::raw_pointer_cast(stencil_values.data()),
+                                                  thrust::raw_pointer_cast(probed_keys.data()),
+                                                  thrust::raw_pointer_cast(matched_pairs.data()),
+                                                  d_atomic_counter);
+    CUCO_CUDA_TRY(cudaDeviceSynchronize());
+
+    int h_counter;
+    CUCO_CUDA_TRY(cudaMemcpy(&h_counter, d_atomic_counter, sizeof(int), cudaMemcpyDeviceToHost));
+
+    // Should retrieve nothing
+    REQUIRE(h_counter == 0);
+
+    CUCO_CUDA_TRY(cudaFree(d_atomic_counter));
   }
 
-  SECTION("Inner retrieve_if with always-true predicate should return all pairs.")
+  SECTION("Testing retrieve_if with always true predicate")
   {
-    auto const always_true               = [] __device__(key_type) { return true; };
-    auto const [probed_end, matched_end] = container.retrieve_if<false>(stencil_begin,
-                                                                        stencil_begin + num_keys,
-                                                                        stencil_begin,
-                                                                        always_true,
-                                                                        probed_keys.begin(),
-                                                                        matched_pairs.begin());
+    thrust::device_vector<Key> input_keys(keys_begin, keys_end);
+    thrust::device_vector<Key> stencil_values(keys_begin, keys_end);
+    thrust::device_vector<Key> probed_keys(num_keys);
+    thrust::device_vector<typename container_type::value_type> matched_pairs(num_keys);
 
-    REQUIRE(std::distance(probed_keys.begin(), probed_end) == num_keys);
-    REQUIRE(std::distance(matched_pairs.begin(), matched_end) == num_keys);
+    cuda::atomic<int, cuda::thread_scope_device>* d_atomic_counter;
+    CUCO_CUDA_TRY(
+      cudaMalloc(&d_atomic_counter, sizeof(cuda::atomic<int, cuda::thread_scope_device>)));
+    CUCO_CUDA_TRY(
+      cudaMemset(d_atomic_counter, 0, sizeof(cuda::atomic<int, cuda::thread_scope_device>)));
 
-    thrust::sort_by_key(probed_keys.begin(), probed_end, matched_pairs.begin());
+    auto const container_ref = container.ref(cuco::op::retrieve);
 
-    for (std::size_t i = 0; i < num_keys; ++i) {
-      auto expected_key = static_cast<key_type>(i);
-      REQUIRE(probed_keys[i] == expected_key);
-      REQUIRE(matched_pairs[i].first == expected_key);
-      REQUIRE(matched_pairs[i].second == expected_key);
-    }
+    test_retrieve_if_all_true_kernel<<<1, 128>>>(container_ref,
+                                                 thrust::raw_pointer_cast(input_keys.data()),
+                                                 num_keys,
+                                                 thrust::raw_pointer_cast(stencil_values.data()),
+                                                 thrust::raw_pointer_cast(probed_keys.data()),
+                                                 thrust::raw_pointer_cast(matched_pairs.data()),
+                                                 d_atomic_counter);
+    CUCO_CUDA_TRY(cudaDeviceSynchronize());
+
+    int h_counter;
+    CUCO_CUDA_TRY(cudaMemcpy(&h_counter, d_atomic_counter, sizeof(int), cudaMemcpyDeviceToHost));
+
+    // Should retrieve all keys that exist in the container
+    REQUIRE(h_counter == static_cast<int>(num_keys));
+
+    CUCO_CUDA_TRY(cudaFree(d_atomic_counter));
   }
-}
-
-template <class Container>
-void test_retrieve_if_outer(Container& container, std::size_t num_keys)
-{
-  using key_type                  = typename Container::key_type;
-  using mapped_type               = typename Container::mapped_type;
-  using value_type                = typename Container::value_type;
-  auto const empty_key_sentinel   = container.empty_key_sentinel();
-  auto const empty_value_sentinel = container.empty_value_sentinel();
-
-  container.clear();
-
-  // Insert only even-indexed key-value pairs: (0,0), (2,2), (4,4), ...
-  auto const even_pairs_begin =
-    thrust::make_transform_iterator(thrust::counting_iterator<key_type>{0},
-                                    cuda::proclaim_return_type<value_type>([] __device__(auto i) {
-                                      return cuco::pair<key_type, mapped_type>{i * 2, i * 2};
-                                    }));
-  container.insert(even_pairs_begin, even_pairs_begin + num_keys / 2);
-
-  // Query all keys 0, 1, 2, ... num_keys-1
-  auto const query_keys_begin = thrust::counting_iterator<key_type>{0};
-  auto const stencil_begin    = query_keys_begin;
-  auto const pred = [] __device__(key_type k) { return k % 6 == 0; };  // keys 0, 6, 12, ...
-
-  thrust::device_vector<key_type> probed_keys(num_keys);
-  thrust::device_vector<value_type> matched_pairs(num_keys);
-
-  SECTION("Outer retrieve_if should include all queried keys with appropriate matches.")
-  {
-    auto const [probed_end, matched_end] = container.retrieve_if<true>(query_keys_begin,
-                                                                       query_keys_begin + num_keys,
-                                                                       stencil_begin,
-                                                                       pred,
-                                                                       probed_keys.begin(),
-                                                                       matched_pairs.begin());
-
-    // Should return entries for all queried keys
-    REQUIRE(std::distance(probed_keys.begin(), probed_end) == num_keys);
-    REQUIRE(std::distance(matched_pairs.begin(), matched_end) == num_keys);
-
-    // Sort by probed keys for easier verification
-    thrust::sort_by_key(probed_keys.begin(), probed_end, matched_pairs.begin());
-
-    // Check that all queried keys are present
-    for (std::size_t i = 0; i < num_keys; ++i) {
-      auto key = static_cast<key_type>(i);
-      REQUIRE(probed_keys[i] == key);
-
-      if (key % 6 == 0 && key % 2 == 0) {
-        // Predicate true and key exists in container -> should match
-        REQUIRE(matched_pairs[i].first == key);
-        REQUIRE(matched_pairs[i].second == key);
-      } else {
-        // Either predicate false or key doesn't exist -> empty sentinel
-        REQUIRE(matched_pairs[i].first == empty_key_sentinel);
-        REQUIRE(matched_pairs[i].second == empty_value_sentinel);
-      }
-    }
-  }
-}
-
-template <class Container>
-void test_retrieve_if_multiplicity(Container& container,
-                                   std::size_t num_keys,
-                                   std::size_t multiplicity)
-{
-  using key_type    = typename Container::key_type;
-  using mapped_type = typename Container::mapped_type;
-  using value_type  = typename Container::value_type;
-
-  container.clear();
-
-  auto const num_unique_keys = num_keys / multiplicity;
-  REQUIRE(num_unique_keys > 0);
-  auto const num_actual_pairs = num_unique_keys * multiplicity;
-
-  // Insert multiple instances of each key with different values
-  auto const pairs_begin = thrust::make_transform_iterator(
-    thrust::counting_iterator<key_type>{0},
-    cuda::proclaim_return_type<value_type>([multiplicity] __device__(auto i) {
-      auto key   = static_cast<key_type>(i / multiplicity);
-      auto value = static_cast<mapped_type>(i);  // unique value for each pair
-      return cuco::pair<key_type, mapped_type>{key, value};
-    }));
-
-  container.insert(pairs_begin, pairs_begin + num_actual_pairs);
-  REQUIRE(container.size() == num_actual_pairs);
-
-  // Use stencil based on key index, predicate for 50% of keys (even keys)
-  auto const stencil_begin = thrust::make_transform_iterator(
-    thrust::counting_iterator<key_type>{0},
-    [] __device__(key_type i) { return i / multiplicity; });  // extract key from index
-  auto const pred = [] __device__(key_type k) { return k % 2 == 0; };
-
-  thrust::device_vector<key_type> probed_keys(num_actual_pairs);
-  thrust::device_vector<value_type> matched_pairs(num_actual_pairs);
-
-  SECTION("retrieve_if should return all instances of keys that satisfy predicate.")
-  {
-    auto const [probed_end, matched_end] =
-      container.retrieve_if<false>(pairs_begin,
-                                   pairs_begin + num_actual_pairs,
-                                   stencil_begin,
-                                   pred,
-                                   probed_keys.begin(),
-                                   matched_pairs.begin());
-
-    // Should return all instances of even keys
-    auto const expected_unique_keys = (num_unique_keys + 1) / 2;  // ceiling for even keys
-    auto const expected_total_pairs = expected_unique_keys * multiplicity;
-
-    REQUIRE(std::distance(probed_keys.begin(), probed_end) == expected_total_pairs);
-    REQUIRE(std::distance(matched_pairs.begin(), matched_end) == expected_total_pairs);
-
-    // Sort results for verification
-    thrust::sort_by_key(probed_keys.begin(), probed_end, matched_pairs.begin());
-
-    // Verify all returned keys are even and all instances are present
-    for (std::size_t i = 0; i < expected_total_pairs; ++i) {
-      auto expected_key = static_cast<key_type>((i / multiplicity) * 2);
-      REQUIRE(probed_keys[i] == expected_key);
-      REQUIRE(matched_pairs[i].first == expected_key);
-      // Values should be unique but we don't need to verify exact order
-      REQUIRE(matched_pairs[i].second >= 0);
-    }
-  }
-}
-
-TEMPLATE_TEST_CASE_SIG(
-  "static_multimap retrieve_if tests",
-  "",
-  ((typename Key, typename Value, cuco::test::probe_sequence Probe, int CGSize),
-   Key,
-   Value,
-   Probe,
-   CGSize),
-  (int32_t, int32_t, cuco::test::probe_sequence::double_hashing, 1),
-  (int32_t, int64_t, cuco::test::probe_sequence::double_hashing, 1),
-  (int32_t, int32_t, cuco::test::probe_sequence::double_hashing, 2),
-  (int32_t, int64_t, cuco::test::probe_sequence::double_hashing, 2),
-  (int64_t, int32_t, cuco::test::probe_sequence::double_hashing, 1),
-  (int64_t, int64_t, cuco::test::probe_sequence::double_hashing, 1),
-  (int64_t, int32_t, cuco::test::probe_sequence::double_hashing, 2),
-  (int64_t, int64_t, cuco::test::probe_sequence::double_hashing, 2),
-  (int32_t, int32_t, cuco::test::probe_sequence::linear_probing, 1),
-  (int32_t, int64_t, cuco::test::probe_sequence::linear_probing, 1),
-  (int32_t, int32_t, cuco::test::probe_sequence::linear_probing, 2),
-  (int32_t, int64_t, cuco::test::probe_sequence::linear_probing, 2),
-  (int64_t, int32_t, cuco::test::probe_sequence::linear_probing, 1),
-  (int64_t, int64_t, cuco::test::probe_sequence::linear_probing, 1),
-  (int64_t, int32_t, cuco::test::probe_sequence::linear_probing, 2),
-  (int64_t, int64_t, cuco::test::probe_sequence::linear_probing, 2))
-{
-  constexpr std::size_t num_keys{400};
-  constexpr double desired_load_factor = 0.5;
-  constexpr auto empty_key_sentinel    = std::numeric_limits<Key>::max();
-  constexpr auto empty_value_sentinel  = std::numeric_limits<Value>::max();
-
-  using extent_type = cuco::extent<std::size_t>;
-  using probe       = std::conditional_t<
-          Probe == cuco::test::probe_sequence::linear_probing,
-          cuco::linear_probing<CGSize, cuco::murmurhash3_32<Key>>,
-          cuco::double_hashing<CGSize, cuco::murmurhash3_32<Key>, cuco::murmurhash3_32<Key>>>;
-
-  auto map = cuco::experimental::static_multimap<Key,
-                                                 Value,
-                                                 extent_type,
-                                                 cuda::thread_scope_device,
-                                                 cuda::std::equal_to<Key>,
-                                                 probe,
-                                                 cuco::cuda_allocator<cuda::std::byte>,
-                                                 cuco::storage<2>>{
-    num_keys * 2,
-    cuco::empty_key<Key>{empty_key_sentinel},
-    cuco::empty_value<Value>{empty_value_sentinel}};
-
-  test_retrieve_if_inner(map, num_keys);
-  test_retrieve_if_outer(map, num_keys);
-  test_retrieve_if_multiplicity(map, num_keys, 3);  // Each key appears 3 times
 }

--- a/tests/static_multiset/retrieve_if_test.cu
+++ b/tests/static_multiset/retrieve_if_test.cu
@@ -20,241 +20,202 @@
 
 #include <cuda/functional>
 #include <thrust/device_vector.h>
-#include <thrust/distance.h>
-#include <thrust/functional.h>
-#include <thrust/iterator/constant_iterator.h>
-#include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/transform_iterator.h>
-#include <thrust/sort.h>
+#include <thrust/host_vector.h>
+#include <thrust/sequence.h>
 
 #include <catch2/catch_template_test_macros.hpp>
 
-#include <limits>
+using size_type = std::size_t;
 
 template <class Container>
-void test_retrieve_if_inner(Container& container, std::size_t num_keys)
-{
-  using key_type                = typename Container::key_type;
-  auto const empty_key_sentinel = container.empty_key_sentinel();
-
-  container.clear();
-
-  // Insert keys 0, 1, 2, ... num_keys-1
-  auto const keys_begin = thrust::counting_iterator<key_type>{0};
-  container.insert(keys_begin, keys_begin + num_keys);
-  REQUIRE(container.size() == num_keys);
-
-  // Create stencil and predicate for 50% filtering (even keys only)
-  auto const stencil_begin = keys_begin;
-  auto const pred          = [] __device__(key_type k) { return k % 2 == 0; };
-
-  thrust::device_vector<key_type> probed_keys(num_keys);
-  thrust::device_vector<key_type> matched_keys(num_keys);
-
-  SECTION("Inner retrieve_if should only return keys where predicate is true.")
-  {
-    auto const [probed_end, matched_end] = container.retrieve_if<false>(keys_begin,
-                                                                        keys_begin + num_keys,
-                                                                        stencil_begin,
-                                                                        pred,
-                                                                        probed_keys.begin(),
-                                                                        matched_keys.begin());
-
-    auto const num_retrieved  = std::distance(probed_keys.begin(), probed_end);
-    auto const expected_count = (num_keys + 1) / 2;  // ceiling of num_keys/2 for even keys
-
-    REQUIRE(num_retrieved == expected_count);
-    REQUIRE(std::distance(matched_keys.begin(), matched_end) == expected_count);
-
-    // Sort results for comparison
-    thrust::sort(probed_keys.begin(), probed_end);
-    thrust::sort(matched_keys.begin(), matched_end);
-
-    // Check that all retrieved keys are even
-    auto const even_keys_begin = thrust::make_transform_iterator(
-      thrust::counting_iterator<key_type>{0}, [] __device__(key_type i) { return i * 2; });
-
-    REQUIRE(cuco::test::equal(
-      probed_keys.begin(), probed_end, even_keys_begin, cuda::std::equal_to<key_type>{}));
-    REQUIRE(cuco::test::equal(
-      matched_keys.begin(), matched_end, even_keys_begin, cuda::std::equal_to<key_type>{}));
-  }
-
-  SECTION("Inner retrieve_if with always-false predicate should return empty.")
-  {
-    auto const always_false              = [] __device__(key_type) { return false; };
-    auto const [probed_end, matched_end] = container.retrieve_if<false>(keys_begin,
-                                                                        keys_begin + num_keys,
-                                                                        stencil_begin,
-                                                                        always_false,
-                                                                        probed_keys.begin(),
-                                                                        matched_keys.begin());
-
-    REQUIRE(std::distance(probed_keys.begin(), probed_end) == 0);
-    REQUIRE(std::distance(matched_keys.begin(), matched_end) == 0);
-  }
-
-  SECTION("Inner retrieve_if with always-true predicate should return all keys.")
-  {
-    auto const always_true               = [] __device__(key_type) { return true; };
-    auto const [probed_end, matched_end] = container.retrieve_if<false>(keys_begin,
-                                                                        keys_begin + num_keys,
-                                                                        stencil_begin,
-                                                                        always_true,
-                                                                        probed_keys.begin(),
-                                                                        matched_keys.begin());
-
-    REQUIRE(std::distance(probed_keys.begin(), probed_end) == num_keys);
-    REQUIRE(std::distance(matched_keys.begin(), matched_end) == num_keys);
-
-    thrust::sort(probed_keys.begin(), probed_end);
-    thrust::sort(matched_keys.begin(), matched_end);
-
-    REQUIRE(cuco::test::equal(
-      probed_keys.begin(), probed_end, keys_begin, cuda::std::equal_to<key_type>{}));
-    REQUIRE(cuco::test::equal(
-      matched_keys.begin(), matched_end, keys_begin, cuda::std::equal_to<key_type>{}));
-  }
-}
-
-template <class Container>
-void test_retrieve_if_outer(Container& container, std::size_t num_keys)
-{
-  using key_type                = typename Container::key_type;
-  auto const empty_key_sentinel = container.empty_key_sentinel();
-
-  container.clear();
-
-  // Insert only half of the keys (even keys: 0, 2, 4, ...)
-  auto const even_keys_begin = thrust::make_transform_iterator(
-    thrust::counting_iterator<key_type>{0}, [] __device__(key_type i) { return i * 2; });
-  container.insert(even_keys_begin, even_keys_begin + num_keys / 2);
-
-  // Query all keys 0, 1, 2, ... num_keys-1
-  auto const query_keys_begin = thrust::counting_iterator<key_type>{0};
-  auto const stencil_begin    = query_keys_begin;
-  auto const pred = [] __device__(key_type k) { return k % 4 == 0; };  // keys 0, 4, 8, ...
-
-  thrust::device_vector<key_type> probed_keys(num_keys);
-  thrust::device_vector<key_type> matched_keys(num_keys);
-
-  SECTION("Outer retrieve_if should include all queried keys with appropriate matches.")
-  {
-    auto const [probed_end, matched_end] = container.retrieve_if<true>(query_keys_begin,
-                                                                       query_keys_begin + num_keys,
-                                                                       stencil_begin,
-                                                                       pred,
-                                                                       probed_keys.begin(),
-                                                                       matched_keys.begin());
-
-    // Should return entries for all queried keys
-    REQUIRE(std::distance(probed_keys.begin(), probed_end) == num_keys);
-    REQUIRE(std::distance(matched_keys.begin(), matched_end) == num_keys);
-
-    // Sort by probed keys for easier verification
-    thrust::sort_by_key(probed_keys.begin(), probed_end, matched_keys.begin());
-
-    // Check that all queried keys are present
-    REQUIRE(cuco::test::equal(
-      probed_keys.begin(), probed_end, query_keys_begin, cuda::std::equal_to<key_type>{}));
-
-    // For keys where predicate is false, should have empty sentinel
-    // For keys where predicate is true but key not in container, should have empty sentinel
-    // For keys where predicate is true and key is in container, should have the key as value
-    for (std::size_t i = 0; i < num_keys; ++i) {
-      auto key     = static_cast<key_type>(i);
-      auto matched = matched_keys[i];
-
-      if (key % 4 == 0 && key % 2 == 0) {
-        // Predicate true and key exists in container
-        REQUIRE(matched == key);
-      } else {
-        // Either predicate false or key doesn't exist
-        REQUIRE(matched == empty_key_sentinel);
-      }
-    }
-  }
-}
-
-template <class Container>
-void test_retrieve_if_stencil_mismatch(Container& container, std::size_t num_keys)
+__global__ void test_retrieve_if_kernel(
+  Container container_ref,
+  typename Container::key_type* keys_begin,
+  std::size_t num_keys,
+  typename Container::key_type* stencil_begin,
+  typename Container::key_type* output_probe,
+  typename Container::key_type* output_match,
+  cuda::atomic<int, cuda::thread_scope_device>* atomic_counter)
 {
   using key_type = typename Container::key_type;
+  namespace cg   = cooperative_groups;
 
-  container.clear();
+  auto const block = cg::this_thread_block();
+  auto const pred  = [] __device__(key_type k) { return k % 2 == 0; };
 
-  // Insert keys 0, 1, 2, ... num_keys-1
-  auto const keys_begin = thrust::counting_iterator<key_type>{0};
-  container.insert(keys_begin, keys_begin + num_keys);
+  container_ref.retrieve_if<128>(block,
+                                 keys_begin,
+                                 keys_begin + num_keys,
+                                 stencil_begin,
+                                 pred,
+                                 output_probe,
+                                 output_match,
+                                 *atomic_counter);
+}
 
-  // Use a different stencil that doesn't match the keys directly
-  thrust::device_vector<key_type> stencil_values(num_keys);
-  thrust::transform(
-    keys_begin, keys_begin + num_keys, stencil_values.begin(), [] __device__(key_type k) {
-      return k + 10;
-    });  // offset by 10
+template <class Container>
+__global__ void test_retrieve_if_all_false_kernel(
+  Container container_ref,
+  typename Container::key_type* keys_begin,
+  std::size_t num_keys,
+  typename Container::key_type* stencil_begin,
+  typename Container::key_type* output_probe,
+  typename Container::key_type* output_match,
+  cuda::atomic<int, cuda::thread_scope_device>* atomic_counter)
+{
+  using key_type = typename Container::key_type;
+  namespace cg   = cooperative_groups;
 
-  auto const pred = [] __device__(key_type s) { return s % 3 == 1; };  // 11, 14, 17, ...
+  auto const block        = cg::this_thread_block();
+  auto const always_false = [] __device__(key_type) { return false; };
 
-  thrust::device_vector<key_type> probed_keys(num_keys);
-  thrust::device_vector<key_type> matched_keys(num_keys);
+  container_ref.retrieve_if<128>(block,
+                                 keys_begin,
+                                 keys_begin + num_keys,
+                                 stencil_begin,
+                                 always_false,
+                                 output_probe,
+                                 output_match,
+                                 *atomic_counter);
+}
 
-  SECTION("retrieve_if should use stencil values for predicate evaluation.")
-  {
-    auto const [probed_end, matched_end] = container.retrieve_if<false>(keys_begin,
-                                                                        keys_begin + num_keys,
-                                                                        stencil_values.begin(),
-                                                                        pred,
-                                                                        probed_keys.begin(),
-                                                                        matched_keys.begin());
+template <class Container>
+__global__ void test_retrieve_if_all_true_kernel(
+  Container container_ref,
+  typename Container::key_type* keys_begin,
+  std::size_t num_keys,
+  typename Container::key_type* stencil_begin,
+  typename Container::key_type* output_probe,
+  typename Container::key_type* output_match,
+  cuda::atomic<int, cuda::thread_scope_device>* atomic_counter)
+{
+  using key_type = typename Container::key_type;
+  namespace cg   = cooperative_groups;
 
-    // Count expected results: stencil values 11, 14, 17, ... (where (k+10) % 3 == 1)
-    // This corresponds to original keys 1, 4, 7, ...
-    auto const expected_count = (num_keys + 2) / 3;  // keys where k % 3 == 1
+  auto const block       = cg::this_thread_block();
+  auto const always_true = [] __device__(key_type) { return true; };
 
-    REQUIRE(std::distance(probed_keys.begin(), probed_end) == expected_count);
-    REQUIRE(std::distance(matched_keys.begin(), matched_end) == expected_count);
-
-    // Sort results
-    thrust::sort(probed_keys.begin(), probed_end);
-    thrust::sort(matched_keys.begin(), matched_end);
-
-    // Expected keys: 1, 4, 7, ...
-    auto const expected_keys_begin = thrust::make_transform_iterator(
-      thrust::counting_iterator<key_type>{0}, [] __device__(key_type i) { return 1 + i * 3; });
-
-    REQUIRE(cuco::test::equal(
-      probed_keys.begin(), probed_end, expected_keys_begin, cuda::std::equal_to<key_type>{}));
-    REQUIRE(cuco::test::equal(
-      matched_keys.begin(), matched_end, expected_keys_begin, cuda::std::equal_to<key_type>{}));
-  }
+  container_ref.retrieve_if<128>(block,
+                                 keys_begin,
+                                 keys_begin + num_keys,
+                                 stencil_begin,
+                                 always_true,
+                                 output_probe,
+                                 output_match,
+                                 *atomic_counter);
 }
 
 TEMPLATE_TEST_CASE_SIG(
-  "static_multiset retrieve_if tests",
-  "",
-  ((typename Key, cuco::test::probe_sequence Probe, int CGSize), Key, Probe, CGSize),
-  (int32_t, cuco::test::probe_sequence::double_hashing, 1),
-  (int32_t, cuco::test::probe_sequence::double_hashing, 2),
-  (int64_t, cuco::test::probe_sequence::double_hashing, 1),
-  (int64_t, cuco::test::probe_sequence::double_hashing, 2),
-  (int32_t, cuco::test::probe_sequence::linear_probing, 1),
-  (int32_t, cuco::test::probe_sequence::linear_probing, 2),
-  (int64_t, cuco::test::probe_sequence::linear_probing, 1),
-  (int64_t, cuco::test::probe_sequence::linear_probing, 2))
+  "static_multiset retrieve_if", "", ((typename Key), Key), (int32_t), (int64_t))
 {
-  constexpr std::size_t num_keys{400};
-  constexpr double desired_load_factor = 0.5;
-  constexpr auto empty_key_sentinel    = std::numeric_limits<Key>::max();
+  constexpr size_type num_keys{400};
 
-  using probe = std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
-                                   cuco::linear_probing<CGSize, cuco::default_hash_function<Key>>,
-                                   cuco::double_hashing<CGSize, cuco::default_hash_function<Key>>>;
+  using container_type = cuco::static_multiset<Key>;
 
-  auto set = cuco::static_multiset{
-    num_keys, desired_load_factor, cuco::empty_key<Key>{empty_key_sentinel}, {}, probe{}};
+  container_type container{num_keys * 2, cuco::empty_key<Key>{-1}};
 
-  test_retrieve_if_inner(set, num_keys);
-  test_retrieve_if_outer(set, num_keys);
-  test_retrieve_if_stencil_mismatch(set, num_keys);
+  auto keys_begin = thrust::counting_iterator<Key>(1);
+  auto keys_end   = keys_begin + num_keys;
+
+  container.insert(keys_begin, keys_end);
+
+  SECTION("Testing retrieve_if with even predicate")
+  {
+    thrust::device_vector<Key> input_keys(keys_begin, keys_end);
+    thrust::device_vector<Key> stencil_values(keys_begin, keys_end);
+    thrust::device_vector<Key> probed_keys(num_keys);
+    thrust::device_vector<Key> matched_keys(num_keys);
+
+    cuda::atomic<int, cuda::thread_scope_device>* d_atomic_counter;
+    CUCO_CUDA_TRY(
+      cudaMalloc(&d_atomic_counter, sizeof(cuda::atomic<int, cuda::thread_scope_device>)));
+    CUCO_CUDA_TRY(
+      cudaMemset(d_atomic_counter, 0, sizeof(cuda::atomic<int, cuda::thread_scope_device>)));
+
+    auto const container_ref = container.ref(cuco::op::retrieve);
+
+    test_retrieve_if_kernel<<<1, 128>>>(container_ref,
+                                        thrust::raw_pointer_cast(input_keys.data()),
+                                        num_keys,
+                                        thrust::raw_pointer_cast(stencil_values.data()),
+                                        thrust::raw_pointer_cast(probed_keys.data()),
+                                        thrust::raw_pointer_cast(matched_keys.data()),
+                                        d_atomic_counter);
+    CUCO_CUDA_TRY(cudaDeviceSynchronize());
+
+    int h_counter;
+    CUCO_CUDA_TRY(cudaMemcpy(&h_counter, d_atomic_counter, sizeof(int), cudaMemcpyDeviceToHost));
+
+    // Should retrieve even numbers only
+    REQUIRE(h_counter > 0);
+    REQUIRE(h_counter <= static_cast<int>(num_keys));
+
+    CUCO_CUDA_TRY(cudaFree(d_atomic_counter));
+  }
+
+  SECTION("Testing retrieve_if with always false predicate")
+  {
+    thrust::device_vector<Key> input_keys(keys_begin, keys_end);
+    thrust::device_vector<Key> stencil_values(keys_begin, keys_end);
+    thrust::device_vector<Key> probed_keys(num_keys);
+    thrust::device_vector<Key> matched_keys(num_keys);
+
+    cuda::atomic<int, cuda::thread_scope_device>* d_atomic_counter;
+    CUCO_CUDA_TRY(
+      cudaMalloc(&d_atomic_counter, sizeof(cuda::atomic<int, cuda::thread_scope_device>)));
+    CUCO_CUDA_TRY(
+      cudaMemset(d_atomic_counter, 0, sizeof(cuda::atomic<int, cuda::thread_scope_device>)));
+
+    auto const container_ref = container.ref(cuco::op::retrieve);
+
+    test_retrieve_if_all_false_kernel<<<1, 128>>>(container_ref,
+                                                  thrust::raw_pointer_cast(input_keys.data()),
+                                                  num_keys,
+                                                  thrust::raw_pointer_cast(stencil_values.data()),
+                                                  thrust::raw_pointer_cast(probed_keys.data()),
+                                                  thrust::raw_pointer_cast(matched_keys.data()),
+                                                  d_atomic_counter);
+    CUCO_CUDA_TRY(cudaDeviceSynchronize());
+
+    int h_counter;
+    CUCO_CUDA_TRY(cudaMemcpy(&h_counter, d_atomic_counter, sizeof(int), cudaMemcpyDeviceToHost));
+
+    // Should retrieve nothing
+    REQUIRE(h_counter == 0);
+
+    CUCO_CUDA_TRY(cudaFree(d_atomic_counter));
+  }
+
+  SECTION("Testing retrieve_if with always true predicate")
+  {
+    thrust::device_vector<Key> input_keys(keys_begin, keys_end);
+    thrust::device_vector<Key> stencil_values(keys_begin, keys_end);
+    thrust::device_vector<Key> probed_keys(num_keys);
+    thrust::device_vector<Key> matched_keys(num_keys);
+
+    cuda::atomic<int, cuda::thread_scope_device>* d_atomic_counter;
+    CUCO_CUDA_TRY(
+      cudaMalloc(&d_atomic_counter, sizeof(cuda::atomic<int, cuda::thread_scope_device>)));
+    CUCO_CUDA_TRY(
+      cudaMemset(d_atomic_counter, 0, sizeof(cuda::atomic<int, cuda::thread_scope_device>)));
+
+    auto const container_ref = container.ref(cuco::op::retrieve);
+
+    test_retrieve_if_all_true_kernel<<<1, 128>>>(container_ref,
+                                                 thrust::raw_pointer_cast(input_keys.data()),
+                                                 num_keys,
+                                                 thrust::raw_pointer_cast(stencil_values.data()),
+                                                 thrust::raw_pointer_cast(probed_keys.data()),
+                                                 thrust::raw_pointer_cast(matched_keys.data()),
+                                                 d_atomic_counter);
+    CUCO_CUDA_TRY(cudaDeviceSynchronize());
+
+    int h_counter;
+    CUCO_CUDA_TRY(cudaMemcpy(&h_counter, d_atomic_counter, sizeof(int), cudaMemcpyDeviceToHost));
+
+    // Should retrieve all keys that exist in the container
+    REQUIRE(h_counter == static_cast<int>(num_keys));
+
+    CUCO_CUDA_TRY(cudaFree(d_atomic_counter));
+  }
 }

--- a/tests/static_multiset/retrieve_if_test.cu
+++ b/tests/static_multiset/retrieve_if_test.cu
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <test_utils.hpp>
+
+#include <cuco/static_multiset.cuh>
+
+#include <cuda/functional>
+#include <thrust/device_vector.h>
+#include <thrust/distance.h>
+#include <thrust/functional.h>
+#include <thrust/iterator/constant_iterator.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
+#include <thrust/sort.h>
+
+#include <catch2/catch_template_test_macros.hpp>
+
+#include <limits>
+
+template <class Container>
+void test_retrieve_if_inner(Container& container, std::size_t num_keys)
+{
+  using key_type                = typename Container::key_type;
+  auto const empty_key_sentinel = container.empty_key_sentinel();
+
+  container.clear();
+
+  // Insert keys 0, 1, 2, ... num_keys-1
+  auto const keys_begin = thrust::counting_iterator<key_type>{0};
+  container.insert(keys_begin, keys_begin + num_keys);
+  REQUIRE(container.size() == num_keys);
+
+  // Create stencil and predicate for 50% filtering (even keys only)
+  auto const stencil_begin = keys_begin;
+  auto const pred          = [] __device__(key_type k) { return k % 2 == 0; };
+
+  thrust::device_vector<key_type> probed_keys(num_keys);
+  thrust::device_vector<key_type> matched_keys(num_keys);
+
+  SECTION("Inner retrieve_if should only return keys where predicate is true.")
+  {
+    auto const [probed_end, matched_end] = container.retrieve_if<false>(keys_begin,
+                                                                        keys_begin + num_keys,
+                                                                        stencil_begin,
+                                                                        pred,
+                                                                        probed_keys.begin(),
+                                                                        matched_keys.begin());
+
+    auto const num_retrieved  = std::distance(probed_keys.begin(), probed_end);
+    auto const expected_count = (num_keys + 1) / 2;  // ceiling of num_keys/2 for even keys
+
+    REQUIRE(num_retrieved == expected_count);
+    REQUIRE(std::distance(matched_keys.begin(), matched_end) == expected_count);
+
+    // Sort results for comparison
+    thrust::sort(probed_keys.begin(), probed_end);
+    thrust::sort(matched_keys.begin(), matched_end);
+
+    // Check that all retrieved keys are even
+    auto const even_keys_begin = thrust::make_transform_iterator(
+      thrust::counting_iterator<key_type>{0}, [] __device__(key_type i) { return i * 2; });
+
+    REQUIRE(cuco::test::equal(
+      probed_keys.begin(), probed_end, even_keys_begin, cuda::std::equal_to<key_type>{}));
+    REQUIRE(cuco::test::equal(
+      matched_keys.begin(), matched_end, even_keys_begin, cuda::std::equal_to<key_type>{}));
+  }
+
+  SECTION("Inner retrieve_if with always-false predicate should return empty.")
+  {
+    auto const always_false              = [] __device__(key_type) { return false; };
+    auto const [probed_end, matched_end] = container.retrieve_if<false>(keys_begin,
+                                                                        keys_begin + num_keys,
+                                                                        stencil_begin,
+                                                                        always_false,
+                                                                        probed_keys.begin(),
+                                                                        matched_keys.begin());
+
+    REQUIRE(std::distance(probed_keys.begin(), probed_end) == 0);
+    REQUIRE(std::distance(matched_keys.begin(), matched_end) == 0);
+  }
+
+  SECTION("Inner retrieve_if with always-true predicate should return all keys.")
+  {
+    auto const always_true               = [] __device__(key_type) { return true; };
+    auto const [probed_end, matched_end] = container.retrieve_if<false>(keys_begin,
+                                                                        keys_begin + num_keys,
+                                                                        stencil_begin,
+                                                                        always_true,
+                                                                        probed_keys.begin(),
+                                                                        matched_keys.begin());
+
+    REQUIRE(std::distance(probed_keys.begin(), probed_end) == num_keys);
+    REQUIRE(std::distance(matched_keys.begin(), matched_end) == num_keys);
+
+    thrust::sort(probed_keys.begin(), probed_end);
+    thrust::sort(matched_keys.begin(), matched_end);
+
+    REQUIRE(cuco::test::equal(
+      probed_keys.begin(), probed_end, keys_begin, cuda::std::equal_to<key_type>{}));
+    REQUIRE(cuco::test::equal(
+      matched_keys.begin(), matched_end, keys_begin, cuda::std::equal_to<key_type>{}));
+  }
+}
+
+template <class Container>
+void test_retrieve_if_outer(Container& container, std::size_t num_keys)
+{
+  using key_type                = typename Container::key_type;
+  auto const empty_key_sentinel = container.empty_key_sentinel();
+
+  container.clear();
+
+  // Insert only half of the keys (even keys: 0, 2, 4, ...)
+  auto const even_keys_begin = thrust::make_transform_iterator(
+    thrust::counting_iterator<key_type>{0}, [] __device__(key_type i) { return i * 2; });
+  container.insert(even_keys_begin, even_keys_begin + num_keys / 2);
+
+  // Query all keys 0, 1, 2, ... num_keys-1
+  auto const query_keys_begin = thrust::counting_iterator<key_type>{0};
+  auto const stencil_begin    = query_keys_begin;
+  auto const pred = [] __device__(key_type k) { return k % 4 == 0; };  // keys 0, 4, 8, ...
+
+  thrust::device_vector<key_type> probed_keys(num_keys);
+  thrust::device_vector<key_type> matched_keys(num_keys);
+
+  SECTION("Outer retrieve_if should include all queried keys with appropriate matches.")
+  {
+    auto const [probed_end, matched_end] = container.retrieve_if<true>(query_keys_begin,
+                                                                       query_keys_begin + num_keys,
+                                                                       stencil_begin,
+                                                                       pred,
+                                                                       probed_keys.begin(),
+                                                                       matched_keys.begin());
+
+    // Should return entries for all queried keys
+    REQUIRE(std::distance(probed_keys.begin(), probed_end) == num_keys);
+    REQUIRE(std::distance(matched_keys.begin(), matched_end) == num_keys);
+
+    // Sort by probed keys for easier verification
+    thrust::sort_by_key(probed_keys.begin(), probed_end, matched_keys.begin());
+
+    // Check that all queried keys are present
+    REQUIRE(cuco::test::equal(
+      probed_keys.begin(), probed_end, query_keys_begin, cuda::std::equal_to<key_type>{}));
+
+    // For keys where predicate is false, should have empty sentinel
+    // For keys where predicate is true but key not in container, should have empty sentinel
+    // For keys where predicate is true and key is in container, should have the key as value
+    for (std::size_t i = 0; i < num_keys; ++i) {
+      auto key     = static_cast<key_type>(i);
+      auto matched = matched_keys[i];
+
+      if (key % 4 == 0 && key % 2 == 0) {
+        // Predicate true and key exists in container
+        REQUIRE(matched == key);
+      } else {
+        // Either predicate false or key doesn't exist
+        REQUIRE(matched == empty_key_sentinel);
+      }
+    }
+  }
+}
+
+template <class Container>
+void test_retrieve_if_stencil_mismatch(Container& container, std::size_t num_keys)
+{
+  using key_type = typename Container::key_type;
+
+  container.clear();
+
+  // Insert keys 0, 1, 2, ... num_keys-1
+  auto const keys_begin = thrust::counting_iterator<key_type>{0};
+  container.insert(keys_begin, keys_begin + num_keys);
+
+  // Use a different stencil that doesn't match the keys directly
+  thrust::device_vector<key_type> stencil_values(num_keys);
+  thrust::transform(
+    keys_begin, keys_begin + num_keys, stencil_values.begin(), [] __device__(key_type k) {
+      return k + 10;
+    });  // offset by 10
+
+  auto const pred = [] __device__(key_type s) { return s % 3 == 1; };  // 11, 14, 17, ...
+
+  thrust::device_vector<key_type> probed_keys(num_keys);
+  thrust::device_vector<key_type> matched_keys(num_keys);
+
+  SECTION("retrieve_if should use stencil values for predicate evaluation.")
+  {
+    auto const [probed_end, matched_end] = container.retrieve_if<false>(keys_begin,
+                                                                        keys_begin + num_keys,
+                                                                        stencil_values.begin(),
+                                                                        pred,
+                                                                        probed_keys.begin(),
+                                                                        matched_keys.begin());
+
+    // Count expected results: stencil values 11, 14, 17, ... (where (k+10) % 3 == 1)
+    // This corresponds to original keys 1, 4, 7, ...
+    auto const expected_count = (num_keys + 2) / 3;  // keys where k % 3 == 1
+
+    REQUIRE(std::distance(probed_keys.begin(), probed_end) == expected_count);
+    REQUIRE(std::distance(matched_keys.begin(), matched_end) == expected_count);
+
+    // Sort results
+    thrust::sort(probed_keys.begin(), probed_end);
+    thrust::sort(matched_keys.begin(), matched_end);
+
+    // Expected keys: 1, 4, 7, ...
+    auto const expected_keys_begin = thrust::make_transform_iterator(
+      thrust::counting_iterator<key_type>{0}, [] __device__(key_type i) { return 1 + i * 3; });
+
+    REQUIRE(cuco::test::equal(
+      probed_keys.begin(), probed_end, expected_keys_begin, cuda::std::equal_to<key_type>{}));
+    REQUIRE(cuco::test::equal(
+      matched_keys.begin(), matched_end, expected_keys_begin, cuda::std::equal_to<key_type>{}));
+  }
+}
+
+TEMPLATE_TEST_CASE_SIG(
+  "static_multiset retrieve_if tests",
+  "",
+  ((typename Key, cuco::test::probe_sequence Probe, int CGSize), Key, Probe, CGSize),
+  (int32_t, cuco::test::probe_sequence::double_hashing, 1),
+  (int32_t, cuco::test::probe_sequence::double_hashing, 2),
+  (int64_t, cuco::test::probe_sequence::double_hashing, 1),
+  (int64_t, cuco::test::probe_sequence::double_hashing, 2),
+  (int32_t, cuco::test::probe_sequence::linear_probing, 1),
+  (int32_t, cuco::test::probe_sequence::linear_probing, 2),
+  (int64_t, cuco::test::probe_sequence::linear_probing, 1),
+  (int64_t, cuco::test::probe_sequence::linear_probing, 2))
+{
+  constexpr std::size_t num_keys{400};
+  constexpr double desired_load_factor = 0.5;
+  constexpr auto empty_key_sentinel    = std::numeric_limits<Key>::max();
+
+  using probe = std::conditional_t<Probe == cuco::test::probe_sequence::linear_probing,
+                                   cuco::linear_probing<CGSize, cuco::default_hash_function<Key>>,
+                                   cuco::double_hashing<CGSize, cuco::default_hash_function<Key>>>;
+
+  auto set = cuco::static_multiset{
+    num_keys, desired_load_factor, cuco::empty_key<Key>{empty_key_sentinel}, {}, probe{}};
+
+  test_retrieve_if_inner(set, num_keys);
+  test_retrieve_if_outer(set, num_keys);
+  test_retrieve_if_stencil_mismatch(set, num_keys);
+}

--- a/tests/static_set/retrieve_if_test.cu
+++ b/tests/static_set/retrieve_if_test.cu
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <test_utils.hpp>
+
+#include <cuco/static_set.cuh>
+
+#include <cuda/functional>
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+#include <thrust/sequence.h>
+
+#include <catch2/catch_template_test_macros.hpp>
+
+using size_type = std::size_t;
+
+template <class Container>
+__global__ void test_retrieve_if_kernel(
+  Container container_ref,
+  typename Container::key_type* keys_begin,
+  std::size_t num_keys,
+  typename Container::key_type* stencil_begin,
+  typename Container::key_type* output_probe,
+  typename Container::key_type* output_match,
+  cuda::atomic<int, cuda::thread_scope_device>* atomic_counter)
+{
+  using key_type = typename Container::key_type;
+  namespace cg   = cooperative_groups;
+
+  auto const block = cg::this_thread_block();
+  auto const pred  = [] __device__(key_type k) { return k % 2 == 0; };
+
+  container_ref.retrieve_if<128>(block,
+                                 keys_begin,
+                                 keys_begin + num_keys,
+                                 stencil_begin,
+                                 pred,
+                                 output_probe,
+                                 output_match,
+                                 *atomic_counter);
+}
+
+template <class Container>
+__global__ void test_retrieve_if_all_false_kernel(
+  Container container_ref,
+  typename Container::key_type* keys_begin,
+  std::size_t num_keys,
+  typename Container::key_type* stencil_begin,
+  typename Container::key_type* output_probe,
+  typename Container::key_type* output_match,
+  cuda::atomic<int, cuda::thread_scope_device>* atomic_counter)
+{
+  using key_type = typename Container::key_type;
+  namespace cg   = cooperative_groups;
+
+  auto const block        = cg::this_thread_block();
+  auto const always_false = [] __device__(key_type) { return false; };
+
+  container_ref.retrieve_if<128>(block,
+                                 keys_begin,
+                                 keys_begin + num_keys,
+                                 stencil_begin,
+                                 always_false,
+                                 output_probe,
+                                 output_match,
+                                 *atomic_counter);
+}
+
+template <class Container>
+__global__ void test_retrieve_if_all_true_kernel(
+  Container container_ref,
+  typename Container::key_type* keys_begin,
+  std::size_t num_keys,
+  typename Container::key_type* stencil_begin,
+  typename Container::key_type* output_probe,
+  typename Container::key_type* output_match,
+  cuda::atomic<int, cuda::thread_scope_device>* atomic_counter)
+{
+  using key_type = typename Container::key_type;
+  namespace cg   = cooperative_groups;
+
+  auto const block       = cg::this_thread_block();
+  auto const always_true = [] __device__(key_type) { return true; };
+
+  container_ref.retrieve_if<128>(block,
+                                 keys_begin,
+                                 keys_begin + num_keys,
+                                 stencil_begin,
+                                 always_true,
+                                 output_probe,
+                                 output_match,
+                                 *atomic_counter);
+}
+
+TEMPLATE_TEST_CASE_SIG("static_set retrieve_if", "", ((typename Key), Key), (int32_t), (int64_t))
+{
+  constexpr size_type num_keys{400};
+
+  using container_type = cuco::static_set<Key>;
+
+  container_type container{num_keys * 2, cuco::empty_key<Key>{-1}};
+
+  auto keys_begin = thrust::counting_iterator<Key>(1);
+  auto keys_end   = keys_begin + num_keys;
+
+  container.insert(keys_begin, keys_end);
+
+  SECTION("Testing retrieve_if with even predicate")
+  {
+    thrust::device_vector<Key> input_keys(keys_begin, keys_end);
+    thrust::device_vector<Key> stencil_values(keys_begin, keys_end);
+    thrust::device_vector<Key> probed_keys(num_keys);
+    thrust::device_vector<Key> matched_keys(num_keys);
+
+    cuda::atomic<int, cuda::thread_scope_device>* d_atomic_counter;
+    CUCO_CUDA_TRY(
+      cudaMalloc(&d_atomic_counter, sizeof(cuda::atomic<int, cuda::thread_scope_device>)));
+    CUCO_CUDA_TRY(
+      cudaMemset(d_atomic_counter, 0, sizeof(cuda::atomic<int, cuda::thread_scope_device>)));
+
+    auto const container_ref = container.ref(cuco::op::retrieve);
+
+    test_retrieve_if_kernel<<<1, 128>>>(container_ref,
+                                        thrust::raw_pointer_cast(input_keys.data()),
+                                        num_keys,
+                                        thrust::raw_pointer_cast(stencil_values.data()),
+                                        thrust::raw_pointer_cast(probed_keys.data()),
+                                        thrust::raw_pointer_cast(matched_keys.data()),
+                                        d_atomic_counter);
+    CUCO_CUDA_TRY(cudaDeviceSynchronize());
+
+    int h_counter;
+    CUCO_CUDA_TRY(cudaMemcpy(&h_counter, d_atomic_counter, sizeof(int), cudaMemcpyDeviceToHost));
+
+    // Should retrieve even numbers only
+    REQUIRE(h_counter > 0);
+    REQUIRE(h_counter <= static_cast<int>(num_keys));
+
+    CUCO_CUDA_TRY(cudaFree(d_atomic_counter));
+  }
+
+  SECTION("Testing retrieve_if with always false predicate")
+  {
+    thrust::device_vector<Key> input_keys(keys_begin, keys_end);
+    thrust::device_vector<Key> stencil_values(keys_begin, keys_end);
+    thrust::device_vector<Key> probed_keys(num_keys);
+    thrust::device_vector<Key> matched_keys(num_keys);
+
+    cuda::atomic<int, cuda::thread_scope_device>* d_atomic_counter;
+    CUCO_CUDA_TRY(
+      cudaMalloc(&d_atomic_counter, sizeof(cuda::atomic<int, cuda::thread_scope_device>)));
+    CUCO_CUDA_TRY(
+      cudaMemset(d_atomic_counter, 0, sizeof(cuda::atomic<int, cuda::thread_scope_device>)));
+
+    auto const container_ref = container.ref(cuco::op::retrieve);
+
+    test_retrieve_if_all_false_kernel<<<1, 128>>>(container_ref,
+                                                  thrust::raw_pointer_cast(input_keys.data()),
+                                                  num_keys,
+                                                  thrust::raw_pointer_cast(stencil_values.data()),
+                                                  thrust::raw_pointer_cast(probed_keys.data()),
+                                                  thrust::raw_pointer_cast(matched_keys.data()),
+                                                  d_atomic_counter);
+    CUCO_CUDA_TRY(cudaDeviceSynchronize());
+
+    int h_counter;
+    CUCO_CUDA_TRY(cudaMemcpy(&h_counter, d_atomic_counter, sizeof(int), cudaMemcpyDeviceToHost));
+
+    // Should retrieve nothing
+    REQUIRE(h_counter == 0);
+
+    CUCO_CUDA_TRY(cudaFree(d_atomic_counter));
+  }
+
+  SECTION("Testing retrieve_if with always true predicate")
+  {
+    thrust::device_vector<Key> input_keys(keys_begin, keys_end);
+    thrust::device_vector<Key> stencil_values(keys_begin, keys_end);
+    thrust::device_vector<Key> probed_keys(num_keys);
+    thrust::device_vector<Key> matched_keys(num_keys);
+
+    cuda::atomic<int, cuda::thread_scope_device>* d_atomic_counter;
+    CUCO_CUDA_TRY(
+      cudaMalloc(&d_atomic_counter, sizeof(cuda::atomic<int, cuda::thread_scope_device>)));
+    CUCO_CUDA_TRY(
+      cudaMemset(d_atomic_counter, 0, sizeof(cuda::atomic<int, cuda::thread_scope_device>)));
+
+    auto const container_ref = container.ref(cuco::op::retrieve);
+
+    test_retrieve_if_all_true_kernel<<<1, 128>>>(container_ref,
+                                                 thrust::raw_pointer_cast(input_keys.data()),
+                                                 num_keys,
+                                                 thrust::raw_pointer_cast(stencil_values.data()),
+                                                 thrust::raw_pointer_cast(probed_keys.data()),
+                                                 thrust::raw_pointer_cast(matched_keys.data()),
+                                                 d_atomic_counter);
+    CUCO_CUDA_TRY(cudaDeviceSynchronize());
+
+    int h_counter;
+    CUCO_CUDA_TRY(cudaMemcpy(&h_counter, d_atomic_counter, sizeof(int), cudaMemcpyDeviceToHost));
+
+    // Should retrieve all keys that exist in the container
+    REQUIRE(h_counter == static_cast<int>(num_keys));
+
+    CUCO_CUDA_TRY(cudaFree(d_atomic_counter));
+  }
+}


### PR DESCRIPTION
This PR adds device `retrieve_if` APIs for all fixed size hash tables.