### PR TITLE
Get rid of the stream_ref default construction to avoid deprecation warnings

### DIFF
--- a/include/cuco/bloom_filter.cuh
+++ b/include/cuco/bloom_filter.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/cuco/bloom_filter.cuh
+++ b/include/cuco/bloom_filter.cuh
@@ -117,7 +117,8 @@ class bloom_filter {
                                            cuda_thread_scope<Scope> scope = {},
                                            Policy const& policy           = {},
                                            Allocator const& alloc         = {},
-                                           cuda::stream_ref stream        = {});
+                                           cuda::stream_ref stream        = cuda::stream_ref{
+                                             cudaStream_t{nullptr}});
 
   /**
    * @brief Erases all information from the filter.
@@ -127,14 +128,15 @@ class bloom_filter {
    *
    * @param stream CUDA stream used for device memory operations and kernel launches
    */
-  __host__ constexpr void clear(cuda::stream_ref stream = {});
+  __host__ constexpr void clear(cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously erases all information from the filter.
    *
    * @param stream CUDA stream used for device memory operations and kernel launches
    */
-  __host__ constexpr void clear_async(cuda::stream_ref stream = {});
+  __host__ constexpr void clear_async(cuda::stream_ref stream = cuda::stream_ref{
+                                        cudaStream_t{nullptr}});
 
   /**
    * @brief Adds all keys in the range `[first, last)` to the filter.
@@ -148,7 +150,9 @@ class bloom_filter {
    * @param stream CUDA stream used for device memory operations and kernel launches
    */
   template <class InputIt>
-  __host__ constexpr void add(InputIt first, InputIt last, cuda::stream_ref stream = {});
+  __host__ constexpr void add(InputIt first,
+                              InputIt last,
+                              cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously adds all keys in the range `[first, last)` to the filter.
@@ -160,7 +164,8 @@ class bloom_filter {
    * @param stream CUDA stream used for device memory operations and kernel launches
    */
   template <class InputIt>
-  __host__ constexpr void add_async(InputIt first, InputIt last, cuda::stream_ref stream = {});
+  __host__ constexpr void add_async(
+    InputIt first, InputIt last, cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Adds keys in the range `[first, last)` if `pred` of the corresponding `stencil` returns
@@ -184,8 +189,11 @@ class bloom_filter {
    * @param stream CUDA stream used for device memory operations and kernel launches
    */
   template <class InputIt, class StencilIt, class Predicate>
-  __host__ constexpr void add_if(
-    InputIt first, InputIt last, StencilIt stencil, Predicate pred, cuda::stream_ref stream = {});
+  __host__ constexpr void add_if(InputIt first,
+                                 InputIt last,
+                                 StencilIt stencil,
+                                 Predicate pred,
+                                 cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously adds keys in the range `[first, last)` if `pred` of the corresponding
@@ -211,7 +219,8 @@ class bloom_filter {
                                        InputIt last,
                                        StencilIt stencil,
                                        Predicate pred,
-                                       cuda::stream_ref stream = {}) noexcept;
+                                       cuda::stream_ref stream = cuda::stream_ref{
+                                         cudaStream_t{nullptr}}) noexcept;
 
   /**
    * @brief Tests all keys in the range `[first, last)` if their fingerprints are present in the
@@ -232,7 +241,8 @@ class bloom_filter {
   __host__ constexpr void contains(InputIt first,
                                    InputIt last,
                                    OutputIt output_begin,
-                                   cuda::stream_ref stream = {}) const;
+                                   cuda::stream_ref stream = cuda::stream_ref{
+                                     cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Asynchronously tests all keys in the range `[first, last)` if their fingerprints are
@@ -250,7 +260,8 @@ class bloom_filter {
   __host__ constexpr void contains_async(InputIt first,
                                          InputIt last,
                                          OutputIt output_begin,
-                                         cuda::stream_ref stream = {}) const noexcept;
+                                         cuda::stream_ref stream = cuda::stream_ref{
+                                           cudaStream_t{nullptr}}) const noexcept;
 
   /**
    * @brief Tests all keys in the range `[first, last)` if their fingerprints are present in the
@@ -281,7 +292,8 @@ class bloom_filter {
                                       StencilIt stencil,
                                       Predicate pred,
                                       OutputIt output_begin,
-                                      cuda::stream_ref stream = {}) const;
+                                      cuda::stream_ref stream = cuda::stream_ref{
+                                        cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Asynchronously tests all keys in the range `[first, last)` if their fingerprints are
@@ -310,7 +322,8 @@ class bloom_filter {
                                             StencilIt stencil,
                                             Predicate pred,
                                             OutputIt output_begin,
-                                            cuda::stream_ref stream = {}) const noexcept;
+                                            cuda::stream_ref stream = cuda::stream_ref{
+                                              cudaStream_t{nullptr}}) const noexcept;
 
   /**
    * @brief Gets a pointer to the underlying filter storage.

--- a/include/cuco/bloom_filter_ref.cuh
+++ b/include/cuco/bloom_filter_ref.cuh
@@ -101,14 +101,15 @@ class bloom_filter_ref {
    *
    * @param stream CUDA stream used for device memory operations and kernel launches
    */
-  __host__ constexpr void clear(cuda::stream_ref stream = {});
+  __host__ constexpr void clear(cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously erases all information from the filter.
    *
    * @param stream CUDA stream used for device memory operations and kernel launches
    */
-  __host__ constexpr void clear_async(cuda::stream_ref stream = {});
+  __host__ constexpr void clear_async(cuda::stream_ref stream = cuda::stream_ref{
+                                        cudaStream_t{nullptr}});
 
   /**
    * @brief Device function that adds a key to the filter.
@@ -163,7 +164,9 @@ class bloom_filter_ref {
    * @param stream CUDA stream used for device memory operations and kernel launches
    */
   template <class InputIt>
-  __host__ constexpr void add(InputIt first, InputIt last, cuda::stream_ref stream = {});
+  __host__ constexpr void add(InputIt first,
+                              InputIt last,
+                              cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously adds all keys in the range `[first, last)` to the filter.
@@ -175,7 +178,8 @@ class bloom_filter_ref {
    * @param stream CUDA stream used for device memory operations and kernel launches
    */
   template <class InputIt>
-  __host__ constexpr void add_async(InputIt first, InputIt last, cuda::stream_ref stream = {});
+  __host__ constexpr void add_async(
+    InputIt first, InputIt last, cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Adds keys in the range `[first, last)` if `pred` of the corresponding `stencil` returns
@@ -199,8 +203,11 @@ class bloom_filter_ref {
    * @param stream CUDA stream used for device memory operations and kernel launches
    */
   template <class InputIt, class StencilIt, class Predicate>
-  __host__ constexpr void add_if(
-    InputIt first, InputIt last, StencilIt stencil, Predicate pred, cuda::stream_ref stream = {});
+  __host__ constexpr void add_if(InputIt first,
+                                 InputIt last,
+                                 StencilIt stencil,
+                                 Predicate pred,
+                                 cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously adds keys in the range `[first, last)` if `pred` of the corresponding
@@ -226,7 +233,8 @@ class bloom_filter_ref {
                                        InputIt last,
                                        StencilIt stencil,
                                        Predicate pred,
-                                       cuda::stream_ref stream = {}) noexcept;
+                                       cuda::stream_ref stream = cuda::stream_ref{
+                                         cudaStream_t{nullptr}}) noexcept;
 
   /**
    * @brief Device function that tests if a key's fingerprint is present in the filter.
@@ -283,7 +291,8 @@ class bloom_filter_ref {
   __host__ constexpr void contains(InputIt first,
                                    InputIt last,
                                    OutputIt output_begin,
-                                   cuda::stream_ref stream = {}) const;
+                                   cuda::stream_ref stream = cuda::stream_ref{
+                                     cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Asynchronously tests all keys in the range `[first, last)` if their fingerprints are
@@ -303,7 +312,8 @@ class bloom_filter_ref {
   __host__ constexpr void contains_async(InputIt first,
                                          InputIt last,
                                          OutputIt output_begin,
-                                         cuda::stream_ref stream = {}) const noexcept;
+                                         cuda::stream_ref stream = cuda::stream_ref{
+                                           cudaStream_t{nullptr}}) const noexcept;
 
   /**
    * @brief Tests all keys in the range `[first, last)` if their fingerprints are present in the
@@ -336,7 +346,8 @@ class bloom_filter_ref {
                                       StencilIt stencil,
                                       Predicate pred,
                                       OutputIt output_begin,
-                                      cuda::stream_ref stream = {}) const;
+                                      cuda::stream_ref stream = cuda::stream_ref{
+                                        cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Asynchronously tests all keys in the range `[first, last)` if their fingerprints are
@@ -367,7 +378,8 @@ class bloom_filter_ref {
                                             StencilIt stencil,
                                             Predicate pred,
                                             OutputIt output_begin,
-                                            cuda::stream_ref stream = {}) const noexcept;
+                                            cuda::stream_ref stream = cuda::stream_ref{
+                                              cudaStream_t{nullptr}}) const noexcept;
 
   /**
    * @brief Gets a pointer to the underlying filter storage.

--- a/include/cuco/bucket_storage.cuh
+++ b/include/cuco/bucket_storage.cuh
@@ -206,7 +206,8 @@ class bucket_storage {
    * @param key Key to which all keys in `slots` are initialized
    * @param stream Stream used for executing the kernel
    */
-  void initialize(value_type key, cuda::stream_ref stream = {});
+  void initialize(value_type key,
+                  cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously initializes each slot in the bucket storage to contain `key`.
@@ -214,7 +215,8 @@ class bucket_storage {
    * @param key Key to which all keys in `slots` are initialized
    * @param stream Stream used for executing the kernel
    */
-  void initialize_async(value_type key, cuda::stream_ref stream = {});
+  void initialize_async(value_type key,
+                        cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Gets the total number of slot buckets in the current storage.

--- a/include/cuco/detail/bitwise_compare.cuh
+++ b/include/cuco/detail/bitwise_compare.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/cuco/detail/open_addressing/open_addressing_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_impl.cuh
@@ -452,7 +452,10 @@ class open_addressing_impl {
    * provided at construction
    */
   template <typename InputIt, typename Ref>
-  void erase_async(InputIt first, InputIt last, Ref container_ref, cuda::stream_ref stream = {})
+  void erase_async(InputIt first,
+                   InputIt last,
+                   Ref container_ref,
+                   cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}})
   {
     CUCO_EXPECTS(this->empty_key_sentinel() != this->erased_key_sentinel(),
                  "The empty key sentinel and erased key sentinel cannot be the same value.",

--- a/include/cuco/detail/roaring_bitmap/roaring_bitmap_impl.cuh
+++ b/include/cuco/detail/roaring_bitmap/roaring_bitmap_impl.cuh
@@ -61,7 +61,7 @@ class roaring_bitmap_impl<cuda::std::uint32_t> {
   __host__ void contains(InputIt first,
                          InputIt last,
                          OutputIt contained,
-                         cuda::stream_ref stream = {}) const
+                         cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const
   {
     this->contains_async(first, last, contained, stream);
 #if CCCL_MAJOR_VERSION > 3 || (CCCL_MAJOR_VERSION == 3 && CCCL_MINOR_VERSION >= 1)
@@ -75,7 +75,8 @@ class roaring_bitmap_impl<cuda::std::uint32_t> {
   __host__ void contains_async(InputIt first,
                                InputIt last,
                                OutputIt contained,
-                               cuda::stream_ref stream = {}) const noexcept
+                               cuda::stream_ref stream = cuda::stream_ref{
+                                 cudaStream_t{nullptr}}) const noexcept
   {
     if (this->empty()) {
       cub::DeviceTransform::Transform(
@@ -304,7 +305,7 @@ class roaring_bitmap_impl<cuda::std::uint64_t> {
   __host__ void contains(InputIt first,
                          InputIt last,
                          OutputIt contained,
-                         cuda::stream_ref stream = {}) const
+                         cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const
   {
     this->contains_async(first, last, contained, stream);
 #if CCCL_MAJOR_VERSION > 3 || (CCCL_MAJOR_VERSION == 3 && CCCL_MINOR_VERSION >= 1)
@@ -318,7 +319,8 @@ class roaring_bitmap_impl<cuda::std::uint64_t> {
   __host__ void contains_async(InputIt first,
                                InputIt last,
                                OutputIt contained,
-                               cuda::stream_ref stream = {}) const noexcept
+                               cuda::stream_ref stream = cuda::stream_ref{
+                                 cudaStream_t{nullptr}}) const noexcept
   {
     if (this->empty()) {
       cub::DeviceTransform::Transform(

--- a/include/cuco/detail/trie/dynamic_bitset/dynamic_bitset.cuh
+++ b/include/cuco/detail/trie/dynamic_bitset/dynamic_bitset.cuh
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights
+ * reserved. SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/cuco/detail/trie/dynamic_bitset/dynamic_bitset.cuh
+++ b/include/cuco/detail/trie/dynamic_bitset/dynamic_bitset.cuh
@@ -144,7 +144,7 @@ class dynamic_bitset {
   constexpr void test(KeyIt keys_begin,
                       KeyIt keys_end,
                       OutputIt outputs_begin,
-                      cuda::stream_ref stream = {}) noexcept;
+                      cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) noexcept;
 
   /**
    * @brief For any element `keys_begin[i]` in the range `[keys_begin, keys_end)`, stores total
@@ -164,7 +164,7 @@ class dynamic_bitset {
   constexpr void rank(KeyIt keys_begin,
                       KeyIt keys_end,
                       OutputIt outputs_begin,
-                      cuda::stream_ref stream = {}) noexcept;
+                      cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) noexcept;
 
   /**
    * @brief For any element `keys_begin[i]` in the range `[keys_begin, keys_end)`, stores the
@@ -184,7 +184,7 @@ class dynamic_bitset {
   constexpr void select(KeyIt keys_begin,
                         KeyIt keys_end,
                         OutputIt outputs_begin,
-                        cuda::stream_ref stream = {}) noexcept;
+                        cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) noexcept;
 
   using rank_type = cuco::experimental::detail::rank;  ///< Rank type
 
@@ -353,7 +353,7 @@ class dynamic_bitset {
    *
    * @param stream Stream to execute kernels
    */
-  constexpr void build(cuda::stream_ref stream = {}) noexcept;
+  constexpr void build(cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) noexcept;
 
   /**
    * @brief Populates rank and select indexes for true or false bits
@@ -367,7 +367,7 @@ class dynamic_bitset {
     thrust::device_vector<rank_type, rank_allocator_type>& ranks,
     thrust::device_vector<size_type, size_allocator_type>& selects,
     bool flip_bits,
-    cuda::stream_ref stream = {});
+    cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 };
 
 }  // namespace detail

--- a/include/cuco/dynamic_map.cuh
+++ b/include/cuco/dynamic_map.cuh
@@ -111,7 +111,7 @@ class dynamic_map {
                         cuda_thread_scope<Scope> scope      = {},
                         Storage storage                     = {},
                         Allocator const& alloc              = {},
-                        cuda::stream_ref stream             = {});
+                        cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Grows the capacity of the map so there is enough space for `n` key/value pairs.
@@ -136,7 +136,9 @@ class dynamic_map {
    * @param stream Stream used for executing the kernels
    */
   template <typename InputIt>
-  void insert(InputIt first, InputIt last, cuda::stream_ref stream = {});
+  void insert(InputIt first,
+              InputIt last,
+              cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Indicates whether the keys in the range `[first, last)` are contained in the map.
@@ -156,7 +158,7 @@ class dynamic_map {
   void contains(InputIt first,
                 InputIt last,
                 OutputIt output_begin,
-                cuda::stream_ref stream = {}) const;
+                cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
  private:
   size_type size_{};      ///< Number of keys in the map

--- a/include/cuco/hyperloglog.cuh
+++ b/include/cuco/hyperloglog.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/cuco/hyperloglog.cuh
+++ b/include/cuco/hyperloglog.cuh
@@ -73,7 +73,7 @@ class hyperloglog {
   constexpr hyperloglog(cuco::sketch_size_kb sketch_size_kb = 32_KB,
                         Hash const& hash                    = {},
                         Allocator const& alloc              = {},
-                        cuda::stream_ref stream             = {});
+                        cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Constructs a `hyperloglog` host object.
@@ -88,7 +88,7 @@ class hyperloglog {
   constexpr hyperloglog(cuco::standard_deviation standard_deviation,
                         Hash const& hash        = {},
                         Allocator const& alloc  = {},
-                        cuda::stream_ref stream = {});
+                        cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   ~hyperloglog() = default;
 
@@ -108,7 +108,8 @@ class hyperloglog {
    *
    * @param stream CUDA stream this operation is executed in
    */
-  constexpr void clear_async(cuda::stream_ref stream = {}) noexcept;
+  constexpr void clear_async(cuda::stream_ref stream = cuda::stream_ref{
+                               cudaStream_t{nullptr}}) noexcept;
 
   /**
    * @brief Resets the estimator, i.e., clears the current count estimate.
@@ -118,7 +119,7 @@ class hyperloglog {
    *
    * @param stream CUDA stream this operation is executed in
    */
-  constexpr void clear(cuda::stream_ref stream = {});
+  constexpr void clear(cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously adds to be counted items to the estimator.
@@ -132,7 +133,9 @@ class hyperloglog {
    * @param stream CUDA stream this operation is executed in
    */
   template <class InputIt>
-  constexpr void add_async(InputIt first, InputIt last, cuda::stream_ref stream = {});
+  constexpr void add_async(InputIt first,
+                           InputIt last,
+                           cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Adds to be counted items to the estimator.
@@ -149,7 +152,9 @@ class hyperloglog {
    * @param stream CUDA stream this operation is executed in
    */
   template <class InputIt>
-  constexpr void add(InputIt first, InputIt last, cuda::stream_ref stream = {});
+  constexpr void add(InputIt first,
+                     InputIt last,
+                     cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously merges the result of `other` estimator into `*this` estimator.
@@ -164,7 +169,7 @@ class hyperloglog {
    */
   template <cuda::thread_scope OtherScope, class OtherAllocator>
   constexpr void merge_async(hyperloglog<T, OtherScope, Hash, OtherAllocator> const& other,
-                             cuda::stream_ref stream = {});
+                             cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Merges the result of `other` estimator into `*this` estimator.
@@ -182,7 +187,7 @@ class hyperloglog {
    */
   template <cuda::thread_scope OtherScope, class OtherAllocator>
   constexpr void merge(hyperloglog<T, OtherScope, Hash, OtherAllocator> const& other,
-                       cuda::stream_ref stream = {});
+                       cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously merges the result of `other` estimator reference into `*this` estimator.
@@ -195,7 +200,8 @@ class hyperloglog {
    * @param stream CUDA stream this operation is executed in
    */
   template <cuda::thread_scope OtherScope>
-  constexpr void merge_async(ref_type<OtherScope> const& other_ref, cuda::stream_ref stream = {});
+  constexpr void merge_async(ref_type<OtherScope> const& other_ref,
+                             cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Merges the result of `other` estimator reference into `*this` estimator.
@@ -211,7 +217,8 @@ class hyperloglog {
    * @param stream CUDA stream this operation is executed in
    */
   template <cuda::thread_scope OtherScope>
-  constexpr void merge(ref_type<OtherScope> const& other_ref, cuda::stream_ref stream = {});
+  constexpr void merge(ref_type<OtherScope> const& other_ref,
+                       cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Compute the estimated distinct items count.
@@ -222,7 +229,8 @@ class hyperloglog {
    *
    * @return Approximate distinct items count
    */
-  [[nodiscard]] constexpr std::size_t estimate(cuda::stream_ref stream = {}) const;
+  [[nodiscard]] constexpr std::size_t estimate(cuda::stream_ref stream = cuda::stream_ref{
+                                                 cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Get device ref.

--- a/include/cuco/hyperloglog_ref.cuh
+++ b/include/cuco/hyperloglog_ref.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/cuco/hyperloglog_ref.cuh
+++ b/include/cuco/hyperloglog_ref.cuh
@@ -82,7 +82,8 @@ class hyperloglog_ref {
    *
    * @param stream CUDA stream this operation is executed in
    */
-  __host__ constexpr void clear_async(cuda::stream_ref stream = {}) noexcept;
+  __host__ constexpr void clear_async(cuda::stream_ref stream = cuda::stream_ref{
+                                        cudaStream_t{nullptr}}) noexcept;
 
   /**
    * @brief Resets the estimator, i.e., clears the current count estimate.
@@ -92,7 +93,7 @@ class hyperloglog_ref {
    *
    * @param stream CUDA stream this operation is executed in
    */
-  __host__ constexpr void clear(cuda::stream_ref stream = {});
+  __host__ constexpr void clear(cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Adds an item to the estimator.
@@ -113,7 +114,8 @@ class hyperloglog_ref {
    * @param stream CUDA stream this operation is executed in
    */
   template <class InputIt>
-  __host__ constexpr void add_async(InputIt first, InputIt last, cuda::stream_ref stream = {});
+  __host__ constexpr void add_async(
+    InputIt first, InputIt last, cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Adds to be counted items to the estimator.
@@ -130,7 +132,9 @@ class hyperloglog_ref {
    * @param stream CUDA stream this operation is executed in
    */
   template <class InputIt>
-  __host__ constexpr void add(InputIt first, InputIt last, cuda::stream_ref stream = {});
+  __host__ constexpr void add(InputIt first,
+                              InputIt last,
+                              cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Merges the result of `other` estimator reference into `*this` estimator reference.
@@ -158,7 +162,8 @@ class hyperloglog_ref {
    */
   template <cuda::thread_scope OtherScope>
   __host__ constexpr void merge_async(hyperloglog_ref<T, OtherScope, Hash> const& other,
-                                      cuda::stream_ref stream = {});
+                                      cuda::stream_ref stream = cuda::stream_ref{
+                                        cudaStream_t{nullptr}});
 
   /**
    * @brief Merges the result of `other` estimator reference into `*this` estimator.
@@ -175,7 +180,7 @@ class hyperloglog_ref {
    */
   template <cuda::thread_scope OtherScope>
   __host__ constexpr void merge(hyperloglog_ref<T, OtherScope, Hash> const& other,
-                                cuda::stream_ref stream = {});
+                                cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Compute the estimated distinct items count.
@@ -196,7 +201,8 @@ class hyperloglog_ref {
    *
    * @return Approximate distinct items count
    */
-  [[nodiscard]] __host__ constexpr std::size_t estimate(cuda::stream_ref stream = {}) const;
+  [[nodiscard]] __host__ constexpr std::size_t estimate(cuda::stream_ref stream = cuda::stream_ref{
+                                                          cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Gets the hash function.

--- a/include/cuco/roaring_bitmap.cuh
+++ b/include/cuco/roaring_bitmap.cuh
@@ -58,7 +58,7 @@ class roaring_bitmap {
    */
   roaring_bitmap(cuda::std::byte const* bitmap,
                  Allocator const& alloc  = {},
-                 cuda::stream_ref stream = {});
+                 cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Copy constructor
@@ -112,7 +112,7 @@ class roaring_bitmap {
   void contains(InputIt first,
                 InputIt last,
                 OutputIt contained,
-                cuda::stream_ref stream = {}) const;
+                cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Asynchronously performs a bulk membership query for keys in `[first, last)`.
@@ -130,7 +130,8 @@ class roaring_bitmap {
   void contains_async(InputIt first,
                       InputIt last,
                       OutputIt contained,
-                      cuda::stream_ref stream = {}) const noexcept;
+                      cuda::stream_ref stream = cuda::stream_ref{
+                        cudaStream_t{nullptr}}) const noexcept;
 
   /**
    * @brief Number of keys stored in the bitmap.

--- a/include/cuco/roaring_bitmap_ref.cuh
+++ b/include/cuco/roaring_bitmap_ref.cuh
@@ -84,7 +84,7 @@ class roaring_bitmap_ref {
   __host__ void contains(InputIt first,
                          InputIt last,
                          OutputIt contained,
-                         cuda::stream_ref stream = {}) const;
+                         cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Asynchronously performs a bulk membership query for keys in `[first, last)`.
@@ -102,7 +102,8 @@ class roaring_bitmap_ref {
   __host__ void contains_async(InputIt first,
                                InputIt last,
                                OutputIt contained,
-                               cuda::stream_ref stream = {}) const noexcept;
+                               cuda::stream_ref stream = cuda::stream_ref{
+                                 cudaStream_t{nullptr}}) const noexcept;
 
   /**
    * @brief Device-side membership query for a single key.

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -184,7 +184,7 @@ class static_map {
                        cuda_thread_scope<Scope> scope      = {},
                        Storage storage                     = {},
                        Allocator const& alloc              = {},
-                       cuda::stream_ref stream             = {});
+                       cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Constructs a statically-sized map with the number of elements to insert `n`, the desired
@@ -228,7 +228,7 @@ class static_map {
                        cuda_thread_scope<Scope> scope      = {},
                        Storage storage                     = {},
                        Allocator const& alloc              = {},
-                       cuda::stream_ref stream             = {});
+                       cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Constructs a statically-sized map with the specified initial capacity, sentinel values
@@ -264,7 +264,7 @@ class static_map {
                        cuda_thread_scope<Scope> scope      = {},
                        Storage storage                     = {},
                        Allocator const& alloc              = {},
-                       cuda::stream_ref stream             = {});
+                       cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Erases all elements from the container. After this call, `size()` returns zero.
@@ -272,7 +272,7 @@ class static_map {
    *
    * @param stream CUDA stream this operation is executed in
    */
-  void clear(cuda::stream_ref stream = {});
+  void clear(cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously erases all elements from the container. After this call, `size()` returns
@@ -280,7 +280,7 @@ class static_map {
    *
    * @param stream CUDA stream this operation is executed in
    */
-  void clear_async(cuda::stream_ref stream = {}) noexcept;
+  void clear_async(cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) noexcept;
 
   /**
    * @brief Inserts all keys in the range `[first, last)` and returns the number of successful
@@ -300,7 +300,9 @@ class static_map {
    * @return Number of successful insertions
    */
   template <typename InputIt>
-  size_type insert(InputIt first, InputIt last, cuda::stream_ref stream = {});
+  size_type insert(InputIt first,
+                   InputIt last,
+                   cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously inserts all keys in the range `[first, last)`.
@@ -314,7 +316,9 @@ class static_map {
    * @param stream CUDA stream used for insert
    */
   template <typename InputIt>
-  void insert_async(InputIt first, InputIt last, cuda::stream_ref stream = {}) noexcept;
+  void insert_async(InputIt first,
+                    InputIt last,
+                    cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) noexcept;
 
   /**
    * @brief Inserts keys in the range `[first, last)` if `pred` of the corresponding stencil returns
@@ -341,8 +345,11 @@ class static_map {
    * @return Number of successful insertions
    */
   template <typename InputIt, typename StencilIt, typename Predicate>
-  size_type insert_if(
-    InputIt first, InputIt last, StencilIt stencil, Predicate pred, cuda::stream_ref stream = {});
+  size_type insert_if(InputIt first,
+                      InputIt last,
+                      StencilIt stencil,
+                      Predicate pred,
+                      cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously inserts keys in the range `[first, last)` if `pred` of the corresponding
@@ -369,7 +376,7 @@ class static_map {
                        InputIt last,
                        StencilIt stencil,
                        Predicate pred,
-                       cuda::stream_ref stream = {}) noexcept;
+                       cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) noexcept;
 
   /**
    * @brief Asynchronously inserts all elements in the range `[first, last)`.
@@ -397,7 +404,8 @@ class static_map {
                              InputIt last,
                              FoundIt found_begin,
                              InsertedIt inserted_begin,
-                             cuda::stream_ref stream = {}) noexcept;
+                             cuda::stream_ref stream = cuda::stream_ref{
+                               cudaStream_t{nullptr}}) noexcept;
 
   /**
    * @brief Inserts all elements in the range `[first, last)`.
@@ -425,7 +433,7 @@ class static_map {
                        InputIt last,
                        FoundIt found_begin,
                        InsertedIt inserted_begin,
-                       cuda::stream_ref stream = {});
+                       cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief For any key-value pair `{k, v}` in the range `[first, last)`, if a key equivalent to `k`
@@ -446,7 +454,9 @@ class static_map {
    * @param stream CUDA stream used for insert
    */
   template <typename InputIt>
-  void insert_or_assign(InputIt first, InputIt last, cuda::stream_ref stream = {});
+  void insert_or_assign(InputIt first,
+                        InputIt last,
+                        cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief For any key-value pair `{k, v}` in the range `[first, last)`, if a key equivalent to `k`
@@ -465,7 +475,10 @@ class static_map {
    * @param stream CUDA stream used for insert
    */
   template <typename InputIt>
-  void insert_or_assign_async(InputIt first, InputIt last, cuda::stream_ref stream = {}) noexcept;
+  void insert_or_assign_async(InputIt first,
+                              InputIt last,
+                              cuda::stream_ref stream = cuda::stream_ref{
+                                cudaStream_t{nullptr}}) noexcept;
 
   /**
    * @brief For any key-value pair `{k, v}` in the range `[first, first + n)`, if a key equivalent
@@ -489,7 +502,10 @@ class static_map {
    * @param stream CUDA stream used for insert
    */
   template <typename InputIt, typename Op>
-  void insert_or_apply(InputIt first, InputIt last, Op op, cuda::stream_ref stream = {});
+  void insert_or_apply(InputIt first,
+                       InputIt last,
+                       Op op,
+                       cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief For any key-value pair `{k, v}` in the range `[first, first + n)`, if a key equivalent
@@ -517,7 +533,11 @@ class static_map {
    * @param stream CUDA stream used for insert
    */
   template <typename InputIt, typename Init, typename Op>
-  void insert_or_apply(InputIt first, InputIt last, Init init, Op op, cuda::stream_ref stream = {});
+  void insert_or_apply(InputIt first,
+                       InputIt last,
+                       Init init,
+                       Op op,
+                       cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief For any key-value pair `{k, v}` in the range `[first, first + n)`, if a key equivalent
@@ -542,7 +562,8 @@ class static_map {
   void insert_or_apply_async(InputIt first,
                              InputIt last,
                              Op op,
-                             cuda::stream_ref stream = {}) noexcept;
+                             cuda::stream_ref stream = cuda::stream_ref{
+                               cudaStream_t{nullptr}}) noexcept;
 
   /**
    * @brief For any key-value pair `{k, v}` in the range `[first, first + n)`, if a key equivalent
@@ -571,8 +592,12 @@ class static_map {
             typename Init,
             typename Op,
             typename = std::enable_if_t<std::is_convertible_v<Init, T>>>
-  void insert_or_apply_async(
-    InputIt first, InputIt last, Init init, Op op, cuda::stream_ref stream = {}) noexcept;
+  void insert_or_apply_async(InputIt first,
+                             InputIt last,
+                             Init init,
+                             Op op,
+                             cuda::stream_ref stream = cuda::stream_ref{
+                               cudaStream_t{nullptr}}) noexcept;
 
   /**
    * @brief Erases keys in the range `[first, last)`.
@@ -599,7 +624,9 @@ class static_map {
    * provided at construction
    */
   template <typename InputIt>
-  void erase(InputIt first, InputIt last, cuda::stream_ref stream = {});
+  void erase(InputIt first,
+             InputIt last,
+             cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously erases keys in the range `[first, last)`.
@@ -624,7 +651,9 @@ class static_map {
    * provided at construction
    */
   template <typename InputIt>
-  void erase_async(InputIt first, InputIt last, cuda::stream_ref stream = {});
+  void erase_async(InputIt first,
+                   InputIt last,
+                   cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Indicates whether the keys in the range `[first, last)` are contained in the map.
@@ -644,7 +673,7 @@ class static_map {
   void contains(InputIt first,
                 InputIt last,
                 OutputIt output_begin,
-                cuda::stream_ref stream = {}) const;
+                cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Asynchronously indicates whether the keys in the range `[first, last)` are contained in
@@ -662,7 +691,8 @@ class static_map {
   void contains_async(InputIt first,
                       InputIt last,
                       OutputIt output_begin,
-                      cuda::stream_ref stream = {}) const noexcept;
+                      cuda::stream_ref stream = cuda::stream_ref{
+                        cudaStream_t{nullptr}}) const noexcept;
 
   /**
    * @brief Indicates whether the keys in the range `[first, last)` are contained in the map if
@@ -695,7 +725,7 @@ class static_map {
                    StencilIt stencil,
                    Predicate pred,
                    OutputIt output_begin,
-                   cuda::stream_ref stream = {}) const;
+                   cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Asynchronously indicates whether the keys in the range `[first, last)` are contained in
@@ -726,7 +756,8 @@ class static_map {
                          StencilIt stencil,
                          Predicate pred,
                          OutputIt output_begin,
-                         cuda::stream_ref stream = {}) const noexcept;
+                         cuda::stream_ref stream = cuda::stream_ref{
+                           cudaStream_t{nullptr}}) const noexcept;
 
   /**
    * @brief For all keys in the range `[first, last)`, finds a payload with its key equivalent to
@@ -745,7 +776,10 @@ class static_map {
    * @param stream Stream used for executing the kernels
    */
   template <typename InputIt, typename OutputIt>
-  void find(InputIt first, InputIt last, OutputIt output_begin, cuda::stream_ref stream = {}) const;
+  void find(InputIt first,
+            InputIt last,
+            OutputIt output_begin,
+            cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief For all keys in the range `[first, last)`, asynchronously finds a payload with its key
@@ -766,7 +800,7 @@ class static_map {
   void find_async(InputIt first,
                   InputIt last,
                   OutputIt output_begin,
-                  cuda::stream_ref stream = {}) const;
+                  cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief For all keys in the range `[first, last)`, asynchronously finds an element with key
@@ -793,7 +827,7 @@ class static_map {
                   ProbeEqual const& probe_equal,
                   ProbeHash const& probe_hash,
                   OutputIt output_begin,
-                  cuda::stream_ref stream = {}) const;
+                  cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief For all keys in the range `[first, last)`, finds a match with its key equivalent to the
@@ -826,7 +860,7 @@ class static_map {
                StencilIt stencil,
                Predicate pred,
                OutputIt output_begin,
-               cuda::stream_ref stream = {}) const;
+               cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief For all keys in the range `[first, last)`, asynchronously finds
@@ -857,7 +891,7 @@ class static_map {
                      StencilIt stencil,
                      Predicate pred,
                      OutputIt output_begin,
-                     cuda::stream_ref stream = {}) const;
+                     cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief For all keys in the range `[first, last)`, asynchronously finds
@@ -899,7 +933,7 @@ class static_map {
                      ProbeEqual const& probe_equal,
                      ProbeHash const& probe_hash,
                      OutputIt output_begin,
-                     cuda::stream_ref stream = {}) const;
+                     cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Applies the given function object `callback_op` to the copy of every filled slot in the
@@ -913,7 +947,8 @@ class static_map {
    * @param stream CUDA stream used for this operation
    */
   template <typename CallbackOp>
-  void for_each(CallbackOp&& callback_op, cuda::stream_ref stream = {}) const;
+  void for_each(CallbackOp&& callback_op,
+                cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Asynchronously applies the given function object `callback_op` to the copy of every
@@ -927,7 +962,8 @@ class static_map {
    * @param stream CUDA stream used for this operation
    */
   template <typename CallbackOp>
-  void for_each_async(CallbackOp&& callback_op, cuda::stream_ref stream = {}) const;
+  void for_each_async(CallbackOp&& callback_op,
+                      cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief For each key in the range [first, last), applies the function object `callback_op` to
@@ -947,7 +983,7 @@ class static_map {
   void for_each(InputIt first,
                 InputIt last,
                 CallbackOp&& callback_op,
-                cuda::stream_ref stream = {}) const;
+                cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief For each key in the range [first, last), asynchronously applies the function object
@@ -967,7 +1003,8 @@ class static_map {
   void for_each_async(InputIt first,
                       InputIt last,
                       CallbackOp&& callback_op,
-                      cuda::stream_ref stream = {}) const noexcept;
+                      cuda::stream_ref stream = cuda::stream_ref{
+                        cudaStream_t{nullptr}}) const noexcept;
 
   /**
    * @brief Counts the occurrences of keys in `[first, last)` contained in the map
@@ -983,7 +1020,9 @@ class static_map {
    * @return The sum of total occurrences of all keys in `[first, last)`
    */
   template <typename InputIt>
-  size_type count(InputIt first, InputIt last, cuda::stream_ref stream = {}) const;
+  size_type count(InputIt first,
+                  InputIt last,
+                  cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Retrieves the matched key-value pair in the map corresponding to all probe keys in the
@@ -1017,7 +1056,8 @@ class static_map {
                                                    InputIt last,
                                                    OutputProbeIt output_probe,
                                                    OutputMatchIt output_match,
-                                                   cuda::stream_ref stream = {}) const;
+                                                   cuda::stream_ref stream = cuda::stream_ref{
+                                                     cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Retrieves all of the keys and their associated values contained in the map
@@ -1042,7 +1082,8 @@ class static_map {
   template <typename KeyOut, typename ValueOut>
   std::pair<KeyOut, ValueOut> retrieve_all(KeyOut keys_out,
                                            ValueOut values_out,
-                                           cuda::stream_ref stream = {}) const;
+                                           cuda::stream_ref stream = cuda::stream_ref{
+                                             cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Regenerates the container.
@@ -1052,7 +1093,7 @@ class static_map {
    *
    * @param stream CUDA stream used for this operation
    */
-  void rehash(cuda::stream_ref stream = {});
+  void rehash(cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Reserves at least the specified number of slots and regenerates the container
@@ -1072,14 +1113,15 @@ class static_map {
    * @param capacity New capacity of the container
    * @param stream CUDA stream used for this operation
    */
-  void rehash(size_type capacity, cuda::stream_ref stream = {});
+  void rehash(size_type capacity,
+              cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously regenerates the container.
    *
    * @param stream CUDA stream used for this operation
    */
-  void rehash_async(cuda::stream_ref stream = {});
+  void rehash_async(cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously reserves at least the specified number of slots and regenerates the
@@ -1097,7 +1139,8 @@ class static_map {
    * @param capacity New capacity of the container
    * @param stream CUDA stream used for this operation
    */
-  void rehash_async(size_type capacity, cuda::stream_ref stream = {});
+  void rehash_async(size_type capacity,
+                    cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Gets the number of elements in the container.
@@ -1107,7 +1150,8 @@ class static_map {
    * @param stream CUDA stream used to get the number of inserted elements
    * @return The number of elements in the container
    */
-  [[nodiscard]] size_type size(cuda::stream_ref stream = {}) const;
+  [[nodiscard]] size_type size(cuda::stream_ref stream = cuda::stream_ref{
+                                 cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Gets the maximum number of elements the hash map can hold.

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -186,7 +186,7 @@ class static_multimap {
                             cuda_thread_scope<Scope> scope      = {},
                             Storage storage                     = {},
                             Allocator const& alloc              = {},
-                            cuda::stream_ref stream             = {});
+                            cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Constructs a statically-sized map with the number of elements to insert `n`, the desired
@@ -230,7 +230,7 @@ class static_multimap {
                             cuda_thread_scope<Scope> scope      = {},
                             Storage storage                     = {},
                             Allocator const& alloc              = {},
-                            cuda::stream_ref stream             = {});
+                            cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Constructs a statically-sized map with the specified initial capacity, sentinel values
@@ -266,7 +266,7 @@ class static_multimap {
                             cuda_thread_scope<Scope> scope      = {},
                             Storage storage                     = {},
                             Allocator const& alloc              = {},
-                            cuda::stream_ref stream             = {});
+                            cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Erases all elements from the container. After this call, `size()` returns zero.
@@ -274,7 +274,7 @@ class static_multimap {
    *
    * @param stream CUDA stream this operation is executed in
    */
-  void clear(cuda::stream_ref stream = {});
+  void clear(cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously erases all elements from the container. After this call, `size()` returns
@@ -282,7 +282,7 @@ class static_multimap {
    *
    * @param stream CUDA stream this operation is executed in
    */
-  void clear_async(cuda::stream_ref stream = {}) noexcept;
+  void clear_async(cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) noexcept;
 
   /**
    * @brief Inserts all keys in the range `[first, last)`
@@ -299,7 +299,9 @@ class static_multimap {
    * @param stream CUDA stream used for insert
    */
   template <typename InputIt>
-  void insert(InputIt first, InputIt last, cuda::stream_ref stream = {});
+  void insert(InputIt first,
+              InputIt last,
+              cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously inserts all keys in the range `[first, last)`.
@@ -313,7 +315,9 @@ class static_multimap {
    * @param stream CUDA stream used for insert
    */
   template <typename InputIt>
-  void insert_async(InputIt first, InputIt last, cuda::stream_ref stream = {}) noexcept;
+  void insert_async(InputIt first,
+                    InputIt last,
+                    cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) noexcept;
 
   /**
    * @brief Inserts keys in the range `[first, last)` if `pred` of the corresponding stencil returns
@@ -340,8 +344,11 @@ class static_multimap {
    * @return Number of successful insertions
    */
   template <typename InputIt, typename StencilIt, typename Predicate>
-  size_type insert_if(
-    InputIt first, InputIt last, StencilIt stencil, Predicate pred, cuda::stream_ref stream = {});
+  size_type insert_if(InputIt first,
+                      InputIt last,
+                      StencilIt stencil,
+                      Predicate pred,
+                      cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously inserts keys in the range `[first, last)` if `pred` of the corresponding
@@ -368,7 +375,7 @@ class static_multimap {
                        InputIt last,
                        StencilIt stencil,
                        Predicate pred,
-                       cuda::stream_ref stream = {}) noexcept;
+                       cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) noexcept;
 
   /**
    * @brief Indicates whether the keys in the range `[first, last)` are contained in the map.
@@ -388,7 +395,7 @@ class static_multimap {
   void contains(InputIt first,
                 InputIt last,
                 OutputIt output_begin,
-                cuda::stream_ref stream = {}) const;
+                cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Asynchronously indicates whether the keys in the range `[first, last)` are contained in
@@ -406,7 +413,8 @@ class static_multimap {
   void contains_async(InputIt first,
                       InputIt last,
                       OutputIt output_begin,
-                      cuda::stream_ref stream = {}) const noexcept;
+                      cuda::stream_ref stream = cuda::stream_ref{
+                        cudaStream_t{nullptr}}) const noexcept;
 
   /**
    * @brief Indicates whether the keys in the range `[first, last)` are contained in the map if
@@ -439,7 +447,7 @@ class static_multimap {
                    StencilIt stencil,
                    Predicate pred,
                    OutputIt output_begin,
-                   cuda::stream_ref stream = {}) const;
+                   cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Asynchronously indicates whether the keys in the range `[first, last)` are contained in
@@ -470,7 +478,8 @@ class static_multimap {
                          StencilIt stencil,
                          Predicate pred,
                          OutputIt output_begin,
-                         cuda::stream_ref stream = {}) const noexcept;
+                         cuda::stream_ref stream = cuda::stream_ref{
+                           cudaStream_t{nullptr}}) const noexcept;
 
   /**
    * @brief For all keys in the range `[first, last)`, finds a payload with its key equivalent to
@@ -492,7 +501,10 @@ class static_multimap {
    * @param stream Stream used for executing the kernels
    */
   template <typename InputIt, typename OutputIt>
-  void find(InputIt first, InputIt last, OutputIt output_begin, cuda::stream_ref stream = {}) const;
+  void find(InputIt first,
+            InputIt last,
+            OutputIt output_begin,
+            cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief For all keys in the range `[first, last)`, asynchronously finds a payload with its key
@@ -516,7 +528,7 @@ class static_multimap {
   void find_async(InputIt first,
                   InputIt last,
                   OutputIt output_begin,
-                  cuda::stream_ref stream = {}) const;
+                  cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief For all keys in the range `[first, last)`, finds a match with its key equivalent to the
@@ -549,7 +561,7 @@ class static_multimap {
                StencilIt stencil,
                Predicate pred,
                OutputIt output_begin,
-               cuda::stream_ref stream = {}) const;
+               cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief For all keys in the range `[first, last)`, asynchronously finds
@@ -580,7 +592,7 @@ class static_multimap {
                      StencilIt stencil,
                      Predicate pred,
                      OutputIt output_begin,
-                     cuda::stream_ref stream = {}) const;
+                     cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Applies the given function object `callback_op` to the copy of every filled slot in the
@@ -594,7 +606,8 @@ class static_multimap {
    * @param stream CUDA stream used for this operation
    */
   template <typename CallbackOp>
-  void for_each(CallbackOp&& callback_op, cuda::stream_ref stream = {}) const;
+  void for_each(CallbackOp&& callback_op,
+                cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Asynchronously applies the given function object `callback_op` to the copy of every
@@ -608,7 +621,8 @@ class static_multimap {
    * @param stream CUDA stream used for this operation
    */
   template <typename CallbackOp>
-  void for_each_async(CallbackOp&& callback_op, cuda::stream_ref stream = {}) const;
+  void for_each_async(CallbackOp&& callback_op,
+                      cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief For each key in the range [first, last), applies the function object `callback_op` to
@@ -628,7 +642,7 @@ class static_multimap {
   void for_each(InputIt first,
                 InputIt last,
                 CallbackOp&& callback_op,
-                cuda::stream_ref stream = {}) const;
+                cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief For each key in the range [first, last), asynchronously applies the function object
@@ -648,7 +662,8 @@ class static_multimap {
   void for_each_async(InputIt first,
                       InputIt last,
                       CallbackOp&& callback_op,
-                      cuda::stream_ref stream = {}) const noexcept;
+                      cuda::stream_ref stream = cuda::stream_ref{
+                        cudaStream_t{nullptr}}) const noexcept;
 
   /**
    * @brief Counts the occurrences of keys in `[first, last)` contained in the multimap
@@ -664,7 +679,9 @@ class static_multimap {
    * @return The sum of total occurrences of all keys in `[first, last)`
    */
   template <typename InputIt>
-  size_type count(InputIt first, InputIt last, cuda::stream_ref stream = {}) const;
+  size_type count(InputIt first,
+                  InputIt last,
+                  cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Counts the occurrences of keys in `[first, last)` contained in the
@@ -689,7 +706,7 @@ class static_multimap {
                   InputIt last,
                   ProbeEqual const& probe_equal,
                   ProbeHash const& probe_hash,
-                  cuda::stream_ref stream = {}) const;
+                  cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Retrieves the matched key-value pair in the multimap corresponding to all probe keys in
@@ -721,7 +738,8 @@ class static_multimap {
                                                    InputIt last,
                                                    OutputProbeIt output_probe,
                                                    OutputMatchIt output_match,
-                                                   cuda::stream_ref stream = {}) const;
+                                                   cuda::stream_ref stream = cuda::stream_ref{
+                                                     cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Retrieves all the slots corresponding to all keys in the range `[first, last)`.
@@ -764,7 +782,8 @@ class static_multimap {
                                                    ProbeHash const& probe_hash,
                                                    OutputProbeIt output_probe,
                                                    OutputMatchIt output_match,
-                                                   cuda::stream_ref stream = {}) const;
+                                                   cuda::stream_ref stream = cuda::stream_ref{
+                                                     cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Retrieves all of the keys and their associated values contained in the multimap
@@ -789,7 +808,8 @@ class static_multimap {
   template <typename KeyOut, typename ValueOut>
   std::pair<KeyOut, ValueOut> retrieve_all(KeyOut keys_out,
                                            ValueOut values_out,
-                                           cuda::stream_ref stream = {}) const;
+                                           cuda::stream_ref stream = cuda::stream_ref{
+                                             cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Regenerates the container.
@@ -799,7 +819,7 @@ class static_multimap {
    *
    * @param stream CUDA stream used for this operation
    */
-  void rehash(cuda::stream_ref stream = {});
+  void rehash(cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Reserves at least the specified number of slots and regenerates the container
@@ -819,14 +839,15 @@ class static_multimap {
    * @param capacity New capacity of the container
    * @param stream CUDA stream used for this operation
    */
-  void rehash(size_type capacity, cuda::stream_ref stream = {});
+  void rehash(size_type capacity,
+              cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously regenerates the container.
    *
    * @param stream CUDA stream used for this operation
    */
-  void rehash_async(cuda::stream_ref stream = {});
+  void rehash_async(cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously reserves at least the specified number of slots and regenerates the
@@ -844,7 +865,8 @@ class static_multimap {
    * @param capacity New capacity of the container
    * @param stream CUDA stream used for this operation
    */
-  void rehash_async(size_type capacity, cuda::stream_ref stream = {});
+  void rehash_async(size_type capacity,
+                    cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Gets the number of elements in the container.
@@ -854,7 +876,8 @@ class static_multimap {
    * @param stream CUDA stream used to get the number of inserted elements
    * @return The number of elements in the container
    */
-  [[nodiscard]] size_type size(cuda::stream_ref stream = {}) const;
+  [[nodiscard]] size_type size(cuda::stream_ref stream = cuda::stream_ref{
+                                 cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Gets the maximum number of elements the multimap can hold.

--- a/include/cuco/static_multiset.cuh
+++ b/include/cuco/static_multiset.cuh
@@ -151,7 +151,7 @@ class static_multiset {
                             cuda_thread_scope<Scope> scope      = {},
                             Storage storage                     = {},
                             Allocator const& alloc              = {},
-                            cuda::stream_ref stream             = {});
+                            cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Constructs a statically-sized multiset with the number of elements to insert `n`, the
@@ -193,7 +193,7 @@ class static_multiset {
                             cuda_thread_scope<Scope> scope      = {},
                             Storage storage                     = {},
                             Allocator const& alloc              = {},
-                            cuda::stream_ref stream             = {});
+                            cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Constructs a statically-sized set with the specified initial capacity, sentinel values
@@ -227,7 +227,7 @@ class static_multiset {
                             cuda_thread_scope<Scope> scope      = {},
                             Storage storage                     = {},
                             Allocator const& alloc              = {},
-                            cuda::stream_ref stream             = {});
+                            cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Erases all elements from the container. After this call, `size()` returns zero.
@@ -235,7 +235,7 @@ class static_multiset {
    *
    * @param stream CUDA stream this operation is executed in
    */
-  void clear(cuda::stream_ref stream = {});
+  void clear(cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously erases all elements from the container. After this call, `size()` returns
@@ -243,7 +243,7 @@ class static_multiset {
    *
    * @param stream CUDA stream this operation is executed in
    */
-  void clear_async(cuda::stream_ref stream = {}) noexcept;
+  void clear_async(cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) noexcept;
 
   /**
    * @brief Inserts all keys in the range `[first, last)`
@@ -261,7 +261,9 @@ class static_multiset {
    * @param stream CUDA stream used for insert
    */
   template <typename InputIt>
-  void insert(InputIt first, InputIt last, cuda::stream_ref stream = {});
+  void insert(InputIt first,
+              InputIt last,
+              cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously inserts all keys in the range `[first, last)`.
@@ -276,7 +278,9 @@ class static_multiset {
    * @param stream CUDA stream used for insert
    */
   template <typename InputIt>
-  void insert_async(InputIt first, InputIt last, cuda::stream_ref stream = {}) noexcept;
+  void insert_async(InputIt first,
+                    InputIt last,
+                    cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) noexcept;
 
   /**
    * @brief Inserts keys in the range `[first, last)` if `pred` of the corresponding stencil returns
@@ -303,8 +307,11 @@ class static_multiset {
    * @return Number of successful insertions
    */
   template <typename InputIt, typename StencilIt, typename Predicate>
-  size_type insert_if(
-    InputIt first, InputIt last, StencilIt stencil, Predicate pred, cuda::stream_ref stream = {});
+  size_type insert_if(InputIt first,
+                      InputIt last,
+                      StencilIt stencil,
+                      Predicate pred,
+                      cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously inserts keys in the range `[first, last)` if `pred` of the corresponding
@@ -331,7 +338,7 @@ class static_multiset {
                        InputIt last,
                        StencilIt stencil,
                        Predicate pred,
-                       cuda::stream_ref stream = {}) noexcept;
+                       cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) noexcept;
 
   /**
    * @brief Indicates whether the keys in the range `[first, last)` are contained in the multiset.
@@ -351,7 +358,7 @@ class static_multiset {
   void contains(InputIt first,
                 InputIt last,
                 OutputIt output_begin,
-                cuda::stream_ref stream = {}) const;
+                cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Asynchronously indicates whether the keys in the range `[first, last)` are contained in
@@ -369,7 +376,8 @@ class static_multiset {
   void contains_async(InputIt first,
                       InputIt last,
                       OutputIt output_begin,
-                      cuda::stream_ref stream = {}) const noexcept;
+                      cuda::stream_ref stream = cuda::stream_ref{
+                        cudaStream_t{nullptr}}) const noexcept;
 
   /**
    * @brief Indicates whether the keys in the range `[first, last)` are contained in the multiset if
@@ -402,7 +410,7 @@ class static_multiset {
                    StencilIt stencil,
                    Predicate pred,
                    OutputIt output_begin,
-                   cuda::stream_ref stream = {}) const;
+                   cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Asynchronously indicates whether the keys in the range `[first, last)` are contained in
@@ -433,7 +441,8 @@ class static_multiset {
                          StencilIt stencil,
                          Predicate pred,
                          OutputIt output_begin,
-                         cuda::stream_ref stream = {}) const noexcept;
+                         cuda::stream_ref stream = cuda::stream_ref{
+                           cudaStream_t{nullptr}}) const noexcept;
 
   /**
    * @brief For all keys in the range `[first, last)`, finds an element with its key equivalent to
@@ -455,7 +464,10 @@ class static_multiset {
    * @param stream Stream used for executing the kernels
    */
   template <typename InputIt, typename OutputIt>
-  void find(InputIt first, InputIt last, OutputIt output_begin, cuda::stream_ref stream = {}) const;
+  void find(InputIt first,
+            InputIt last,
+            OutputIt output_begin,
+            cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief For all keys in the range `[first, last)`, asynchronously finds an element with its key
@@ -479,7 +491,7 @@ class static_multiset {
   void find_async(InputIt first,
                   InputIt last,
                   OutputIt output_begin,
-                  cuda::stream_ref stream = {}) const;
+                  cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief For all keys in the range `[first, last)`, finds a match with its key equivalent to the
@@ -512,7 +524,7 @@ class static_multiset {
                StencilIt stencil,
                Predicate pred,
                OutputIt output_begin,
-               cuda::stream_ref stream = {}) const;
+               cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief For all keys in the range `[first, last)`, asynchronously finds
@@ -543,7 +555,7 @@ class static_multiset {
                      StencilIt stencil,
                      Predicate pred,
                      OutputIt output_begin,
-                     cuda::stream_ref stream = {}) const;
+                     cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Applies the given function object `callback_op` to the copy of every filled slot in the
@@ -557,7 +569,8 @@ class static_multiset {
    * @param stream CUDA stream used for this operation
    */
   template <typename CallbackOp>
-  void for_each(CallbackOp&& callback_op, cuda::stream_ref stream = {}) const;
+  void for_each(CallbackOp&& callback_op,
+                cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Asynchronously applies the given function object `callback_op` to the copy of every
@@ -571,7 +584,8 @@ class static_multiset {
    * @param stream CUDA stream used for this operation
    */
   template <typename CallbackOp>
-  void for_each_async(CallbackOp&& callback_op, cuda::stream_ref stream = {}) const;
+  void for_each_async(CallbackOp&& callback_op,
+                      cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief For each key in the range [first, last), applies the function object `callback_op` to
@@ -591,7 +605,7 @@ class static_multiset {
   void for_each(InputIt first,
                 InputIt last,
                 CallbackOp&& callback_op,
-                cuda::stream_ref stream = {}) const;
+                cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief For each key in the range [first, last), asynchronously applies the function object
@@ -611,7 +625,8 @@ class static_multiset {
   void for_each_async(InputIt first,
                       InputIt last,
                       CallbackOp&& callback_op,
-                      cuda::stream_ref stream = {}) const noexcept;
+                      cuda::stream_ref stream = cuda::stream_ref{
+                        cudaStream_t{nullptr}}) const noexcept;
 
   /**
    * @brief Counts the occurrences of keys in `[first, last)` contained in the multiset
@@ -627,7 +642,9 @@ class static_multiset {
    * @return The sum of total occurrences of all keys in `[first, last)`
    */
   template <typename InputIt>
-  size_type count(InputIt first, InputIt last, cuda::stream_ref stream = {}) const;
+  size_type count(InputIt first,
+                  InputIt last,
+                  cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Counts the occurrences of keys in `[first, last)` contained in the multiset
@@ -651,7 +668,7 @@ class static_multiset {
                   InputIt last,
                   ProbeKeyEqual const& probe_key_equal,
                   ProbeHash const& probe_hash,
-                  cuda::stream_ref stream = {}) const;
+                  cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Counts the occurrences of keys in `[first, last)` contained in the multiset
@@ -677,7 +694,7 @@ class static_multiset {
                         InputIt last,
                         ProbeKeyEqual const& probe_key_equal,
                         ProbeHash const& probe_hash,
-                        cuda::stream_ref stream = {}) const;
+                        cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Counts the number of occurrences of each query key in the multiset
@@ -708,7 +725,7 @@ class static_multiset {
                   ProbeKeyEqual const& probe_key_equal,
                   ProbeHash const& probe_hash,
                   OutputIt output_begin,
-                  cuda::stream_ref stream = {}) const;
+                  cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Counts the number of occurrences of each query key in the multiset with outer semantics.
@@ -745,7 +762,7 @@ class static_multiset {
                         ProbeKeyEqual const& probe_key_equal,
                         ProbeHash const& probe_hash,
                         OutputIt output_begin,
-                        cuda::stream_ref stream = {}) const;
+                        cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Retrieves all the slots corresponding to all keys in the range `[first, last)`.
@@ -778,7 +795,8 @@ class static_multiset {
                                                    InputProbeIt last,
                                                    OutputProbeIt output_probe,
                                                    OutputMatchIt output_match,
-                                                   cuda::stream_ref stream = {}) const;
+                                                   cuda::stream_ref stream = cuda::stream_ref{
+                                                     cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Retrieves all the slots corresponding to all keys in the range `[first, last)`.
@@ -821,7 +839,8 @@ class static_multiset {
                                                    ProbeHash const& probe_hash,
                                                    OutputProbeIt output_probe,
                                                    OutputMatchIt output_match,
-                                                   cuda::stream_ref stream = {}) const;
+                                                   cuda::stream_ref stream = cuda::stream_ref{
+                                                     cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Retrieves all the slots corresponding to all keys in the range `[first, last)`.
@@ -867,7 +886,8 @@ class static_multiset {
                                                          ProbeHash const& probe_hash,
                                                          OutputProbeIt output_probe,
                                                          OutputMatchIt output_match,
-                                                         cuda::stream_ref stream = {}) const;
+                                                         cuda::stream_ref stream = cuda::stream_ref{
+                                                           cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Retrieves all keys contained in the multiset
@@ -887,7 +907,8 @@ class static_multiset {
    * @return Iterator indicating the end of the output
    */
   template <typename OutputIt>
-  OutputIt retrieve_all(OutputIt output_begin, cuda::stream_ref stream = {}) const;
+  OutputIt retrieve_all(OutputIt output_begin,
+                        cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Regenerates the container.
@@ -897,7 +918,7 @@ class static_multiset {
    *
    * @param stream CUDA stream used for this operation
    */
-  void rehash(cuda::stream_ref stream = {});
+  void rehash(cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Reserves at least the specified number of slots and regenerates the container
@@ -917,14 +938,15 @@ class static_multiset {
    * @param capacity New capacity of the container
    * @param stream CUDA stream used for this operation
    */
-  void rehash(size_type capacity, cuda::stream_ref stream = {});
+  void rehash(size_type capacity,
+              cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously regenerates the container.
    *
    * @param stream CUDA stream used for this operation
    */
-  void rehash_async(cuda::stream_ref stream = {});
+  void rehash_async(cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously reserves at least the specified number of slots and regenerates the
@@ -942,7 +964,8 @@ class static_multiset {
    * @param capacity New capacity of the container
    * @param stream CUDA stream used for this operation
    */
-  void rehash_async(size_type capacity, cuda::stream_ref stream = {});
+  void rehash_async(size_type capacity,
+                    cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Gets the number of elements in the container.
@@ -952,7 +975,8 @@ class static_multiset {
    * @param stream CUDA stream used to get the number of inserted elements
    * @return The number of elements in the container
    */
-  [[nodiscard]] size_type size(cuda::stream_ref stream = {}) const;
+  [[nodiscard]] size_type size(cuda::stream_ref stream = cuda::stream_ref{
+                                 cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Gets the maximum number of elements the multiset can hold.

--- a/include/cuco/static_set.cuh
+++ b/include/cuco/static_set.cuh
@@ -156,7 +156,7 @@ class static_set {
                        cuda_thread_scope<Scope> scope      = {},
                        Storage storage                     = {},
                        Allocator const& alloc              = {},
-                       cuda::stream_ref stream             = {});
+                       cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Constructs a statically-sized set with the number of elements to insert `n`, the desired
@@ -198,7 +198,7 @@ class static_set {
                        cuda_thread_scope<Scope> scope      = {},
                        Storage storage                     = {},
                        Allocator const& alloc              = {},
-                       cuda::stream_ref stream             = {});
+                       cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Constructs a statically-sized set with the specified initial capacity, sentinel values
@@ -232,7 +232,7 @@ class static_set {
                        cuda_thread_scope<Scope> scope      = {},
                        Storage storage                     = {},
                        Allocator const& alloc              = {},
-                       cuda::stream_ref stream             = {});
+                       cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Erases all elements from the container. After this call, `size()` returns zero.
@@ -240,7 +240,7 @@ class static_set {
    *
    * @param stream CUDA stream this operation is executed in
    */
-  void clear(cuda::stream_ref stream = {});
+  void clear(cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously erases all elements from the container. After this call, `size()` returns
@@ -248,7 +248,7 @@ class static_set {
    *
    * @param stream CUDA stream this operation is executed in
    */
-  void clear_async(cuda::stream_ref stream = {}) noexcept;
+  void clear_async(cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) noexcept;
 
   /**
    * @brief Inserts all keys in the range `[first, last)` and returns the number of successful
@@ -268,7 +268,9 @@ class static_set {
    * @return Number of successfully inserted keys
    */
   template <typename InputIt>
-  size_type insert(InputIt first, InputIt last, cuda::stream_ref stream = {});
+  size_type insert(InputIt first,
+                   InputIt last,
+                   cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously inserts all keys in the range `[first, last)`.
@@ -282,7 +284,9 @@ class static_set {
    * @param stream CUDA stream used for insert
    */
   template <typename InputIt>
-  void insert_async(InputIt first, InputIt last, cuda::stream_ref stream = {}) noexcept;
+  void insert_async(InputIt first,
+                    InputIt last,
+                    cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) noexcept;
 
   /**
    * @brief Inserts keys in the range `[first, last)` if `pred` of the corresponding stencil returns
@@ -309,8 +313,11 @@ class static_set {
    * @return Number of successfully inserted keys
    */
   template <typename InputIt, typename StencilIt, typename Predicate>
-  size_type insert_if(
-    InputIt first, InputIt last, StencilIt stencil, Predicate pred, cuda::stream_ref stream = {});
+  size_type insert_if(InputIt first,
+                      InputIt last,
+                      StencilIt stencil,
+                      Predicate pred,
+                      cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously inserts keys in the range `[first, last)` if `pred` of the corresponding
@@ -337,7 +344,7 @@ class static_set {
                        InputIt last,
                        StencilIt stencil,
                        Predicate pred,
-                       cuda::stream_ref stream = {}) noexcept;
+                       cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) noexcept;
 
   /**
    * @brief Asynchronously inserts all elements in the range `[first, last)`.
@@ -365,7 +372,8 @@ class static_set {
                              InputIt last,
                              FoundIt found_begin,
                              InsertedIt inserted_begin,
-                             cuda::stream_ref stream = {}) noexcept;
+                             cuda::stream_ref stream = cuda::stream_ref{
+                               cudaStream_t{nullptr}}) noexcept;
 
   /**
    * @brief Inserts all elements in the range `[first, last)`.
@@ -393,7 +401,7 @@ class static_set {
                        InputIt last,
                        FoundIt found_begin,
                        InsertedIt inserted_begin,
-                       cuda::stream_ref stream = {});
+                       cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Erases keys in the range `[first, last)`.
@@ -420,7 +428,9 @@ class static_set {
    * provided at construction
    */
   template <typename InputIt>
-  void erase(InputIt first, InputIt last, cuda::stream_ref stream = {});
+  void erase(InputIt first,
+             InputIt last,
+             cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously erases keys in the range `[first, last)`.
@@ -445,7 +455,9 @@ class static_set {
    * provided at construction
    */
   template <typename InputIt>
-  void erase_async(InputIt first, InputIt last, cuda::stream_ref stream = {});
+  void erase_async(InputIt first,
+                   InputIt last,
+                   cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Indicates whether the keys in the range `[first, last)` are contained in the set.
@@ -465,7 +477,7 @@ class static_set {
   void contains(InputIt first,
                 InputIt last,
                 OutputIt output_begin,
-                cuda::stream_ref stream = {}) const;
+                cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Asynchronously indicates whether the keys in the range `[first, last)` are contained in
@@ -483,7 +495,8 @@ class static_set {
   void contains_async(InputIt first,
                       InputIt last,
                       OutputIt output_begin,
-                      cuda::stream_ref stream = {}) const noexcept;
+                      cuda::stream_ref stream = cuda::stream_ref{
+                        cudaStream_t{nullptr}}) const noexcept;
 
   /**
    * @brief Indicates whether the keys in the range `[first, last)` are contained in the set if
@@ -516,7 +529,7 @@ class static_set {
                    StencilIt stencil,
                    Predicate pred,
                    OutputIt output_begin,
-                   cuda::stream_ref stream = {}) const;
+                   cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Asynchronously indicates whether the keys in the range `[first, last)` are contained in
@@ -547,7 +560,8 @@ class static_set {
                          StencilIt stencil,
                          Predicate pred,
                          OutputIt output_begin,
-                         cuda::stream_ref stream = {}) const noexcept;
+                         cuda::stream_ref stream = cuda::stream_ref{
+                           cudaStream_t{nullptr}}) const noexcept;
 
   /**
    * @brief For all keys in the range `[first, last)`, finds an element with key equivalent to the
@@ -566,7 +580,10 @@ class static_set {
    * @param stream Stream used for executing the kernels
    */
   template <typename InputIt, typename OutputIt>
-  void find(InputIt first, InputIt last, OutputIt output_begin, cuda::stream_ref stream = {}) const;
+  void find(InputIt first,
+            InputIt last,
+            OutputIt output_begin,
+            cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief For all keys in the range `[first, last)`, asynchronously finds an element with key
@@ -587,7 +604,7 @@ class static_set {
   void find_async(InputIt first,
                   InputIt last,
                   OutputIt output_begin,
-                  cuda::stream_ref stream = {}) const;
+                  cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief For all keys in the range `[first, last)`, asynchronously finds an element with key
@@ -615,7 +632,7 @@ class static_set {
                   ProbeEqual const& probe_equal,
                   ProbeHash const& probe_hash,
                   OutputIt output_begin,
-                  cuda::stream_ref stream = {}) const;
+                  cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief For all keys in the range `[first, last)`, finds a match with its key equivalent to the
@@ -648,7 +665,7 @@ class static_set {
                StencilIt stencil,
                Predicate pred,
                OutputIt output_begin,
-               cuda::stream_ref stream = {}) const;
+               cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief For all keys in the range `[first, last)`, asynchronously finds
@@ -679,7 +696,7 @@ class static_set {
                      StencilIt stencil,
                      Predicate pred,
                      OutputIt output_begin,
-                     cuda::stream_ref stream = {}) const;
+                     cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief For all keys in the range `[first, last)`, asynchronously finds
@@ -722,7 +739,7 @@ class static_set {
                      ProbeEqual const& probe_equal,
                      ProbeHash const& probe_hash,
                      OutputIt output_begin,
-                     cuda::stream_ref stream = {}) const;
+                     cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Applies the given function object `callback_op` to the copy of every filled slot in the
@@ -736,7 +753,8 @@ class static_set {
    * @param stream CUDA stream used for this operation
    */
   template <typename CallbackOp>
-  void for_each(CallbackOp&& callback_op, cuda::stream_ref stream = {}) const;
+  void for_each(CallbackOp&& callback_op,
+                cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Asynchronously applies the given function object `callback_op` to the copy of every
@@ -750,7 +768,8 @@ class static_set {
    * @param stream CUDA stream used for this operation
    */
   template <typename CallbackOp>
-  void for_each_async(CallbackOp&& callback_op, cuda::stream_ref stream = {}) const;
+  void for_each_async(CallbackOp&& callback_op,
+                      cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief For each key in the range [first, last), applies the function object `callback_op` to
@@ -770,7 +789,7 @@ class static_set {
   void for_each(InputIt first,
                 InputIt last,
                 CallbackOp&& callback_op,
-                cuda::stream_ref stream = {}) const;
+                cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief For each key in the range [first, last), asynchronously applies the function object
@@ -790,7 +809,8 @@ class static_set {
   void for_each_async(InputIt first,
                       InputIt last,
                       CallbackOp&& callback_op,
-                      cuda::stream_ref stream = {}) const noexcept;
+                      cuda::stream_ref stream = cuda::stream_ref{
+                        cudaStream_t{nullptr}}) const noexcept;
 
   /**
    * @brief Counts the occurrences of keys in `[first, last)` contained in the set
@@ -806,7 +826,9 @@ class static_set {
    * @return The sum of total occurrences of all keys in `[first, last)`
    */
   template <typename InputIt>
-  size_type count(InputIt first, InputIt last, cuda::stream_ref stream = {}) const;
+  size_type count(InputIt first,
+                  InputIt last,
+                  cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Retrieves the matched key in the set corresponding to all probe keys in the range
@@ -839,7 +861,8 @@ class static_set {
                                            InputIt last,
                                            OutputIt1 output_probe,
                                            OutputIt2 output_match,
-                                           cuda::stream_ref stream = {}) const;
+                                           cuda::stream_ref stream = cuda::stream_ref{
+                                             cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Retrieves all keys contained in the set.
@@ -859,7 +882,8 @@ class static_set {
    * @return Iterator indicating the end of the output
    */
   template <typename OutputIt>
-  OutputIt retrieve_all(OutputIt output_begin, cuda::stream_ref stream = {}) const;
+  OutputIt retrieve_all(OutputIt output_begin,
+                        cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Regenerates the container.
@@ -869,7 +893,7 @@ class static_set {
    *
    * @param stream CUDA stream used for this operation
    */
-  void rehash(cuda::stream_ref stream = {});
+  void rehash(cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Reserves at least the specified number of slots and regenerates the container
@@ -889,14 +913,15 @@ class static_set {
    * @param capacity New capacity of the container
    * @param stream CUDA stream used for this operation
    */
-  void rehash(size_type capacity, cuda::stream_ref stream = {});
+  void rehash(size_type capacity,
+              cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously regenerates the container.
    *
    * @param stream CUDA stream used for this operation
    */
-  void rehash_async(cuda::stream_ref stream = {});
+  void rehash_async(cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Asynchronously reserves at least the specified number of slots and regenerates the
@@ -914,7 +939,8 @@ class static_set {
    * @param capacity New capacity of the container
    * @param stream CUDA stream used for this operation
    */
-  void rehash_async(size_type capacity, cuda::stream_ref stream = {});
+  void rehash_async(size_type capacity,
+                    cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
    * @brief Gets the number of elements in the container.
@@ -924,7 +950,8 @@ class static_set {
    * @param stream CUDA stream used to get the number of inserted elements
    * @return The number of elements in the container
    */
-  [[nodiscard]] size_type size(cuda::stream_ref stream = {}) const;
+  [[nodiscard]] size_type size(cuda::stream_ref stream = cuda::stream_ref{
+                                 cudaStream_t{nullptr}}) const;
 
   /**
    * @brief Gets the maximum number of elements the hash set can hold.


### PR DESCRIPTION
The default constructor of `cuda::stream_ref` is being deprecated in CCCL, and this PR addresses the warnings by replacing default construction of `cuda::stream_ref`, e.g. https://godbolt.org/z/rd45Mx9dq:

```bash
 warning: 'constexpr cuda::__4::stream_ref::stream_ref()' is deprecated: Using the default/null stream is generally discouraged. If you need to use it, please construct a stream_ref from cudaStream_t{nullptr}
```
