### PR TITLE
Synchronize CUDA stream before variable usage

### DIFF
--- a/include/cuco/detail/dynamic_map.inl
+++ b/include/cuco/detail/dynamic_map.inl
@@ -175,6 +175,7 @@ void dynamic_map<Key, Value, Scope, Allocator>::insert(
                                     sizeof(atomic_ctr_type),
                                     cudaMemcpyDeviceToHost,
                                     stream));
+      CUCO_CUDA_TRY(cudaStreamSynchronize(stream));
       submaps_[submap_idx]->size_ += h_num_successes;
       size_ += h_num_successes;
       first += n;
@@ -223,6 +224,7 @@ void dynamic_map<Key, Value, Scope, Allocator>::erase(
                                   sizeof(atomic_ctr_type),
                                   cudaMemcpyDeviceToHost,
                                   stream));
+    CUCO_CUDA_TRY(cudaStreamSynchronize(stream));
     submaps_[i]->size_ -= h_submap_num_successes;
     size_ -= h_submap_num_successes;
   }


### PR DESCRIPTION
To get correct value of `h_num_successes`, we need to sync stream to ensure `h_num_successes` is updated.
Same for `h_submap_num_successes`