### PR TITLE
Use static_for for fixed-size loops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,30 @@ option(CUCO_DOWNLOAD_ROARING_TESTDATA "Download RoaringFormatSpec test data" ON)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/roaring_testdata.cmake)
 
 ###################################################################################################
+# - common compile options function ---------------------------------------------------------------
+
+function(cuco_set_common_compile_options target_name)
+    # Parse optional arguments
+    cmake_parse_arguments(CUCO_OPTS "ADD_LINEINFO" "" "" ${ARGN})
+    
+    # Base compile options common to all targets
+    target_compile_options(${target_name} PRIVATE 
+        --compiler-options=-Wall --compiler-options=-Wextra --compiler-options=-Werror 
+        -Wno-deprecated-gpu-targets --expt-extended-lambda -Werror=all-warnings
+    )
+    
+    # Add lineinfo option if requested (typically for benchmarks)
+    if(CUCO_OPTS_ADD_LINEINFO)
+        target_compile_options(${target_name} PRIVATE -lineinfo)
+    endif()
+    
+    # Add GCC-specific warning suppression only for GCC
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        target_compile_options(${target_name} PRIVATE -Xcompiler -Wno-subobject-linkage)
+    endif()
+endfunction()
+
+###################################################################################################
 # - optionally build tests ------------------------------------------------------------------------
 
 if(BUILD_TESTS)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -28,7 +28,7 @@ function(ConfigureBench BENCH_NAME)
     target_include_directories(${BENCH_NAME} PRIVATE
                                              "${CMAKE_CURRENT_SOURCE_DIR}")
     target_compile_options(${BENCH_NAME} PRIVATE --compiler-options=-Wall --compiler-options=-Wextra
-      --compiler-options=-Werror -Wno-deprecated-gpu-targets --expt-extended-lambda -lineinfo)
+      --compiler-options=-Werror -Wno-deprecated-gpu-targets --expt-extended-lambda -lineinfo -Xcudafe --promote_warnings)
     # Add GCC-specific warning suppression only for GCC
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
       target_compile_options(${BENCH_NAME} PRIVATE -Xcompiler -Wno-subobject-linkage)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -27,12 +27,7 @@ function(ConfigureBench BENCH_NAME)
                                         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/benchmarks")
     target_include_directories(${BENCH_NAME} PRIVATE
                                              "${CMAKE_CURRENT_SOURCE_DIR}")
-    target_compile_options(${BENCH_NAME} PRIVATE --compiler-options=-Wall --compiler-options=-Wextra
-      --compiler-options=-Werror -Wno-deprecated-gpu-targets --expt-extended-lambda -lineinfo -Xcudafe --promote_warnings)
-    # Add GCC-specific warning suppression only for GCC
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-      target_compile_options(${BENCH_NAME} PRIVATE -Xcompiler -Wno-subobject-linkage)
-    endif()
+    cuco_set_common_compile_options(${BENCH_NAME} ADD_LINEINFO)
     target_link_libraries(${BENCH_NAME} PRIVATE
                                         nvbench::main
                                         pthread

--- a/benchmarks/dynamic_map/contains_bench.cu
+++ b/benchmarks/dynamic_map/contains_bench.cu
@@ -43,7 +43,7 @@ std::enable_if_t<(sizeof(Key) == sizeof(Value)), void> dynamic_map_contains(
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   thrust::device_vector<pair_type> pairs(num_keys);

--- a/benchmarks/dynamic_map/erase_bench.cu
+++ b/benchmarks/dynamic_map/erase_bench.cu
@@ -43,7 +43,7 @@ std::enable_if_t<(sizeof(Key) == sizeof(Value)), void> dynamic_map_erase(
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   thrust::device_vector<pair_type> pairs(num_keys);

--- a/benchmarks/dynamic_map/find_bench.cu
+++ b/benchmarks/dynamic_map/find_bench.cu
@@ -43,7 +43,7 @@ std::enable_if_t<(sizeof(Key) == sizeof(Value)), void> dynamic_map_find(
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   thrust::device_vector<pair_type> pairs(num_keys);

--- a/benchmarks/dynamic_map/insert_bench.cu
+++ b/benchmarks/dynamic_map/insert_bench.cu
@@ -45,7 +45,7 @@ std::enable_if_t<(sizeof(Key) == sizeof(Value)), void> dynamic_map_insert(
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   thrust::device_vector<pair_type> pairs(num_keys);

--- a/benchmarks/dynamic_map/retrieve_all_bench.cu
+++ b/benchmarks/dynamic_map/retrieve_all_bench.cu
@@ -42,7 +42,7 @@ std::enable_if_t<(sizeof(Key) == sizeof(Value)), void> dynamic_map_retrieve_all(
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   thrust::device_vector<pair_type> pairs(num_keys);

--- a/benchmarks/hyperloglog/hyperloglog_bench.cu
+++ b/benchmarks/hyperloglog/hyperloglog_bench.cu
@@ -58,7 +58,7 @@ template <class Estimator, class Dist>
 
   thrust::device_vector<T> items(num_items);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   Estimator estimator{cuco::sketch_size_kb(sketch_size_kb)};
   double error_sum = 0;
   for (std::size_t i = 0; i < num_samples; ++i) {
@@ -97,7 +97,7 @@ void hyperloglog_e2e(nvbench::state& state, nvbench::type_list<T, Dist>)
 
   thrust::device_vector<T> items(num_items);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), items.begin(), items.end());
 
   estimator_type estimator{cuco::sketch_size_kb(sketch_size_kb)};
@@ -126,7 +126,7 @@ void hyperloglog_add(nvbench::state& state, nvbench::type_list<T, Dist>)
 
   thrust::device_vector<T> items(num_items);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), items.begin(), items.end());
 
   state.add_element_count(num_items);

--- a/benchmarks/roaring_bitmap/contains_bench.cu
+++ b/benchmarks/roaring_bitmap/contains_bench.cu
@@ -55,7 +55,7 @@ void roaring_bitmap_contains(nvbench::state& state, nvbench::type_list<T>)
 
   thrust::device_vector<T> items(num_items);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(distribution::unique{}, items.begin(), items.end());
 
   thrust::device_vector<bool> contained(items.size(), false);

--- a/benchmarks/static_map/contains_bench.cu
+++ b/benchmarks/static_map/contains_bench.cu
@@ -45,7 +45,7 @@ std::enable_if_t<(sizeof(Key) == sizeof(Value)), void> static_map_contains(
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   thrust::device_vector<pair_type> pairs(num_keys);

--- a/benchmarks/static_map/erase_bench.cu
+++ b/benchmarks/static_map/erase_bench.cu
@@ -45,7 +45,7 @@ std::enable_if_t<(sizeof(Key) == sizeof(Value)), void> static_map_erase(
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   thrust::device_vector<pair_type> pairs(num_keys);

--- a/benchmarks/static_map/find_bench.cu
+++ b/benchmarks/static_map/find_bench.cu
@@ -45,7 +45,7 @@ std::enable_if_t<(sizeof(Key) == sizeof(Value)), void> static_map_find(
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   thrust::device_vector<pair_type> pairs(num_keys);

--- a/benchmarks/static_map/insert_bench.cu
+++ b/benchmarks/static_map/insert_bench.cu
@@ -44,7 +44,7 @@ std::enable_if_t<(sizeof(Key) == sizeof(Value)), void> static_map_insert(
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   thrust::device_vector<pair_type> pairs(num_keys);

--- a/benchmarks/static_map/insert_or_apply_bench.cu
+++ b/benchmarks/static_map/insert_or_apply_bench.cu
@@ -46,7 +46,7 @@ std::enable_if_t<(sizeof(Key) == sizeof(Value)), void> static_map_insert_or_appl
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   thrust::device_vector<pair_type> pairs(num_keys);

--- a/benchmarks/static_multimap/count_bench.cu
+++ b/benchmarks/static_multimap/count_bench.cu
@@ -45,7 +45,7 @@ std::enable_if_t<(sizeof(Key) == sizeof(Value)), void> static_multimap_count(
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   thrust::device_vector<pair_type> pairs(num_keys);

--- a/benchmarks/static_multimap/insert_bench.cu
+++ b/benchmarks/static_multimap/insert_bench.cu
@@ -44,7 +44,7 @@ std::enable_if_t<(sizeof(Key) == sizeof(Value)), void> static_multimap_insert(
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   thrust::device_vector<pair_type> pairs(num_keys);

--- a/benchmarks/static_multimap/query_bench.cu
+++ b/benchmarks/static_multimap/query_bench.cu
@@ -45,7 +45,7 @@ std::enable_if_t<(sizeof(Key) == sizeof(Value)), void> static_multimap_query(
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   thrust::device_vector<pair_type> pairs(num_keys);

--- a/benchmarks/static_multimap/retrieve_bench.cu
+++ b/benchmarks/static_multimap/retrieve_bench.cu
@@ -45,7 +45,7 @@ std::enable_if_t<(sizeof(Key) == sizeof(Value)), void> static_multimap_retrieve(
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   thrust::device_vector<pair_type> pairs(num_keys);

--- a/benchmarks/static_multiset/contains_bench.cu
+++ b/benchmarks/static_multiset/contains_bench.cu
@@ -41,7 +41,7 @@ void static_multiset_contains(nvbench::state& state, nvbench::type_list<Key, Dis
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   cuco::static_multiset<Key> set{size, cuco::empty_key<Key>{-1}};

--- a/benchmarks/static_multiset/count_bench.cu
+++ b/benchmarks/static_multiset/count_bench.cu
@@ -42,7 +42,7 @@ void static_multiset_count(nvbench::state& state, nvbench::type_list<Key, Dist>)
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   auto map = cuco::static_multiset{size, cuco::empty_key<Key>{-1}};

--- a/benchmarks/static_multiset/find_bench.cu
+++ b/benchmarks/static_multiset/find_bench.cu
@@ -42,7 +42,7 @@ void static_multiset_find(nvbench::state& state, nvbench::type_list<Key, Dist>)
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   cuco::static_multiset<Key> set{size, cuco::empty_key<Key>{-1}};

--- a/benchmarks/static_multiset/insert_bench.cu
+++ b/benchmarks/static_multiset/insert_bench.cu
@@ -40,7 +40,7 @@ void static_multiset_insert(nvbench::state& state, nvbench::type_list<Key, Dist>
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   state.add_element_count(num_keys);

--- a/benchmarks/static_multiset/retrieve_bench.cu
+++ b/benchmarks/static_multiset/retrieve_bench.cu
@@ -42,7 +42,7 @@ void static_multiset_retrieve(nvbench::state& state, nvbench::type_list<Key, Dis
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   gen.dropout(keys.begin(), keys.end(), matching_rate);

--- a/benchmarks/static_set/contains_bench.cu
+++ b/benchmarks/static_set/contains_bench.cu
@@ -41,7 +41,7 @@ void static_set_contains(nvbench::state& state, nvbench::type_list<Key, Dist>)
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   cuco::static_set<Key> set{size, cuco::empty_key<Key>{-1}};

--- a/benchmarks/static_set/find_bench.cu
+++ b/benchmarks/static_set/find_bench.cu
@@ -42,7 +42,7 @@ void static_set_find(nvbench::state& state, nvbench::type_list<Key, Dist>)
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   cuco::static_set<Key> set{size, cuco::empty_key<Key>{-1}};

--- a/benchmarks/static_set/insert_bench.cu
+++ b/benchmarks/static_set/insert_bench.cu
@@ -40,7 +40,7 @@ void static_set_insert(nvbench::state& state, nvbench::type_list<Key, Dist>)
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   state.add_element_count(num_keys);

--- a/benchmarks/static_set/rehash_bench.cu
+++ b/benchmarks/static_set/rehash_bench.cu
@@ -40,7 +40,7 @@ void static_set_rehash(nvbench::state& state, nvbench::type_list<Key, Dist>)
 
   thrust::device_vector<Key> keys(num_keys);  // slots per second
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   state.add_element_count(capacity);

--- a/benchmarks/static_set/retrieve_all_bench.cu
+++ b/benchmarks/static_set/retrieve_all_bench.cu
@@ -40,7 +40,7 @@ void static_set_retrieve_all(nvbench::state& state, nvbench::type_list<Key, Dist
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   cuco::static_set<Key> set{size, cuco::empty_key<Key>{-1}};

--- a/benchmarks/static_set/retrieve_bench.cu
+++ b/benchmarks/static_set/retrieve_bench.cu
@@ -42,7 +42,7 @@ void static_set_retrieve(nvbench::state& state, nvbench::type_list<Key, Dist>)
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   gen.dropout(keys.begin(), keys.end(), matching_rate);

--- a/benchmarks/static_set/size_bench.cu
+++ b/benchmarks/static_set/size_bench.cu
@@ -40,7 +40,7 @@ void static_set_size(nvbench::state& state, nvbench::type_list<Key, Dist>)
 
   thrust::device_vector<Key> keys(num_keys);
 
-  key_generator gen{};
+  [[maybe_unused]] key_generator gen{};
   gen.generate(dist_from_state<Dist>(state), keys.begin(), keys.end());
 
   state.add_element_count(num_keys);

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -25,7 +25,7 @@ function(ConfigureExample EXAMPLE_NAME EXAMPLE_SRC)
     target_include_directories(${EXAMPLE_NAME} PRIVATE
                                              "${CMAKE_CURRENT_SOURCE_DIR}")
     target_compile_options(${EXAMPLE_NAME} PRIVATE --compiler-options=-Wall --compiler-options=-Wextra
-      --compiler-options=-Werror -Wno-deprecated-gpu-targets --expt-extended-lambda)
+      --compiler-options=-Werror -Wno-deprecated-gpu-targets --expt-extended-lambda -Xcudafe --promote_warnings)
     # Add GCC-specific warning suppression only for GCC
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
       target_compile_options(${EXAMPLE_NAME} PRIVATE -Xcompiler -Wno-subobject-linkage)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -24,12 +24,7 @@ function(ConfigureExample EXAMPLE_NAME EXAMPLE_SRC)
                                           RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples")
     target_include_directories(${EXAMPLE_NAME} PRIVATE
                                              "${CMAKE_CURRENT_SOURCE_DIR}")
-    target_compile_options(${EXAMPLE_NAME} PRIVATE --compiler-options=-Wall --compiler-options=-Wextra
-      --compiler-options=-Werror -Wno-deprecated-gpu-targets --expt-extended-lambda -Xcudafe --promote_warnings)
-    # Add GCC-specific warning suppression only for GCC
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-      target_compile_options(${EXAMPLE_NAME} PRIVATE -Xcompiler -Wno-subobject-linkage)
-    endif()
+    cuco_set_common_compile_options(${EXAMPLE_NAME})
     target_link_libraries(${EXAMPLE_NAME} PRIVATE cuco CUDA::cudart)
 endfunction(ConfigureExample)
 

--- a/include/cuco/detail/bloom_filter/bloom_filter_impl.cuh
+++ b/include/cuco/detail/bloom_filter/bloom_filter_impl.cuh
@@ -34,6 +34,7 @@
 #include <cuda/std/tuple>
 #include <cuda/std/type_traits>
 #include <cuda/stream_ref>
+#include <cuda/utility>
 #include <thrust/iterator/constant_iterator.h>
 
 #include <cooperative_groups.h>
@@ -142,15 +143,14 @@ class bloom_filter_impl {
   template <class HashValue, class BlockIndex>
   __device__ void add_impl(HashValue const& hash_value, BlockIndex block_index)
   {
-#pragma unroll words_per_block
-    for (uint32_t i = 0; i < words_per_block; ++i) {
-      auto const word = policy_.word_pattern(hash_value, i);
+    cuda::static_for<words_per_block>([&](auto i) {
+      auto const word = policy_.word_pattern(hash_value, i());
       if (word != 0) {
         auto atom_word = cuda::atomic_ref<word_type, thread_scope>{
-          *(words_ + (block_index * words_per_block + i))};
+          *(words_ + (block_index * words_per_block + i()))};
         atom_word.fetch_or(word, cuda::memory_order_relaxed);
       }
-    }
+    });
   }
 
   template <class CG, class ProbeKey>
@@ -205,9 +205,11 @@ class bloom_filter_impl {
           block_index = policy_.block_index(hash_value, num_blocks_);
         }
 
-        for (uint32_t j = 0; (j < num_threads) and (i + j < num_keys); ++j) {
-          this->add_impl(group, group.shfl(hash_value, j), group.shfl(block_index, j));
-        }
+        cuda::static_for<num_threads>([&](auto j) {
+          if ((j() < num_threads) and (i + j() < num_keys)) {
+            this->add_impl(group, group.shfl(hash_value, j()), group.shfl(block_index, j()));
+          }
+        });
       }
     } else {  // subdivide given CG into multiple optimal CGs
       typename policy_type::hash_result_type hash_value;
@@ -225,10 +227,13 @@ class bloom_filter_impl {
           block_index = policy_.block_index(hash_value, num_blocks_);
         }
 
-        for (uint32_t j = 0; (j < worker_num_threads) and (i + worker_offset + j < num_keys); ++j) {
-          this->add_impl(
-            worker_group, worker_group.shfl(hash_value, j), worker_group.shfl(block_index, j));
-        }
+        cuda::static_for<worker_num_threads>([&](auto j) {
+          if ((j() < worker_num_threads) and (i + worker_offset + j() < num_keys)) {
+            this->add_impl(worker_group,
+                           worker_group.shfl(hash_value, j()),
+                           worker_group.shfl(block_index, j()));
+          }
+        });
       }
     }
   }
@@ -245,12 +250,13 @@ class bloom_filter_impl {
         *(words_ + (block_index * words_per_block + rank))};
       atom_word.fetch_or(policy_.word_pattern(hash_value, rank), cuda::memory_order_relaxed);
     } else {
-#pragma unroll
-      for (auto i = rank; i < words_per_block; i += num_threads) {
-        auto atom_word = cuda::atomic_ref<word_type, thread_scope>{
-          *(words_ + (block_index * words_per_block + i))};
-        atom_word.fetch_or(policy_.word_pattern(hash_value, i), cuda::memory_order_relaxed);
-      }
+      cuda::static_for<words_per_block>([&](auto i) {
+        if (i() >= rank && (i() - rank) % num_threads == 0) {
+          auto atom_word = cuda::atomic_ref<word_type, thread_scope>{
+            *(words_ + (block_index * words_per_block + i()))};
+          atom_word.fetch_or(policy_.word_pattern(hash_value, i()), cuda::memory_order_relaxed);
+        }
+      });
     }
   }
 
@@ -330,11 +336,12 @@ class bloom_filter_impl {
     auto const stored_pattern = this->vec_load_words<words_per_block>(
       policy_.block_index(hash_value, num_blocks_) * words_per_block);
 
-#pragma unroll words_per_block
-    for (uint32_t i = 0; i < words_per_block; ++i) {
-      auto const expected_pattern = policy_.word_pattern(hash_value, i);
-      if ((stored_pattern[i] & expected_pattern) != expected_pattern) { return false; }
-    }
+    bool result = true;
+    cuda::static_for<words_per_block>([&](auto i) {
+      auto const expected_pattern = policy_.word_pattern(hash_value, i());
+      if ((stored_pattern[i()] & expected_pattern) != expected_pattern) { result = false; }
+    });
+    if (!result) { return false; }
 
     return true;
   }
@@ -354,17 +361,17 @@ class bloom_filter_impl {
       auto const hash_value = policy_.hash(key);
       bool success          = true;
 
-#pragma unroll
-      for (uint32_t i = rank; i < optimal_num_threads; i += num_threads) {
-        auto const thread_offset  = i * words_per_thread;
-        auto const stored_pattern = this->vec_load_words<words_per_thread>(
-          policy_.block_index(hash_value, num_blocks_) * words_per_block + thread_offset);
-#pragma unroll words_per_thread
-        for (uint32_t j = 0; j < words_per_thread; ++j) {
-          auto const expected_pattern = policy_.word_pattern(hash_value, thread_offset + j);
-          if ((stored_pattern[j] & expected_pattern) != expected_pattern) { success = false; }
+      cuda::static_for<optimal_num_threads>([&](auto i) {
+        if (i() >= rank && (i() - rank) % num_threads == 0) {
+          auto const thread_offset  = i() * words_per_thread;
+          auto const stored_pattern = this->vec_load_words<words_per_thread>(
+            policy_.block_index(hash_value, num_blocks_) * words_per_block + thread_offset);
+          cuda::static_for<words_per_thread>([&](auto j) {
+            auto const expected_pattern = policy_.word_pattern(hash_value, thread_offset + j());
+            if ((stored_pattern[j()] & expected_pattern) != expected_pattern) { success = false; }
+          });
         }
-      }
+      });
 
       return group.all(success);
     }

--- a/include/cuco/detail/bloom_filter/bloom_filter_impl.cuh
+++ b/include/cuco/detail/bloom_filter/bloom_filter_impl.cuh
@@ -43,6 +43,204 @@
 
 namespace cuco::detail {
 
+/**
+ * @brief Device functor for adding a single key to the bloom filter
+ *
+ * This functor is used with cuda::static_for to iterate over all words in a filter block
+ * and set the appropriate bits for a given key's hash value. Each iteration processes
+ * one word in the block using atomic operations to ensure thread safety.
+ *
+ * @tparam HashValue Type of the hash value (typically uint64_t)
+ * @tparam BlockIndex Type of the block index (typically size_t or uint32_t)
+ * @tparam Policy Filter policy type that provides word pattern generation
+ * @tparam WordType Underlying word type of the filter (typically uint64_t)
+ * @tparam Scope CUDA thread scope for atomic operations
+ */
+template <typename HashValue,
+          typename BlockIndex,
+          typename Policy,
+          typename WordType,
+          cuda::thread_scope Scope>
+struct add_impl_functor {
+  HashValue hash_value;    ///< Hash value of the key being added
+  BlockIndex block_index;  ///< Index of the filter block to modify
+  Policy policy_;          ///< Filter policy for generating bit patterns
+  WordType* words_;        ///< Pointer to the filter's word array
+  size_t words_per_block;  ///< Number of words in each filter block
+
+  /**
+   * @brief Processes one word in the filter block for key insertion
+   *
+   * @tparam I Type of the integral constant passed by cuda::static_for
+   * @param i Integral constant representing the word index within the block
+   */
+  template <typename I>
+  __device__ void operator()(I i) const
+  {
+    auto const word = policy_.word_pattern(hash_value, i());
+    if (word != 0) {
+      auto atom_word =
+        cuda::atomic_ref<WordType, Scope>{*(words_ + (block_index * words_per_block + i()))};
+      atom_word.fetch_or(word, cuda::memory_order_relaxed);
+    }
+  }
+};
+
+/**
+ * @brief Device functor for cooperative group-based batch key insertion
+ *
+ * This functor is used with cuda::static_for to process multiple keys in parallel
+ * within a cooperative group. Each thread in the group processes a different key
+ * using shuffle operations to share hash values and block indices across threads.
+ *
+ * @tparam CG Cooperative group type (e.g., thread_block_tile)
+ * @tparam HashValue Type of the hash value
+ * @tparam BlockIndex Type of the block index
+ * @tparam BloomFilterImpl Type of the bloom filter implementation
+ */
+template <typename CG, typename HashValue, typename BlockIndex, typename BloomFilterImpl>
+struct add_group_functor {
+  CG group;                ///< Cooperative group for parallel processing
+  HashValue hash_value;    ///< Hash value of the current thread's key
+  BlockIndex block_index;  ///< Block index of the current thread's key
+  size_t i;                ///< Starting index in the key batch
+  size_t num_keys;         ///< Total number of keys to process
+  size_t num_threads;      ///< Number of threads in the group
+  BloomFilterImpl* self;   ///< Pointer to the bloom filter implementation
+
+  /**
+   * @brief Processes one thread's key in the cooperative group batch insertion
+   *
+   * @tparam J Type of the integral constant passed by cuda::static_for
+   * @param j Integral constant representing the thread index within the group
+   */
+  template <typename J>
+  __device__ void operator()(J j) const
+  {
+    if ((j() < num_threads) and (i + j() < num_keys)) {
+      self->add_impl(group, group.shfl(hash_value, j()), group.shfl(block_index, j()));
+    }
+  }
+};
+
+/**
+ * @brief Device functor for worker group-based batch key insertion
+ *
+ * This functor is used with cuda::static_for to process multiple keys in parallel
+ * within a worker group (subdivision of a larger cooperative group). Similar to
+ * add_group_functor but operates on a smaller worker group with offset handling
+ * for processing different portions of the key batch.
+ *
+ * @tparam WorkerGroup Worker group type (subdivision of cooperative group)
+ * @tparam HashValue Type of the hash value
+ * @tparam BlockIndex Type of the block index
+ * @tparam BloomFilterImpl Type of the bloom filter implementation
+ */
+template <typename WorkerGroup, typename HashValue, typename BlockIndex, typename BloomFilterImpl>
+struct add_worker_group_functor {
+  WorkerGroup worker_group;   ///< Worker group (subdivision of cooperative group)
+  HashValue hash_value;       ///< Hash value of the current thread's key
+  BlockIndex block_index;     ///< Block index of the current thread's key
+  size_t i;                   ///< Starting index in the key batch
+  size_t worker_offset;       ///< Offset for this worker group within the batch
+  size_t num_keys;            ///< Total number of keys to process
+  size_t worker_num_threads;  ///< Number of threads in the worker group
+  BloomFilterImpl* self;      ///< Pointer to the bloom filter implementation
+
+  /**
+   * @brief Processes one thread's key in the worker group batch insertion
+   *
+   * @tparam J Type of the integral constant passed by cuda::static_for
+   * @param j Integral constant representing the thread index within the worker group
+   */
+  template <typename J>
+  __device__ void operator()(J j) const
+  {
+    if ((j() < worker_num_threads) and (i + worker_offset + j() < num_keys)) {
+      self->add_impl(
+        worker_group, worker_group.shfl(hash_value, j()), worker_group.shfl(block_index, j()));
+    }
+  }
+};
+
+/**
+ * @brief Device functor for cooperative group-based single key insertion
+ *
+ * This functor is used with cuda::static_for to add a single key to the bloom filter
+ * using a cooperative group. Each thread in the group processes different words in
+ * the filter block based on thread rank and stride pattern. Used when the group size
+ * doesn't match the number of words per block.
+ *
+ * @tparam HashValue Type of the hash value
+ * @tparam BlockIndex Type of the block index
+ * @tparam WordType Underlying word type of the filter
+ * @tparam Scope CUDA thread scope for atomic operations
+ * @tparam Policy Filter policy type that provides word pattern generation
+ */
+template <typename HashValue,
+          typename BlockIndex,
+          typename WordType,
+          cuda::thread_scope Scope,
+          typename Policy>
+struct add_impl_group_functor {
+  HashValue hash_value;    ///< Hash value of the key being added
+  BlockIndex block_index;  ///< Index of the filter block to modify
+  WordType* words_;        ///< Pointer to the filter's word array
+  size_t words_per_block;  ///< Number of words in each filter block
+  size_t rank;             ///< Thread rank within the cooperative group
+  size_t num_threads;      ///< Number of threads in the cooperative group
+  Policy policy_;          ///< Filter policy for generating bit patterns
+
+  /**
+   * @brief Processes one word in the filter block using cooperative group stride pattern
+   *
+   * @tparam I Type of the integral constant passed by cuda::static_for
+   * @param i Integral constant representing the word index within the block
+   */
+  template <typename I>
+  __device__ void operator()(I i) const
+  {
+    if (i() >= rank && (i() - rank) % num_threads == 0) {
+      auto atom_word =
+        cuda::atomic_ref<WordType, Scope>{*(words_ + (block_index * words_per_block + i()))};
+      atom_word.fetch_or(policy_.word_pattern(hash_value, i()), cuda::memory_order_relaxed);
+    }
+  }
+};
+
+/**
+ * @brief Device functor for checking if a key exists in the bloom filter
+ *
+ * This functor is used with cuda::static_for to iterate over all words in a filter block
+ * and check if the expected bit patterns for a given key's hash value are present.
+ * If any expected bit is missing, the result is set to false, indicating the key
+ * is definitely not in the set.
+ *
+ * @tparam HashValue Type of the hash value
+ * @tparam StoredPattern Type of the stored pattern array (typically array of WordType)
+ * @tparam Policy Filter policy type that provides word pattern generation
+ */
+template <typename HashValue, typename StoredPattern, typename Policy>
+struct contains_functor {
+  HashValue hash_value;          ///< Hash value of the key being queried
+  StoredPattern stored_pattern;  ///< Array of stored bit patterns from the filter block
+  Policy policy_;                ///< Filter policy for generating expected bit patterns
+  bool* result;                  ///< Pointer to result flag (set to false if key not found)
+
+  /**
+   * @brief Checks one word in the filter block for the expected bit pattern
+   *
+   * @tparam I Type of the integral constant passed by cuda::static_for
+   * @param i Integral constant representing the word index within the block
+   */
+  template <typename I>
+  __device__ void operator()(I i) const
+  {
+    auto const expected_pattern = policy_.word_pattern(hash_value, i());
+    if ((stored_pattern[i()] & expected_pattern) != expected_pattern) { *result = false; }
+  }
+};
+
 template <class Key, class Extent, cuda::thread_scope Scope, class Policy>
 class bloom_filter_impl {
  public:
@@ -143,14 +341,9 @@ class bloom_filter_impl {
   template <class HashValue, class BlockIndex>
   __device__ void add_impl(HashValue const& hash_value, BlockIndex block_index)
   {
-    cuda::static_for<words_per_block>([&](auto i) {
-      auto const word = policy_.word_pattern(hash_value, i());
-      if (word != 0) {
-        auto atom_word = cuda::atomic_ref<word_type, thread_scope>{
-          *(words_ + (block_index * words_per_block + i()))};
-        atom_word.fetch_or(word, cuda::memory_order_relaxed);
-      }
-    });
+    add_impl_functor<HashValue, BlockIndex, policy_type, word_type, thread_scope> functor{
+      hash_value, block_index, policy_, words_, words_per_block};
+    cuda::static_for<words_per_block>(functor);
   }
 
   template <class CG, class ProbeKey>
@@ -205,11 +398,15 @@ class bloom_filter_impl {
           block_index = policy_.block_index(hash_value, num_blocks_);
         }
 
-        cuda::static_for<num_threads>([&](auto j) {
-          if ((j() < num_threads) and (i + j() < num_keys)) {
-            this->add_impl(group, group.shfl(hash_value, j()), group.shfl(block_index, j()));
-          }
-        });
+        add_group_functor<CG, decltype(hash_value), decltype(block_index), bloom_filter_impl>
+          functor{group,
+                  hash_value,
+                  block_index,
+                  static_cast<size_t>(i),
+                  static_cast<size_t>(num_keys),
+                  static_cast<size_t>(num_threads),
+                  this};
+        cuda::static_for<num_threads>(functor);
       }
     } else {  // subdivide given CG into multiple optimal CGs
       typename policy_type::hash_result_type hash_value;
@@ -227,13 +424,19 @@ class bloom_filter_impl {
           block_index = policy_.block_index(hash_value, num_blocks_);
         }
 
-        cuda::static_for<worker_num_threads>([&](auto j) {
-          if ((j() < worker_num_threads) and (i + worker_offset + j() < num_keys)) {
-            this->add_impl(worker_group,
-                           worker_group.shfl(hash_value, j()),
-                           worker_group.shfl(block_index, j()));
-          }
-        });
+        add_worker_group_functor<decltype(worker_group),
+                                 decltype(hash_value),
+                                 decltype(block_index),
+                                 bloom_filter_impl>
+          functor{worker_group,
+                  hash_value,
+                  block_index,
+                  static_cast<size_t>(i),
+                  static_cast<size_t>(worker_offset),
+                  static_cast<size_t>(num_keys),
+                  static_cast<size_t>(worker_num_threads),
+                  this};
+        cuda::static_for<worker_num_threads>(functor);
       }
     }
   }
@@ -250,13 +453,9 @@ class bloom_filter_impl {
         *(words_ + (block_index * words_per_block + rank))};
       atom_word.fetch_or(policy_.word_pattern(hash_value, rank), cuda::memory_order_relaxed);
     } else {
-      cuda::static_for<words_per_block>([&](auto i) {
-        if (i() >= rank && (i() - rank) % num_threads == 0) {
-          auto atom_word = cuda::atomic_ref<word_type, thread_scope>{
-            *(words_ + (block_index * words_per_block + i()))};
-          atom_word.fetch_or(policy_.word_pattern(hash_value, i()), cuda::memory_order_relaxed);
-        }
-      });
+      add_impl_group_functor<HashValue, BlockIndex, word_type, thread_scope, policy_type> functor{
+        hash_value, block_index, words_, words_per_block, rank, num_threads, policy_};
+      cuda::static_for<words_per_block>(functor);
     }
   }
 
@@ -337,10 +536,9 @@ class bloom_filter_impl {
       policy_.block_index(hash_value, num_blocks_) * words_per_block);
 
     bool result = true;
-    cuda::static_for<words_per_block>([&](auto i) {
-      auto const expected_pattern = policy_.word_pattern(hash_value, i());
-      if ((stored_pattern[i()] & expected_pattern) != expected_pattern) { result = false; }
-    });
+    contains_functor<decltype(hash_value), decltype(stored_pattern), policy_type> functor{
+      hash_value, stored_pattern, policy_, &result};
+    cuda::static_for<words_per_block>(functor);
     if (!result) { return false; }
 
     return true;
@@ -361,17 +559,21 @@ class bloom_filter_impl {
       auto const hash_value = policy_.hash(key);
       bool success          = true;
 
-      cuda::static_for<optimal_num_threads>([&](auto i) {
-        if (i() >= rank && (i() - rank) % num_threads == 0) {
-          auto const thread_offset  = i() * words_per_thread;
+// Use pragma unroll instead of cuda::static_for to avoid CUDA 12.0 compatibility issues
+#pragma unroll
+      for (size_type i = 0; i < optimal_num_threads; ++i) {
+        if (i >= rank && (i - rank) % num_threads == 0) {
+          auto const thread_offset  = i * words_per_thread;
           auto const stored_pattern = this->vec_load_words<words_per_thread>(
             policy_.block_index(hash_value, num_blocks_) * words_per_block + thread_offset);
-          cuda::static_for<words_per_thread>([&](auto j) {
-            auto const expected_pattern = policy_.word_pattern(hash_value, thread_offset + j());
-            if ((stored_pattern[j()] & expected_pattern) != expected_pattern) { success = false; }
-          });
+
+#pragma unroll
+          for (size_type j = 0; j < words_per_thread; ++j) {
+            auto const expected_pattern = policy_.word_pattern(hash_value, thread_offset + j);
+            if ((stored_pattern[j] & expected_pattern) != expected_pattern) { success = false; }
+          }
         }
-      });
+      }
 
       return group.all(success);
     }

--- a/include/cuco/detail/hyperloglog/kernels.cuh
+++ b/include/cuco/detail/hyperloglog/kernels.cuh
@@ -72,14 +72,14 @@ CUCO_KERNEL void add_shmem_vectorized(typename RefType::value_type const* first,
 #if defined(CUCO_HAS_CG_INVOKE_ONE)
   cooperative_groups::invoke_one(grid, [&]() {
     auto const remainder = n % VectorSize;
-    cuda::static_for<VectorSize>([&](auto i) {
+    cuda::static_for<VectorSize>([&] __device__(auto i) {
       if (i() < remainder) { local_ref.add(*(first + n - i() - 1)); }
     });
   });
 #else
   if (grid.thread_rank() == 0) {
     auto const remainder = n % VectorSize;
-    cuda::static_for<VectorSize>([&](auto i) {
+    cuda::static_for<VectorSize>([&] __device__(auto i) {
       if (i() < remainder) { local_ref.add(*(first + n - i() - 1)); }
     });
   }

--- a/include/cuco/detail/hyperloglog/kernels.cuh
+++ b/include/cuco/detail/hyperloglog/kernels.cuh
@@ -20,6 +20,7 @@
 
 #include <cuda/std/array>
 #include <cuda/std/span>
+#include <cuda/utility>
 
 #include <cooperative_groups.h>
 
@@ -71,16 +72,16 @@ CUCO_KERNEL void add_shmem_vectorized(typename RefType::value_type const* first,
 #if defined(CUCO_HAS_CG_INVOKE_ONE)
   cooperative_groups::invoke_one(grid, [&]() {
     auto const remainder = n % VectorSize;
-    for (int i = 0; i < remainder; ++i) {
-      local_ref.add(*(first + n - i - 1));
-    }
+    cuda::static_for<VectorSize>([&](auto i) {
+      if (i() < remainder) { local_ref.add(*(first + n - i() - 1)); }
+    });
   });
 #else
   if (grid.thread_rank() == 0) {
     auto const remainder = n % VectorSize;
-    for (int i = 0; i < remainder; ++i) {
-      local_ref.add(*(first + n - i - 1));
-    }
+    cuda::static_for<VectorSize>([&](auto i) {
+      if (i() < remainder) { local_ref.add(*(first + n - i() - 1)); }
+    });
   }
 #endif
   block.sync();

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -28,6 +28,7 @@
 #include <cuda/std/functional>
 #include <cuda/std/iterator>
 #include <cuda/std/type_traits>
+#include <cuda/utility>
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/logical.h>
@@ -441,23 +442,25 @@ class open_addressing_ref_impl {
       auto const bucket_slots = storage_ref_[*probing_iter];
 
       auto const [state, intra_bucket_index] = [&]() {
-        for (auto i = 0; i < bucket_size; ++i) {
-          switch (this->predicate_.template operator()<is_insert::YES>(
-            key, this->extract_key(bucket_slots[i]))) {
-            case detail::equal_result::AVAILABLE:
-              return bucket_probing_results{detail::equal_result::AVAILABLE, i};
-            case detail::equal_result::EQUAL: {
-              if constexpr (allows_duplicates) {
-                continue;
-              } else {
-                return bucket_probing_results{detail::equal_result::EQUAL, i};
+        bucket_probing_results result{detail::equal_result::UNEQUAL, -1};
+        cuda::static_for<bucket_size>([&](auto i) {
+          if (result.state_ == detail::equal_result::UNEQUAL) {
+            switch (this->predicate_.template operator()<is_insert::YES>(
+              key, this->extract_key(bucket_slots[i()]))) {
+              case detail::equal_result::AVAILABLE:
+                result = bucket_probing_results{detail::equal_result::AVAILABLE, i()};
+                break;
+              case detail::equal_result::EQUAL: {
+                if constexpr (!allows_duplicates) {
+                  result = bucket_probing_results{detail::equal_result::EQUAL, i()};
+                }
+                break;
               }
+              default: break;
             }
-            default: continue;
           }
-        }
-        // returns dummy index `-1` for UNEQUAL
-        return bucket_probing_results{detail::equal_result::UNEQUAL, -1};
+        });
+        return result;
       }();
 
       if constexpr (not allows_duplicates) {
@@ -610,14 +613,15 @@ class open_addressing_ref_impl {
       auto const bucket_slots = storage_ref_[*probing_iter];
 
       auto const [state, intra_bucket_index] = [&]() {
-        auto res = detail::equal_result::UNEQUAL;
-        for (auto i = 0; i < bucket_size; ++i) {
-          res = this->predicate_.template operator()<is_insert::YES>(
-            key, this->extract_key(bucket_slots[i]));
-          if (res != detail::equal_result::UNEQUAL) { return bucket_probing_results{res, i}; }
-        }
-        // returns dummy index `-1` for UNEQUAL
-        return bucket_probing_results{res, -1};
+        bucket_probing_results result{detail::equal_result::UNEQUAL, -1};
+        cuda::static_for<bucket_size>([&](auto i) {
+          if (result.state_ == detail::equal_result::UNEQUAL) {
+            auto res = this->predicate_.template operator()<is_insert::YES>(
+              key, this->extract_key(bucket_slots[i()]));
+            if (res != detail::equal_result::UNEQUAL) { result = bucket_probing_results{res, i()}; }
+          }
+        });
+        return result;
       }();
 
       auto* slot_ptr = this->get_slot_ptr(*probing_iter, intra_bucket_index);
@@ -743,14 +747,15 @@ class open_addressing_ref_impl {
       auto const bucket_slots = storage_ref_[*probing_iter];
 
       auto const [state, intra_bucket_index] = [&]() {
-        auto res = detail::equal_result::UNEQUAL;
-        for (auto i = 0; i < bucket_size; ++i) {
-          res = this->predicate_.template operator()<is_insert::NO>(
-            key, this->extract_key(bucket_slots[i]));
-          if (res != detail::equal_result::UNEQUAL) { return bucket_probing_results{res, i}; }
-        }
-        // returns dummy index `-1` for UNEQUAL
-        return bucket_probing_results{res, -1};
+        bucket_probing_results result{detail::equal_result::UNEQUAL, -1};
+        cuda::static_for<bucket_size>([&](auto i) {
+          if (result.state_ == detail::equal_result::UNEQUAL) {
+            auto res = this->predicate_.template operator()<is_insert::NO>(
+              key, this->extract_key(bucket_slots[i()]));
+            if (res != detail::equal_result::UNEQUAL) { result = bucket_probing_results{res, i()}; }
+          }
+        });
+        return result;
       }();
 
       auto const group_contains_equal = group.ballot(state == detail::equal_result::EQUAL);
@@ -925,14 +930,15 @@ class open_addressing_ref_impl {
       auto const bucket_slots = storage_ref_[*probing_iter];
 
       auto const [state, intra_bucket_index] = [&]() {
-        auto res = detail::equal_result::UNEQUAL;
-        for (auto i = 0; i < bucket_size; ++i) {
-          res = this->predicate_.template operator()<is_insert::NO>(
-            key, this->extract_key(bucket_slots[i]));
-          if (res != detail::equal_result::UNEQUAL) { return bucket_probing_results{res, i}; }
-        }
-        // returns dummy index `-1` for UNEQUAL
-        return bucket_probing_results{res, -1};
+        bucket_probing_results result{detail::equal_result::UNEQUAL, -1};
+        cuda::static_for<bucket_size>([&](auto i) {
+          if (result.state_ == detail::equal_result::UNEQUAL) {
+            auto res = this->predicate_.template operator()<is_insert::NO>(
+              key, this->extract_key(bucket_slots[i()]));
+            if (res != detail::equal_result::UNEQUAL) { result = bucket_probing_results{res, i()}; }
+          }
+        });
+        return result;
       }();
 
       // Find a match for the probe key, thus return an iterator to the entry
@@ -978,16 +984,12 @@ class open_addressing_ref_impl {
         cuda::std::int32_t equals[bucket_size] = {0};
         bool empty_found                       = false;
 
-#pragma unroll bucket_size
-        for (cuda::std::int32_t i = 0; i < bucket_size; ++i) {
-          auto const result =
-            predicate_.template operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i]));
-          equals[i] = (result == detail::equal_result::EQUAL);
-          if (result == detail::equal_result::EMPTY) {
-            empty_found = true;
-            break;
-          }
-        }
+        cuda::static_for<bucket_size>([&](auto i) {
+          auto const result = predicate_.template operator()<is_insert::NO>(
+            key, this->extract_key(bucket_slots[i()]));
+          equals[i()] = (result == detail::equal_result::EQUAL);
+          if (result == detail::equal_result::EMPTY) { empty_found = true; }
+        });
 
         count += thrust::reduce(thrust::seq, equals, equals + bucket_size);
 
@@ -1024,16 +1026,12 @@ class open_addressing_ref_impl {
       cuda::std::int32_t equals[bucket_size] = {0};
       bool empty_found                       = false;
 
-#pragma unroll bucket_size
-      for (cuda::std::int32_t i = 0; i < bucket_size; ++i) {
+      cuda::static_for<bucket_size>([&](auto i) {
         auto const result =
-          predicate_.template operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i]));
-        equals[i] = (result == detail::equal_result::EQUAL);
-        if (result == detail::equal_result::EMPTY) {
-          empty_found = true;
-          break;
-        }
-      }
+          predicate_.template operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i()]));
+        equals[i()] = (result == detail::equal_result::EQUAL);
+        if (result == detail::equal_result::EMPTY) { empty_found = true; }
+      });
 
       count += thrust::reduce(thrust::seq, equals, equals + bucket_size);
 
@@ -1337,20 +1335,19 @@ class open_addressing_ref_impl {
             // TODO atomic_ref::load if insert operator is present
             auto const bucket_slots = this->storage_ref_[*probing_iter];
 
-#pragma unroll bucket_size
-            for (cuda::std::int32_t i = 0; i < bucket_size; ++i) {
-              equals[i] = false;
+            cuda::static_for<bucket_size>([&](auto i) {
+              equals[i()] = false;
               if (running) {
                 // inspect slot content
                 switch (this->predicate_.template operator()<is_insert::NO>(
-                  probe_key, this->extract_key(bucket_slots[i]))) {
+                  probe_key, this->extract_key(bucket_slots[i()]))) {
                   case detail::equal_result::EMPTY: {
                     running = false;
                     break;
                   }
                   case detail::equal_result::EQUAL: {
                     if constexpr (!AllowsDuplicates) { running = false; }
-                    equals[i] = true;
+                    equals[i()] = true;
                     break;
                   }
                   default: {
@@ -1358,14 +1355,12 @@ class open_addressing_ref_impl {
                   }
                 }
               }
-            }
+            });
 
             probing_tile.sync();
             running = probing_tile.all(running);
-#pragma unroll bucket_size
-            for (cuda::std::int32_t i = 0; i < bucket_size; ++i) {
-              exists[i] = probing_tile.ballot(equals[i]);
-            }
+            cuda::static_for<bucket_size>(
+              [&](auto i) { exists[i()] = probing_tile.ballot(equals[i()]); });
 
             // Fill the buffer if any matching keys are found
             auto const lane_id = probing_tile.thread_rank();
@@ -1374,9 +1369,8 @@ class open_addressing_ref_impl {
 
               cuda::std::int32_t num_matches[bucket_size];
 
-              for (cuda::std::int32_t i = 0; i < bucket_size; ++i) {
-                num_matches[i] = __popc(exists[i]);
-              }
+              cuda::static_for<bucket_size>(
+                [&](auto i) { num_matches[i()] = __popc(exists[i()]); });
 
               cuda::std::int32_t output_idx;
               if (lane_id == 0) {
@@ -1389,15 +1383,15 @@ class open_addressing_ref_impl {
               output_idx = probing_tile.shfl(output_idx, 0);
 
               cuda::std::int32_t matches_offset = 0;
-#pragma unroll bucket_size
-              for (cuda::std::int32_t i = 0; i < bucket_size; ++i) {
-                if (equals[i]) {
-                  auto const lane_offset = detail::count_least_significant_bits(exists[i], lane_id);
+              cuda::static_for<bucket_size>([&](auto i) {
+                if (equals[i()]) {
+                  auto const lane_offset =
+                    detail::count_least_significant_bits(exists[i()], lane_id);
                   buffers[flushing_tile_id][output_idx + matches_offset + lane_offset] = {
-                    probe_key, bucket_slots[i]};
+                    probe_key, bucket_slots[i()]};
                 }
-                matches_offset += num_matches[i];
-              }
+                matches_offset += num_matches[i()];
+              });
             }
             // Special handling for outer cases where no match is found
             if constexpr (IsOuter) {
@@ -1462,19 +1456,24 @@ class open_addressing_ref_impl {
       // TODO atomic_ref::load if insert operator is present
       auto const bucket_slots = this->storage_ref_[*probing_iter];
 
-      for (cuda::std::int32_t i = 0; i < bucket_size; ++i) {
-        switch (this->predicate_.template operator()<is_insert::NO>(
-          key, this->extract_key(bucket_slots[i]))) {
-          case detail::equal_result::EMPTY: {
-            return;
+      bool should_return = false;
+      cuda::static_for<bucket_size>([&](auto i) {
+        if (!should_return) {
+          switch (this->predicate_.template operator()<is_insert::NO>(
+            key, this->extract_key(bucket_slots[i()]))) {
+            case detail::equal_result::EMPTY: {
+              should_return = true;
+              break;
+            }
+            case detail::equal_result::EQUAL: {
+              callback_op(bucket_slots[i()]);
+              break;
+            }
+            default: break;
           }
-          case detail::equal_result::EQUAL: {
-            callback_op(bucket_slots[i]);
-            continue;
-          }
-          default: continue;
         }
-      }
+      });
+      if (should_return) { return; }
       ++probing_iter;
       if (*probing_iter == init_idx) { return; }
     }

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -443,7 +443,7 @@ class open_addressing_ref_impl {
 
       auto const [state, intra_bucket_index] = [&]() {
         bucket_probing_results result{detail::equal_result::UNEQUAL, -1};
-        cuda::static_for<bucket_size>([&](auto i) {
+        cuda::static_for<bucket_size>([&] __device__(auto i) {
           if (result.state_ == detail::equal_result::UNEQUAL) {
             switch (this->predicate_.template operator()<is_insert::YES>(
               key, this->extract_key(bucket_slots[i()]))) {
@@ -614,7 +614,7 @@ class open_addressing_ref_impl {
 
       auto const [state, intra_bucket_index] = [&]() {
         bucket_probing_results result{detail::equal_result::UNEQUAL, -1};
-        cuda::static_for<bucket_size>([&](auto i) {
+        cuda::static_for<bucket_size>([&] __device__(auto i) {
           if (result.state_ == detail::equal_result::UNEQUAL) {
             auto res = this->predicate_.template operator()<is_insert::YES>(
               key, this->extract_key(bucket_slots[i()]));
@@ -748,7 +748,7 @@ class open_addressing_ref_impl {
 
       auto const [state, intra_bucket_index] = [&]() {
         bucket_probing_results result{detail::equal_result::UNEQUAL, -1};
-        cuda::static_for<bucket_size>([&](auto i) {
+        cuda::static_for<bucket_size>([&] __device__(auto i) {
           if (result.state_ == detail::equal_result::UNEQUAL) {
             auto res = this->predicate_.template operator()<is_insert::NO>(
               key, this->extract_key(bucket_slots[i()]));
@@ -931,7 +931,7 @@ class open_addressing_ref_impl {
 
       auto const [state, intra_bucket_index] = [&]() {
         bucket_probing_results result{detail::equal_result::UNEQUAL, -1};
-        cuda::static_for<bucket_size>([&](auto i) {
+        cuda::static_for<bucket_size>([&] __device__(auto i) {
           if (result.state_ == detail::equal_result::UNEQUAL) {
             auto res = this->predicate_.template operator()<is_insert::NO>(
               key, this->extract_key(bucket_slots[i()]));
@@ -984,7 +984,7 @@ class open_addressing_ref_impl {
         cuda::std::int32_t equals[bucket_size] = {0};
         bool empty_found                       = false;
 
-        cuda::static_for<bucket_size>([&](auto i) {
+        cuda::static_for<bucket_size>([&] __device__(auto i) {
           auto const result = predicate_.template operator()<is_insert::NO>(
             key, this->extract_key(bucket_slots[i()]));
           equals[i()] = (result == detail::equal_result::EQUAL);
@@ -1026,7 +1026,7 @@ class open_addressing_ref_impl {
       cuda::std::int32_t equals[bucket_size] = {0};
       bool empty_found                       = false;
 
-      cuda::static_for<bucket_size>([&](auto i) {
+      cuda::static_for<bucket_size>([&] __device__(auto i) {
         auto const result =
           predicate_.template operator()<is_insert::NO>(key, this->extract_key(bucket_slots[i()]));
         equals[i()] = (result == detail::equal_result::EQUAL);
@@ -1335,7 +1335,7 @@ class open_addressing_ref_impl {
             // TODO atomic_ref::load if insert operator is present
             auto const bucket_slots = this->storage_ref_[*probing_iter];
 
-            cuda::static_for<bucket_size>([&](auto i) {
+            cuda::static_for<bucket_size>([&] __device__(auto i) {
               equals[i()] = false;
               if (running) {
                 // inspect slot content
@@ -1383,7 +1383,7 @@ class open_addressing_ref_impl {
               output_idx = probing_tile.shfl(output_idx, 0);
 
               cuda::std::int32_t matches_offset = 0;
-              cuda::static_for<bucket_size>([&](auto i) {
+              cuda::static_for<bucket_size>([&] __device__(auto i) {
                 if (equals[i()]) {
                   auto const lane_offset =
                     detail::count_least_significant_bits(exists[i()], lane_id);
@@ -1457,7 +1457,7 @@ class open_addressing_ref_impl {
       auto const bucket_slots = this->storage_ref_[*probing_iter];
 
       bool should_return = false;
-      cuda::static_for<bucket_size>([&](auto i) {
+      cuda::static_for<bucket_size>([&] __device__(auto i) {
         if (!should_return) {
           switch (this->predicate_.template operator()<is_insert::NO>(
             key, this->extract_key(bucket_slots[i()]))) {

--- a/include/cuco/detail/roaring_bitmap/roaring_bitmap_impl.cuh
+++ b/include/cuco/detail/roaring_bitmap/roaring_bitmap_impl.cuh
@@ -27,6 +27,7 @@
 #include <cuda/std/functional>
 #include <cuda/std/iterator>
 #include <cuda/stream_ref>
+#include <cuda/utility>
 #include <thrust/iterator/constant_iterator.h>
 
 namespace cuco::experimental::detail {

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -578,7 +578,7 @@ class operator_impl<
 
       auto const [state, intra_bucket_index] = [&]() {
         detail::bucket_probing_results result{detail::equal_result::UNEQUAL, -1};
-        cuda::static_for<bucket_size>([&](auto i) {
+        cuda::static_for<bucket_size>([&] __device__(auto i) {
           if (result.state_ == detail::equal_result::UNEQUAL) {
             auto res = ref_.impl_.predicate_.template operator()<is_insert::YES>(
               key, bucket_slots[i()].first);
@@ -981,7 +981,7 @@ class operator_impl<
 
       auto const [state, intra_bucket_index] = [&]() {
         detail::bucket_probing_results result{detail::equal_result::UNEQUAL, -1};
-        cuda::static_for<bucket_size>([&](auto i) {
+        cuda::static_for<bucket_size>([&] __device__(auto i) {
           if (result.state_ == detail::equal_result::UNEQUAL) {
             auto res = ref_.impl_.predicate_.template operator()<is_insert::YES>(
               key, bucket_slots[i()].first);

--- a/include/cuco/detail/static_map/static_map_ref.inl
+++ b/include/cuco/detail/static_map/static_map_ref.inl
@@ -24,6 +24,7 @@
 #include <cuda/std/iterator>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
+#include <cuda/utility>
 
 #include <cooperative_groups.h>
 
@@ -576,16 +577,17 @@ class operator_impl<
       auto const bucket_slots = storage_ref[*probing_iter];
 
       auto const [state, intra_bucket_index] = [&]() {
-        auto res = detail::equal_result::UNEQUAL;
-        for (auto i = 0; i < bucket_size; ++i) {
-          res =
-            ref_.impl_.predicate_.template operator()<is_insert::YES>(key, bucket_slots[i].first);
-          if (res != detail::equal_result::UNEQUAL) {
-            return detail::bucket_probing_results{res, i};
+        detail::bucket_probing_results result{detail::equal_result::UNEQUAL, -1};
+        cuda::static_for<bucket_size>([&](auto i) {
+          if (result.state_ == detail::equal_result::UNEQUAL) {
+            auto res = ref_.impl_.predicate_.template operator()<is_insert::YES>(
+              key, bucket_slots[i()].first);
+            if (res != detail::equal_result::UNEQUAL) {
+              result = detail::bucket_probing_results{res, i()};
+            }
           }
-        }
-        // returns dummy index `-1` for UNEQUAL
-        return detail::bucket_probing_results{res, -1};
+        });
+        return result;
       }();
 
       auto slot_ptr = ref_.impl_.get_slot_ptr(*probing_iter, intra_bucket_index);
@@ -978,16 +980,17 @@ class operator_impl<
       auto const bucket_slots = storage_ref[*probing_iter];
 
       auto const [state, intra_bucket_index] = [&]() {
-        auto res = detail::equal_result::UNEQUAL;
-        for (auto i = 0; i < bucket_size; ++i) {
-          res =
-            ref_.impl_.predicate_.template operator()<is_insert::YES>(key, bucket_slots[i].first);
-          if (res != detail::equal_result::UNEQUAL) {
-            return detail::bucket_probing_results{res, i};
+        detail::bucket_probing_results result{detail::equal_result::UNEQUAL, -1};
+        cuda::static_for<bucket_size>([&](auto i) {
+          if (result.state_ == detail::equal_result::UNEQUAL) {
+            auto res = ref_.impl_.predicate_.template operator()<is_insert::YES>(
+              key, bucket_slots[i()].first);
+            if (res != detail::equal_result::UNEQUAL) {
+              result = detail::bucket_probing_results{res, i()};
+            }
           }
-        }
-        // returns dummy index `-1` for UNEQUAL
-        return detail::bucket_probing_results{res, -1};
+        });
+        return result;
       }();
 
       auto* slot_ptr = ref_.impl_.get_slot_ptr(*probing_iter, intra_bucket_index);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,7 +39,7 @@ function(ConfigureTest TEST_NAME)
     set_target_properties(${TEST_NAME} PROPERTIES
                                        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests")
     target_compile_options(${TEST_NAME} PRIVATE --compiler-options=-Wall --compiler-options=-Wextra
-      --compiler-options=-Werror -Wno-deprecated-gpu-targets --expt-extended-lambda)
+      --compiler-options=-Werror -Wno-deprecated-gpu-targets --expt-extended-lambda -Xcudafe --promote_warnings)
     # Add GCC-specific warning suppression only for GCC
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
       target_compile_options(${TEST_NAME} PRIVATE -Xcompiler -Wno-subobject-linkage)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,12 +38,7 @@ function(ConfigureTest TEST_NAME)
     target_include_directories(${TEST_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
     set_target_properties(${TEST_NAME} PROPERTIES
                                        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests")
-    target_compile_options(${TEST_NAME} PRIVATE --compiler-options=-Wall --compiler-options=-Wextra
-      --compiler-options=-Werror -Wno-deprecated-gpu-targets --expt-extended-lambda -Xcudafe --promote_warnings)
-    # Add GCC-specific warning suppression only for GCC
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-      target_compile_options(${TEST_NAME} PRIVATE -Xcompiler -Wno-subobject-linkage)
-    endif()
+    cuco_set_common_compile_options(${TEST_NAME})
     catch_discover_tests(${TEST_NAME} EXTRA_ARGS --allow-running-no-tests)
 endfunction(ConfigureTest)
 


### PR DESCRIPTION
Closes #770

This PR replaces naive for loops with `cuda::static_for` in cases where the loop size is known at compile time, enabling guaranteed compile-time unrolling and improving runtime performance. It also updates CMake to treat device compiler warnings as errors and addresses warnings for variables like `gen` being declared but unused, which appears to be a compiler bug in CUDA 12.0.