### PR TITLE
Add Hyperloglog add_if_async host API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
 set(rapids-cmake-version 25.12)
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/CUCO_RAPIDS.cmake)
     file(DOWNLOAD
-      https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-${rapids-cmake-version}/RAPIDS.cmake
+      https://raw.githubusercontent.com/rapidsai/rapids-cmake/release/${rapids-cmake-version}/RAPIDS.cmake
          ${CMAKE_CURRENT_BINARY_DIR}/CUCO_RAPIDS.cmake)
 endif()
 include(${CMAKE_CURRENT_BINARY_DIR}/CUCO_RAPIDS.cmake)

--- a/include/cuco/detail/hyperloglog/hyperloglog.inl
+++ b/include/cuco/detail/hyperloglog/hyperloglog.inl
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,14 @@ constexpr void hyperloglog<T, Scope, Hash, Allocator>::add(InputIt first,
                                                            cuda::stream_ref stream)
 {
   ref_.add(first, last, stream);
+}
+
+template <class T, cuda::thread_scope Scope, class Hash, class Allocator>
+template <class InputIt, class StencilIt, class Predicate>
+constexpr void hyperloglog<T, Scope, Hash, Allocator>::add_if_async(
+  InputIt first, InputIt last, StencilIt stencil, Predicate pred, cuda::stream_ref stream)
+{
+  ref_.add_if_async(first, last, stencil, pred, stream);
 }
 
 template <class T, cuda::thread_scope Scope, class Hash, class Allocator>

--- a/include/cuco/detail/hyperloglog/hyperloglog.inl
+++ b/include/cuco/detail/hyperloglog/hyperloglog.inl
@@ -50,6 +50,22 @@ constexpr hyperloglog<T, Scope, Hash, Allocator>::hyperloglog(
 }
 
 template <class T, cuda::thread_scope Scope, class Hash, class Allocator>
+constexpr hyperloglog<T, Scope, Hash, Allocator>::hyperloglog(cuco::precision precision,
+                                                              Hash const& hash,
+                                                              Allocator const& alloc,
+                                                              cuda::stream_ref stream)
+  : allocator_{alloc},
+    sketch_{
+      allocator_.allocate(sketch_bytes(precision) / sizeof(register_type), stream),
+      detail::custom_deleter{sketch_bytes(precision) / sizeof(register_type), allocator_, stream}},
+    ref_{
+      cuda::std::span{reinterpret_cast<cuda::std::byte*>(sketch_.get()), sketch_bytes(precision)},
+      hash}
+{
+  this->clear_async(stream);
+}
+
+template <class T, cuda::thread_scope Scope, class Hash, class Allocator>
 constexpr void hyperloglog<T, Scope, Hash, Allocator>::clear_async(cuda::stream_ref stream) noexcept
 {
   ref_.clear_async(stream);
@@ -164,6 +180,13 @@ constexpr size_t hyperloglog<T, Scope, Hash, Allocator>::sketch_bytes(
   cuco::standard_deviation standard_deviation) noexcept
 {
   return ref_type<>::sketch_bytes(standard_deviation);
+}
+
+template <class T, cuda::thread_scope Scope, class Hash, class Allocator>
+constexpr size_t hyperloglog<T, Scope, Hash, Allocator>::sketch_bytes(
+  cuco::precision precision) noexcept
+{
+  return ref_type<>::sketch_bytes(precision);
 }
 
 template <class T, cuda::thread_scope Scope, class Hash, class Allocator>

--- a/include/cuco/detail/hyperloglog/hyperloglog_impl.cuh
+++ b/include/cuco/detail/hyperloglog/hyperloglog_impl.cuh
@@ -26,12 +26,14 @@
 #include <cuco/utility/traits.hpp>
 
 #include <cuda/atomic>
+#include <cuda/functional>
 #include <cuda/std/__algorithm/max.h>  // TODO #include <cuda/std/algorithm> once available
 #include <cuda/std/bit>
 #include <cuda/std/cstddef>
 #include <cuda/std/span>
 #include <cuda/std/utility>
 #include <cuda/stream_ref>
+#include <thrust/iterator/constant_iterator.h>
 #include <thrust/type_traits/is_contiguous_iterator.h>
 
 #include <cooperative_groups.h>
@@ -173,81 +175,8 @@ class hyperloglog_impl {
   template <class InputIt>
   __host__ constexpr void add_async(InputIt first, InputIt last, cuda::stream_ref stream)
   {
-    auto const num_items = cuco::detail::distance(first, last);
-    if (num_items == 0) { return; }
-
-    int grid_size         = 0;
-    int block_size        = 0;
-    int const shmem_bytes = sketch_bytes();
-    void const* kernel    = nullptr;
-
-    // In case the input iterator represents a contiguous memory segment we can employ efficient
-    // vectorized loads
-    if constexpr (thrust::is_contiguous_iterator_v<InputIt>) {
-      auto const ptr                  = thrust::raw_pointer_cast(&first[0]);
-      auto constexpr max_vector_bytes = 32;
-      auto const alignment =
-        1 << cuda::std::countr_zero(reinterpret_cast<cuda::std::uintptr_t>(ptr) | max_vector_bytes);
-      auto const vector_size = alignment / sizeof(value_type);
-
-      switch (vector_size) {
-        case 2:
-          kernel = reinterpret_cast<void const*>(
-            cuco::hyperloglog_ns::detail::add_shmem_vectorized<2, hyperloglog_impl>);
-          break;
-        case 4:
-          kernel = reinterpret_cast<void const*>(
-            cuco::hyperloglog_ns::detail::add_shmem_vectorized<4, hyperloglog_impl>);
-          break;
-        case 8:
-          kernel = reinterpret_cast<void const*>(
-            cuco::hyperloglog_ns::detail::add_shmem_vectorized<8, hyperloglog_impl>);
-          break;
-        case 16:
-          kernel = reinterpret_cast<void const*>(
-            cuco::hyperloglog_ns::detail::add_shmem_vectorized<16, hyperloglog_impl>);
-          break;
-      };
-    }
-
-    if (kernel != nullptr and this->try_reserve_shmem(kernel, shmem_bytes)) {
-      if constexpr (thrust::is_contiguous_iterator_v<InputIt>) {
-        // We make use of the occupancy calculator to get the minimum number of blocks which still
-        // saturates the GPU. This reduces the shmem initialization overhead and atomic contention
-        // on the final register array during the merge phase.
-        CUCO_CUDA_TRY(
-          cudaOccupancyMaxPotentialBlockSize(&grid_size, &block_size, kernel, shmem_bytes));
-
-        auto const ptr      = thrust::raw_pointer_cast(&first[0]);
-        void* kernel_args[] = {
-          (void*)(&ptr),  // TODO can't use reinterpret_cast since it can't cast away const
-          (void*)(&num_items),
-          reinterpret_cast<void*>(this)};
-        CUCO_CUDA_TRY(
-          cudaLaunchKernel(kernel, grid_size, block_size, kernel_args, shmem_bytes, stream.get()));
-      }
-    } else {
-      kernel = reinterpret_cast<void const*>(
-        cuco::hyperloglog_ns::detail::add_shmem<InputIt, hyperloglog_impl>);
-      void* kernel_args[] = {(void*)(&first), (void*)(&num_items), reinterpret_cast<void*>(this)};
-      if (this->try_reserve_shmem(kernel, shmem_bytes)) {
-        CUCO_CUDA_TRY(
-          cudaOccupancyMaxPotentialBlockSize(&grid_size, &block_size, kernel, shmem_bytes));
-
-        CUCO_CUDA_TRY(
-          cudaLaunchKernel(kernel, grid_size, block_size, kernel_args, shmem_bytes, stream.get()));
-      } else {
-        // Computes sketch directly in global memory. (Fallback path in case there is not enough
-        // shared memory avalable)
-        kernel = reinterpret_cast<void const*>(
-          cuco::hyperloglog_ns::detail::add_gmem<InputIt, hyperloglog_impl>);
-
-        CUCO_CUDA_TRY(cudaOccupancyMaxPotentialBlockSize(&grid_size, &block_size, kernel, 0));
-
-        CUCO_CUDA_TRY(
-          cudaLaunchKernel(kernel, grid_size, block_size, kernel_args, 0, stream.get()));
-      }
-    }
+    auto const always_true = thrust::constant_iterator<bool>(true);
+    this->add_if_async(first, last, always_true, cuda::std::identity{}, stream);
   }
 
   /**
@@ -273,6 +202,112 @@ class hyperloglog_impl {
 #else
     stream.wait();
 #endif
+  }
+
+  /**
+   * @brief Asynchronously adds items in the range `[first, last)` if `pred` of the corresponding
+   * stencil returns true.
+   *
+   * @note The item `*(first + i)` is added if `pred( *(stencil + i) )` returns true.
+   *
+   * @tparam InputIt Device accessible random access input iterator where
+   * <tt>std::is_convertible<std::iterator_traits<InputIt>::value_type,
+   * T></tt> is `true`
+   * @tparam StencilIt Device accessible random access iterator whose value_type is
+   * convertible to Predicate's argument type
+   * @tparam Predicate Unary predicate callable whose return type must be convertible to `bool` and
+   * argument type is convertible from <tt>std::iterator_traits<StencilIt>::value_type</tt>
+   *
+   * @param first Beginning of the sequence of items
+   * @param last End of the sequence of items
+   * @param stencil Beginning of the stencil sequence
+   * @param pred Predicate to test on every element in the range `[stencil, stencil +
+   * std::distance(first, last))`
+   * @param stream CUDA stream this operation is executed in
+   */
+  template <class InputIt, class StencilIt, class Predicate>
+  __host__ constexpr void add_if_async(
+    InputIt first, InputIt last, StencilIt stencil, Predicate pred, cuda::stream_ref stream)
+  {
+    auto const num_items = cuco::detail::distance(first, last);
+    if (num_items == 0) { return; }
+
+    int grid_size         = 0;
+    int block_size        = 0;
+    int const shmem_bytes = sketch_bytes();
+    void const* kernel    = nullptr;
+
+    if constexpr (thrust::is_contiguous_iterator_v<InputIt>) {
+      auto const ptr                  = thrust::raw_pointer_cast(&first[0]);
+      auto constexpr max_vector_bytes = 32;
+      auto const alignment =
+        1 << cuda::std::countr_zero(reinterpret_cast<cuda::std::uintptr_t>(ptr) | max_vector_bytes);
+      auto const vector_size = alignment / sizeof(value_type);
+
+      switch (vector_size) {
+        case 2:
+          kernel = reinterpret_cast<void const*>(
+            cuco::hyperloglog_ns::detail::
+              add_if_shmem_vectorized<2, StencilIt, Predicate, hyperloglog_impl>);
+          break;
+        case 4:
+          kernel = reinterpret_cast<void const*>(
+            cuco::hyperloglog_ns::detail::
+              add_if_shmem_vectorized<4, StencilIt, Predicate, hyperloglog_impl>);
+          break;
+        case 8:
+          kernel = reinterpret_cast<void const*>(
+            cuco::hyperloglog_ns::detail::
+              add_if_shmem_vectorized<8, StencilIt, Predicate, hyperloglog_impl>);
+          break;
+        case 16:
+          kernel = reinterpret_cast<void const*>(
+            cuco::hyperloglog_ns::detail::
+              add_if_shmem_vectorized<16, StencilIt, Predicate, hyperloglog_impl>);
+          break;
+      };
+    }
+
+    if (kernel != nullptr and this->try_reserve_shmem(kernel, shmem_bytes)) {
+      if constexpr (thrust::is_contiguous_iterator_v<InputIt>) {
+        CUCO_CUDA_TRY(
+          cudaOccupancyMaxPotentialBlockSize(&grid_size, &block_size, kernel, shmem_bytes));
+
+        auto const ptr      = thrust::raw_pointer_cast(&first[0]);
+        void* kernel_args[] = {(void*)(&ptr),
+                               (void*)(&num_items),
+                               (void*)(&stencil),
+                               (void*)(&pred),
+                               reinterpret_cast<void*>(this)};
+        CUCO_CUDA_TRY(
+          cudaLaunchKernel(kernel, grid_size, block_size, kernel_args, shmem_bytes, stream.get()));
+      }
+    } else {
+      kernel = reinterpret_cast<void const*>(
+        cuco::hyperloglog_ns::detail::
+          add_if_shmem<InputIt, StencilIt, Predicate, hyperloglog_impl>);
+      void* kernel_args[] = {(void*)(&first),
+                             (void*)(&num_items),
+                             (void*)(&stencil),
+                             (void*)(&pred),
+                             reinterpret_cast<void*>(this)};
+      if (this->try_reserve_shmem(kernel, shmem_bytes)) {
+        CUCO_CUDA_TRY(
+          cudaOccupancyMaxPotentialBlockSize(&grid_size, &block_size, kernel, shmem_bytes));
+
+        CUCO_CUDA_TRY(
+          cudaLaunchKernel(kernel, grid_size, block_size, kernel_args, shmem_bytes, stream.get()));
+      } else {
+        kernel = reinterpret_cast<void const*>(
+          cuco::hyperloglog_ns::detail::
+            add_if_gmem<InputIt, StencilIt, Predicate, hyperloglog_impl>);
+
+        CUCO_CUDA_TRY(cudaOccupancyMaxPotentialBlockSize(&grid_size, &block_size, kernel, 0));
+
+        CUCO_CUDA_TRY(
+          cudaLaunchKernel(kernel, grid_size, block_size, kernel_args, 0, stream.get()));
+      }
+    }
   }
 
   /**

--- a/include/cuco/detail/hyperloglog/hyperloglog_impl.cuh
+++ b/include/cuco/detail/hyperloglog/hyperloglog_impl.cuh
@@ -519,12 +519,13 @@ class hyperloglog_impl {
    *
    * @return The number of bytes required for the sketch
    */
-  [[nodiscard]] __host__ __device__ static constexpr size_t sketch_bytes(
+  [[nodiscard]] __host__ __device__ static constexpr cuda::std::size_t sketch_bytes(
     cuco::sketch_size_kb sketch_size_kb) noexcept
   {
     // minimum precision is 4 or 64 bytes
-    return cuda::std::max(static_cast<size_t>(sizeof(register_type) * 1ull << 4),
-                          cuda::std::bit_floor(static_cast<size_t>(sketch_size_kb * 1024)));
+    return cuda::std::max(
+      static_cast<cuda::std::size_t>(sizeof(register_type) * 1ull << 4),
+      cuda::std::bit_floor(static_cast<cuda::std::size_t>(sketch_size_kb * 1024)));
   }
 
   /**
@@ -534,7 +535,7 @@ class hyperloglog_impl {
    *
    * @return The number of bytes required for the sketch
    */
-  [[nodiscard]] __host__ __device__ static constexpr std::size_t sketch_bytes(
+  [[nodiscard]] __host__ __device__ static constexpr cuda::std::size_t sketch_bytes(
     cuco::standard_deviation standard_deviation) noexcept
   {
     // implementation taken from
@@ -542,8 +543,8 @@ class hyperloglog_impl {
 
     //  minimum precision is 4 or 64 bytes
     auto const precision = cuda::std::max(
-      static_cast<int32_t>(4),
-      static_cast<int32_t>(
+      static_cast<cuda::std::int32_t>(4),
+      static_cast<cuda::std::int32_t>(
         cuda::std::ceil(2.0 * cuda::std::log(1.106 / standard_deviation) / cuda::std::log(2.0))));
 
     // inverse of this function (ommitting the minimum precision constraint) is
@@ -553,13 +554,29 @@ class hyperloglog_impl {
   }
 
   /**
+   * @brief Gets the number of bytes required for the sketch storage.
+   *
+   * @param precision HyperLogLog precision parameter
+   *
+   * @return The number of bytes required for the sketch
+   */
+  [[nodiscard]] __host__ __device__ static constexpr cuda::std::size_t sketch_bytes(
+    cuco::precision precision) noexcept
+  {
+    // minimum precision is 4 or 64 bytes
+    auto const clamped_precision =
+      cuda::std::max(cuda::std::int32_t{4}, cuda::std::int32_t{precision});
+    return cuda::std::size_t{sizeof(register_type) * (1ull << clamped_precision)};
+  }
+
+  /**
    * @brief Gets the alignment required for the sketch storage.
    *
    * @return The required alignment
    */
-  [[nodiscard]] __host__ __device__ static constexpr size_t sketch_alignment() noexcept
+  [[nodiscard]] __host__ __device__ static constexpr cuda::std::size_t sketch_alignment() noexcept
   {
-    return alignof(register_type);
+    return cuda::std::size_t{alignof(register_type)};
   }
 
  private:

--- a/include/cuco/detail/hyperloglog/hyperloglog_impl.cuh
+++ b/include/cuco/detail/hyperloglog/hyperloglog_impl.cuh
@@ -54,9 +54,9 @@ namespace cuco::detail {
 template <class T, cuda::thread_scope Scope, class Hash>
 class hyperloglog_impl {
   // We use `int` here since this is the smallest type that supports native `atomicMax` on GPUs
-  using fp_type = double;  ///< Floating point type used for reduction
-  using hash_value_type =
-    decltype(cuda::std::declval<Hash>()(cuda::std::declval<T>()));  ///< Hash value type
+  using fp_type         = double;  ///< Floating point type used for reduction
+  using hash_value_type = cuda::std::remove_cvref_t<decltype(cuda::std::declval<Hash>()(
+    cuda::std::declval<T>()))>;  ///< Hash value type
  public:
   static constexpr auto thread_scope = Scope;  ///< CUDA thread scope
 

--- a/include/cuco/detail/hyperloglog/hyperloglog_impl.cuh
+++ b/include/cuco/detail/hyperloglog/hyperloglog_impl.cuh
@@ -175,8 +175,8 @@ class hyperloglog_impl {
   template <class InputIt>
   __host__ constexpr void add_async(InputIt first, InputIt last, cuda::stream_ref stream)
   {
-    auto const always_true = thrust::constant_iterator<bool>(true);
-    this->add_if_async(first, last, always_true, cuda::std::identity{}, stream);
+    this->add_if_async(
+      first, last, thrust::constant_iterator<bool>{true}, cuda::std::identity{}, stream);
   }
 
   /**

--- a/include/cuco/detail/hyperloglog/hyperloglog_impl.cuh
+++ b/include/cuco/detail/hyperloglog/hyperloglog_impl.cuh
@@ -19,9 +19,9 @@
 #include <cuco/detail/error.hpp>
 #include <cuco/detail/hyperloglog/finalizer.cuh>
 #include <cuco/detail/hyperloglog/kernels.cuh>
+#include <cuco/detail/utility/strong_type.cuh>
 #include <cuco/detail/utils.hpp>
 #include <cuco/hash_functions.cuh>
-#include <cuco/types.cuh>
 #include <cuco/utility/cuda_thread_scope.cuh>
 #include <cuco/utility/traits.hpp>
 
@@ -42,6 +42,9 @@
 #include <vector>
 
 namespace cuco::detail {
+CUCO_DEFINE_STRONG_TYPE(sketch_size_kb, double);
+CUCO_DEFINE_STRONG_TYPE(standard_deviation, double);
+CUCO_DEFINE_STRONG_TYPE(precision, int32_t);
 
 /**
  * @brief A GPU-accelerated utility for approximating the number of distinct items in a multiset.
@@ -84,9 +87,9 @@ class hyperloglog_impl {
   __host__ __device__ constexpr hyperloglog_impl(cuda::std::span<cuda::std::byte> sketch_span,
                                                  Hash const& hash)
     : hash_{hash},
-      precision_{cuda::std::countr_zero(
-        sketch_bytes(cuco::sketch_size_kb(static_cast<double>(sketch_span.size() / 1024.0))) /
-        sizeof(register_type))},
+      precision_{cuda::std::countr_zero(sketch_bytes(cuco::detail::sketch_size_kb(
+                                          static_cast<double>(sketch_span.size() / 1024.0))) /
+                                        sizeof(register_type))},
       sketch_{reinterpret_cast<register_type*>(sketch_span.data()),
               this->sketch_bytes() / sizeof(register_type)}
   {
@@ -520,7 +523,7 @@ class hyperloglog_impl {
    * @return The number of bytes required for the sketch
    */
   [[nodiscard]] __host__ __device__ static constexpr cuda::std::size_t sketch_bytes(
-    cuco::sketch_size_kb sketch_size_kb) noexcept
+    cuco::detail::sketch_size_kb sketch_size_kb) noexcept
   {
     // minimum precision is 4 or 64 bytes
     return cuda::std::max(
@@ -536,7 +539,7 @@ class hyperloglog_impl {
    * @return The number of bytes required for the sketch
    */
   [[nodiscard]] __host__ __device__ static constexpr cuda::std::size_t sketch_bytes(
-    cuco::standard_deviation standard_deviation) noexcept
+    cuco::detail::standard_deviation standard_deviation) noexcept
   {
     // implementation taken from
     // https://github.com/apache/spark/blob/6a27789ad7d59cd133653a49be0bb49729542abe/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/HyperLogLogPlusPlusHelper.scala#L43
@@ -561,7 +564,7 @@ class hyperloglog_impl {
    * @return The number of bytes required for the sketch
    */
   [[nodiscard]] __host__ __device__ static constexpr cuda::std::size_t sketch_bytes(
-    cuco::precision precision) noexcept
+    cuco::detail::precision precision) noexcept
   {
     // minimum precision is 4 or 64 bytes
     auto const clamped_precision =

--- a/include/cuco/detail/hyperloglog/hyperloglog_ref.inl
+++ b/include/cuco/detail/hyperloglog/hyperloglog_ref.inl
@@ -148,6 +148,13 @@ __host__ __device__ constexpr std::size_t hyperloglog_ref<T, Scope, Hash>::sketc
 }
 
 template <class T, cuda::thread_scope Scope, class Hash>
+__host__ __device__ constexpr std::size_t hyperloglog_ref<T, Scope, Hash>::sketch_bytes(
+  cuco::precision precision) noexcept
+{
+  return impl_type::sketch_bytes(precision);
+}
+
+template <class T, cuda::thread_scope Scope, class Hash>
 __host__ __device__ constexpr std::size_t
 hyperloglog_ref<T, Scope, Hash>::sketch_alignment() noexcept
 {

--- a/include/cuco/detail/hyperloglog/hyperloglog_ref.inl
+++ b/include/cuco/detail/hyperloglog/hyperloglog_ref.inl
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,6 +65,14 @@ __host__ constexpr void hyperloglog_ref<T, Scope, Hash>::add(InputIt first,
                                                              cuda::stream_ref stream)
 {
   impl_.add(first, last, stream);
+}
+
+template <class T, cuda::thread_scope Scope, class Hash>
+template <class InputIt, class StencilIt, class Predicate>
+__host__ constexpr void hyperloglog_ref<T, Scope, Hash>::add_if_async(
+  InputIt first, InputIt last, StencilIt stencil, Predicate pred, cuda::stream_ref stream)
+{
+  impl_.add_if_async(first, last, stencil, pred, stream);
 }
 
 template <class T, cuda::thread_scope Scope, class Hash>

--- a/include/cuco/detail/hyperloglog/kernels.cuh
+++ b/include/cuco/detail/hyperloglog/kernels.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,17 +36,55 @@ CUCO_KERNEL void clear(RefType ref)
   if (block.group_index().x == 0) { ref.clear(block); }
 }
 
-template <int32_t VectorSize, class RefType>
-CUCO_KERNEL void add_shmem_vectorized(typename RefType::value_type const* first,
-                                      cuco::detail::index_type n,
-                                      RefType ref)
+template <class InputIt, class StencilIt, class Predicate, class RefType>
+CUCO_KERNEL void add_if_gmem(
+  InputIt first, cuco::detail::index_type n, StencilIt stencil, Predicate pred, RefType ref)
+{
+  auto const loop_stride = cuco::detail::grid_stride();
+  auto idx               = cuco::detail::global_thread_id();
+
+  while (idx < n) {
+    if (pred(*(stencil + idx))) { ref.add(*(first + idx)); }
+    idx += loop_stride;
+  }
+}
+
+template <class InputIt, class StencilIt, class Predicate, class RefType>
+CUCO_KERNEL void add_if_shmem(
+  InputIt first, cuco::detail::index_type n, StencilIt stencil, Predicate pred, RefType ref)
+{
+  using local_ref_type = typename RefType::template with_scope<cuda::thread_scope_block>;
+
+  extern __shared__ cuda::std::byte local_sketch[];
+
+  auto const loop_stride = cuco::detail::grid_stride();
+  auto idx               = cuco::detail::global_thread_id();
+  auto const block       = cooperative_groups::this_thread_block();
+
+  local_ref_type local_ref(cuda::std::span{local_sketch, ref.sketch_bytes()}, {});
+  local_ref.clear(block);
+  block.sync();
+
+  while (idx < n) {
+    if (pred(*(stencil + idx))) { local_ref.add(*(first + idx)); }
+    idx += loop_stride;
+  }
+  block.sync();
+
+  ref.merge(block, local_ref);
+}
+
+template <int32_t VectorSize, class StencilIt, class Predicate, class RefType>
+CUCO_KERNEL void add_if_shmem_vectorized(typename RefType::value_type const* first,
+                                         cuco::detail::index_type n,
+                                         StencilIt stencil,
+                                         Predicate pred,
+                                         RefType ref)
 {
   using value_type     = typename RefType::value_type;
   using vector_type    = cuda::std::array<value_type, VectorSize>;
   using local_ref_type = typename RefType::template with_scope<cuda::thread_scope_block>;
 
-  // Base address of dynamic shared memory is guaranteed to be aligned to at least 16 bytes which is
-  // sufficient for this purpose
   extern __shared__ cuda::std::byte local_sketch[];
 
   auto const loop_stride = cuco::detail::grid_stride();
@@ -58,72 +96,36 @@ CUCO_KERNEL void add_shmem_vectorized(typename RefType::value_type const* first,
   local_ref.clear(block);
   block.sync();
 
-  // each thread processes VectorSize-many items per iteration
   vector_type vec;
   while (idx < n / VectorSize) {
     vec = *reinterpret_cast<vector_type*>(
       __builtin_assume_aligned(first + idx * VectorSize, sizeof(vector_type)));
-    for (auto const& i : vec) {
-      local_ref.add(i);
+    for (auto i = 0; i < VectorSize; ++i) {
+      if (pred(*(stencil + idx * VectorSize + i))) { local_ref.add(vec[i]); }
     }
     idx += loop_stride;
   }
-  // a single thread processes the remaining items
+
 #if defined(CUCO_HAS_CG_INVOKE_ONE)
   cooperative_groups::invoke_one(grid, [&]() {
     auto const remainder = n % VectorSize;
     cuda::static_for<VectorSize>([&] __device__(auto i) {
-      if (i() < remainder) { local_ref.add(*(first + n - i() - 1)); }
+      auto const item_idx = n - i() - 1;
+      if (i() < remainder && pred(*(stencil + item_idx))) { local_ref.add(*(first + item_idx)); }
     });
   });
 #else
   if (grid.thread_rank() == 0) {
     auto const remainder = n % VectorSize;
     cuda::static_for<VectorSize>([&] __device__(auto i) {
-      if (i() < remainder) { local_ref.add(*(first + n - i() - 1)); }
+      auto const item_idx = n - i() - 1;
+      if (i() < remainder && pred(*(stencil + item_idx))) { local_ref.add(*(first + item_idx)); }
     });
   }
 #endif
   block.sync();
 
   ref.merge(block, local_ref);
-}
-
-template <class InputIt, class RefType>
-CUCO_KERNEL void add_shmem(InputIt first, cuco::detail::index_type n, RefType ref)
-{
-  using local_ref_type = typename RefType::template with_scope<cuda::thread_scope_block>;
-
-  // TODO assert alignment
-  extern __shared__ cuda::std::byte local_sketch[];
-
-  auto const loop_stride = cuco::detail::grid_stride();
-  auto idx               = cuco::detail::global_thread_id();
-  auto const block       = cooperative_groups::this_thread_block();
-
-  local_ref_type local_ref(cuda::std::span{local_sketch, ref.sketch_bytes()}, {});
-  local_ref.clear(block);
-  block.sync();
-
-  while (idx < n) {
-    local_ref.add(*(first + idx));
-    idx += loop_stride;
-  }
-  block.sync();
-
-  ref.merge(block, local_ref);
-}
-
-template <class InputIt, class RefType>
-CUCO_KERNEL void add_gmem(InputIt first, cuco::detail::index_type n, RefType ref)
-{
-  auto const loop_stride = cuco::detail::grid_stride();
-  auto idx               = cuco::detail::global_thread_id();
-
-  while (idx < n) {
-    ref.add(*(first + idx));
-    idx += loop_stride;
-  }
 }
 
 template <class OtherRefType, class RefType>

--- a/include/cuco/hyperloglog.cuh
+++ b/include/cuco/hyperloglog.cuh
@@ -18,7 +18,6 @@
 #include <cuco/detail/storage/storage_base.cuh>
 #include <cuco/hash_functions.cuh>
 #include <cuco/hyperloglog_ref.cuh>
-#include <cuco/types.cuh>
 #include <cuco/utility/allocator.hpp>
 #include <cuco/utility/cuda_thread_scope.cuh>
 

--- a/include/cuco/hyperloglog.cuh
+++ b/include/cuco/hyperloglog.cuh
@@ -90,6 +90,22 @@ class hyperloglog {
                         Allocator const& alloc  = {},
                         cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
+  /**
+   * @brief Constructs a `hyperloglog` host object.
+   *
+   * @note This function synchronizes the given stream.
+   *
+   * @param precision HyperLogLog precision parameter (determines number of registers as
+   * 2^precision)
+   * @param hash The hash function used to hash items
+   * @param alloc Allocator used for allocating device storage
+   * @param stream CUDA stream used to initialize the object
+   */
+  constexpr hyperloglog(cuco::precision precision,
+                        Hash const& hash        = {},
+                        Allocator const& alloc  = {},
+                        cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
+
   ~hyperloglog() = default;
 
   hyperloglog(hyperloglog const&)            = delete;
@@ -307,6 +323,15 @@ class hyperloglog {
    */
   [[nodiscard]] static constexpr std::size_t sketch_bytes(
     cuco::standard_deviation standard_deviation) noexcept;
+
+  /**
+   * @brief Gets the number of bytes required for the sketch storage.
+   *
+   * @param precision HyperLogLog precision parameter
+   *
+   * @return The number of bytes required for the sketch
+   */
+  [[nodiscard]] static constexpr std::size_t sketch_bytes(cuco::precision precision) noexcept;
 
   /**
    * @brief Gets the alignment required for the sketch storage.

--- a/include/cuco/hyperloglog.cuh
+++ b/include/cuco/hyperloglog.cuh
@@ -157,6 +157,34 @@ class hyperloglog {
                      cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
+   * @brief Asynchronously adds items in the range `[first, last)` if `pred` of the corresponding
+   * stencil returns true.
+   *
+   * @note The item `*(first + i)` is added if `pred( *(stencil + i) )` returns true.
+   *
+   * @tparam InputIt Device accessible random access input iterator where
+   * <tt>std::is_convertible<std::iterator_traits<InputIt>::value_type,
+   * T></tt> is `true`
+   * @tparam StencilIt Device accessible random access iterator whose value_type is
+   * convertible to Predicate's argument type
+   * @tparam Predicate Unary predicate callable whose return type must be convertible to `bool` and
+   * argument type is convertible from <tt>std::iterator_traits<StencilIt>::value_type</tt>
+   *
+   * @param first Beginning of the sequence of items
+   * @param last End of the sequence of items
+   * @param stencil Beginning of the stencil sequence
+   * @param pred Predicate to test on every element in the range `[stencil, stencil +
+   * std::distance(first, last))`
+   * @param stream CUDA stream this operation is executed in
+   */
+  template <class InputIt, class StencilIt, class Predicate>
+  constexpr void add_if_async(InputIt first,
+                              InputIt last,
+                              StencilIt stencil,
+                              Predicate pred,
+                              cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
+
+  /**
    * @brief Asynchronously merges the result of `other` estimator into `*this` estimator.
    *
    * @throw If this->sketch_bytes() != other.sketch_bytes()

--- a/include/cuco/hyperloglog_ref.cuh
+++ b/include/cuco/hyperloglog_ref.cuh
@@ -17,13 +17,49 @@
 
 #include <cuco/detail/hyperloglog/hyperloglog_impl.cuh>
 #include <cuco/hash_functions.cuh>
-#include <cuco/types.cuh>
 #include <cuco/utility/cuda_thread_scope.cuh>
 
 #include <cuda/std/cstddef>
 #include <cuda/stream_ref>
 
 #include <cooperative_groups.h>
+
+namespace cuco {
+/**
+ * @brief A strong type wrapper for specifying the upper-bound sketch size of
+ * `cuco::hyperloglog(_ref)` in KB.
+ *
+ * @note Underlying type is `double`. Values can also be specified as literals, e.g., 64.3_KB.
+ */
+using sketch_size_kb = detail::sketch_size_kb;
+
+/**
+ * @brief A strong type wrapper for specifying the desired standard deviation for the cardinality
+ * estimate of `cuco::hyperloglog(_ref)`.
+ *
+ * @note Underlying type is `double`.
+ */
+using standard_deviation = detail::standard_deviation;
+
+/**
+ * @brief A strong type wrapper for specifying the HyperLogLog precision parameter of
+ * `cuco::hyperloglog(_ref)`.
+ *
+ * @note Underlying type is `int32_t`. Precision `p` determines the number of registers as `2^p`.
+ * Valid range is typically [4, 18].
+ */
+using precision = detail::precision;
+}  // namespace cuco
+
+__host__ __device__ constexpr cuco::sketch_size_kb operator""_KB(long double value)
+{
+  return cuco::sketch_size_kb{static_cast<double>(value)};
+}
+
+__host__ __device__ constexpr cuco::sketch_size_kb operator""_KB(unsigned long long int value)
+{
+  return cuco::sketch_size_kb{static_cast<double>(value)};
+}
 
 namespace cuco {
 /**

--- a/include/cuco/hyperloglog_ref.cuh
+++ b/include/cuco/hyperloglog_ref.cuh
@@ -137,6 +137,35 @@ class hyperloglog_ref {
                               cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   /**
+   * @brief Asynchronously adds items in the range `[first, last)` if `pred` of the corresponding
+   * stencil returns true.
+   *
+   * @note The item `*(first + i)` is added if `pred( *(stencil + i) )` returns true.
+   *
+   * @tparam InputIt Device accessible random access input iterator where
+   * <tt>std::is_convertible<std::iterator_traits<InputIt>::value_type,
+   * T></tt> is `true`
+   * @tparam StencilIt Device accessible random access iterator whose value_type is
+   * convertible to Predicate's argument type
+   * @tparam Predicate Unary predicate callable whose return type must be convertible to `bool` and
+   * argument type is convertible from <tt>std::iterator_traits<StencilIt>::value_type</tt>
+   *
+   * @param first Beginning of the sequence of items
+   * @param last End of the sequence of items
+   * @param stencil Beginning of the stencil sequence
+   * @param pred Predicate to test on every element in the range `[stencil, stencil +
+   * std::distance(first, last))`
+   * @param stream CUDA stream this operation is executed in
+   */
+  template <class InputIt, class StencilIt, class Predicate>
+  __host__ constexpr void add_if_async(InputIt first,
+                                       InputIt last,
+                                       StencilIt stencil,
+                                       Predicate pred,
+                                       cuda::stream_ref stream = cuda::stream_ref{
+                                         cudaStream_t{nullptr}});
+
+  /**
    * @brief Merges the result of `other` estimator reference into `*this` estimator reference.
    *
    * @throw If this->sketch_bytes() != other.sketch_bytes() then behavior is undefined

--- a/include/cuco/hyperloglog_ref.cuh
+++ b/include/cuco/hyperloglog_ref.cuh
@@ -276,6 +276,16 @@ class hyperloglog_ref {
     cuco::standard_deviation standard_deviation) noexcept;
 
   /**
+   * @brief Gets the number of bytes required for the sketch storage.
+   *
+   * @param precision HyperLogLog precision parameter
+   *
+   * @return The number of bytes required for the sketch
+   */
+  [[nodiscard]] __host__ __device__ static constexpr std::size_t sketch_bytes(
+    cuco::precision precision) noexcept;
+
+  /**
    * @brief Gets the alignment required for the sketch storage.
    *
    * @return The required alignment

--- a/include/cuco/types.cuh
+++ b/include/cuco/types.cuh
@@ -44,38 +44,4 @@ CUCO_DEFINE_TEMPLATE_STRONG_TYPE(empty_value);
  */
 CUCO_DEFINE_TEMPLATE_STRONG_TYPE(erased_key);
 
-/**
- * @brief A strong type wrapper `cuco::sketch_size_kb` for specifying the upper-bound sketch size of
- * `cuco::hyperloglog(_ref)` in KB.
- *
- * @note Values can also be specified as literals, e.g., 64.3_KB.
- */
-CUCO_DEFINE_STRONG_TYPE(sketch_size_kb, double);
-
-/**
- * @brief A strong type wrapper `cuco::standard_deviation` for specifying the desired standard
- * deviation for the cardinality estimate of `cuco::hyperloglog(_ref)`.
- */
-CUCO_DEFINE_STRONG_TYPE(standard_deviation, double);
-
-/**
- * @brief A strong type wrapper `cuco::precision` for specifying the HyperLogLog precision
- * parameter of `cuco::hyperloglog(_ref)`.
- *
- * @note Precision `p` determines the number of registers as `2^p`. Valid range is typically [4,
- * 18].
- */
-CUCO_DEFINE_STRONG_TYPE(precision, int32_t);
-
 }  // namespace cuco
-
-// User-defined literal operators for `cuco::sketch_size_KB`
-__host__ __device__ constexpr cuco::sketch_size_kb operator""_KB(long double value)
-{
-  return cuco::sketch_size_kb{static_cast<double>(value)};
-}
-
-__host__ __device__ constexpr cuco::sketch_size_kb operator""_KB(unsigned long long int value)
-{
-  return cuco::sketch_size_kb{static_cast<double>(value)};
-}

--- a/include/cuco/types.cuh
+++ b/include/cuco/types.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,15 @@ CUCO_DEFINE_STRONG_TYPE(sketch_size_kb, double);
  * deviation for the cardinality estimate of `cuco::hyperloglog(_ref)`.
  */
 CUCO_DEFINE_STRONG_TYPE(standard_deviation, double);
+
+/**
+ * @brief A strong type wrapper `cuco::precision` for specifying the HyperLogLog precision
+ * parameter of `cuco::hyperloglog(_ref)`.
+ *
+ * @note Precision `p` determines the number of registers as `2^p`. Valid range is typically [4,
+ * 18].
+ */
+CUCO_DEFINE_STRONG_TYPE(precision, int32_t);
 
 }  // namespace cuco
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -146,7 +146,8 @@ ConfigureTest(DYNAMIC_BITSET_TEST
 ConfigureTest(HYPERLOGLOG_TEST
     hyperloglog/unique_sequence_test.cu
     hyperloglog/spark_parity_test.cu
-    hyperloglog/device_ref_test.cu)
+    hyperloglog/device_ref_test.cu
+    hyperloglog/type_deduction_test.cu)
 
 ###################################################################################################
 # - bloom_filter ----------------------------------------------------------------------------------

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -147,7 +147,8 @@ ConfigureTest(HYPERLOGLOG_TEST
     hyperloglog/unique_sequence_test.cu
     hyperloglog/spark_parity_test.cu
     hyperloglog/device_ref_test.cu
-    hyperloglog/type_deduction_test.cu)
+    hyperloglog/type_deduction_test.cu
+    hyperloglog/add_if_test.cu)
 
 ###################################################################################################
 # - bloom_filter ----------------------------------------------------------------------------------

--- a/tests/hyperloglog/add_if_test.cu
+++ b/tests/hyperloglog/add_if_test.cu
@@ -29,9 +29,8 @@
 
 TEST_CASE("hyperloglog: add_if with stencil predicate")
 {
-  auto constexpr hll_precision  = 12;
-  auto constexpr sketch_size_kb = 4 * (1ull << hll_precision) / 1024;
-  auto constexpr num_items      = 100000;
+  auto constexpr hll_precision = 12;
+  auto constexpr num_items     = 100000;
 
   double constexpr tolerance_factor = 2.5;
   double const relative_standard_deviation =
@@ -49,7 +48,7 @@ TEST_CASE("hyperloglog: add_if with stencil predicate")
     auto pred = [] __device__(int x) { return x % 2 == 0; };
 
     cuco::hyperloglog<int64_t, cuda::thread_scope_device, cuco::xxhash_64<int64_t>> estimator{
-      cuco::sketch_size_kb(sketch_size_kb)};
+      cuco::precision(hll_precision)};
 
     REQUIRE(estimator.estimate() == 0);
 
@@ -71,7 +70,7 @@ TEST_CASE("hyperloglog: add_if with stencil predicate")
     auto pred = [] __device__(int x) { return x != 0; };
 
     cuco::hyperloglog<int64_t, cuda::thread_scope_device, cuco::xxhash_64<int64_t>> estimator{
-      cuco::sketch_size_kb(sketch_size_kb)};
+      cuco::precision(hll_precision)};
 
     estimator.add_if_async(items.begin(), items.end(), stencil.begin(), pred);
 
@@ -90,7 +89,7 @@ TEST_CASE("hyperloglog: add_if with stencil predicate")
     auto pred = [] __device__(int x) { return x != 0; };
 
     cuco::hyperloglog<int64_t, cuda::thread_scope_device, cuco::xxhash_64<int64_t>> estimator{
-      cuco::sketch_size_kb(sketch_size_kb)};
+      cuco::precision(hll_precision)};
 
     estimator.add_if_async(items.begin(), items.end(), stencil.begin(), pred);
 

--- a/tests/hyperloglog/add_if_test.cu
+++ b/tests/hyperloglog/add_if_test.cu
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <test_utils.hpp>
+
+#include <cuco/hash_functions.cuh>
+#include <cuco/hyperloglog.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/sequence.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmath>
+#include <cstdint>
+
+TEST_CASE("hyperloglog: add_if with stencil predicate")
+{
+  auto constexpr hll_precision  = 12;
+  auto constexpr sketch_size_kb = 4 * (1ull << hll_precision) / 1024;
+  auto constexpr num_items      = 100000;
+
+  double constexpr tolerance_factor = 2.5;
+  double const relative_standard_deviation =
+    1.04 / std::sqrt(static_cast<double>(1ull << hll_precision));
+
+  thrust::device_vector<int64_t> items(num_items);
+  thrust::device_vector<int> stencil(num_items);
+
+  thrust::sequence(items.begin(), items.end(), 0);
+
+  SECTION("Add only even items using stencil")
+  {
+    thrust::sequence(stencil.begin(), stencil.end(), 0);
+
+    auto pred = [] __device__(int x) { return x % 2 == 0; };
+
+    cuco::hyperloglog<int64_t, cuda::thread_scope_device, cuco::xxhash_64<int64_t>> estimator{
+      cuco::sketch_size_kb(sketch_size_kb)};
+
+    REQUIRE(estimator.estimate() == 0);
+
+    estimator.add_if_async(items.begin(), items.end(), stencil.begin(), pred);
+
+    auto const estimate       = estimator.estimate();
+    auto const expected_count = num_items / 2;
+
+    double const relative_error =
+      std::abs((static_cast<double>(estimate) / static_cast<double>(expected_count)) - 1.0);
+
+    REQUIRE(relative_error < tolerance_factor * relative_standard_deviation);
+  }
+
+  SECTION("Add all items when predicate always returns true")
+  {
+    thrust::fill(stencil.begin(), stencil.end(), 1);
+
+    auto pred = [] __device__(int x) { return x != 0; };
+
+    cuco::hyperloglog<int64_t, cuda::thread_scope_device, cuco::xxhash_64<int64_t>> estimator{
+      cuco::sketch_size_kb(sketch_size_kb)};
+
+    estimator.add_if_async(items.begin(), items.end(), stencil.begin(), pred);
+
+    auto const estimate = estimator.estimate();
+
+    double const relative_error =
+      std::abs((static_cast<double>(estimate) / static_cast<double>(num_items)) - 1.0);
+
+    REQUIRE(relative_error < tolerance_factor * relative_standard_deviation);
+  }
+
+  SECTION("Add no items when predicate always returns false")
+  {
+    thrust::fill(stencil.begin(), stencil.end(), 0);
+
+    auto pred = [] __device__(int x) { return x != 0; };
+
+    cuco::hyperloglog<int64_t, cuda::thread_scope_device, cuco::xxhash_64<int64_t>> estimator{
+      cuco::sketch_size_kb(sketch_size_kb)};
+
+    estimator.add_if_async(items.begin(), items.end(), stencil.begin(), pred);
+
+    auto const estimate = estimator.estimate();
+
+    REQUIRE(estimate == 0);
+  }
+}

--- a/tests/hyperloglog/type_deduction_test.cu
+++ b/tests/hyperloglog/type_deduction_test.cu
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <test_utils.hpp>
+
+#include <cuco/hash_functions.cuh>
+#include <cuco/hyperloglog.cuh>
+
+#include <cuda/functional>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+
+TEST_CASE("hyperloglog: type deduction bug with hash functions returning references")
+{
+  auto constexpr sketch_size_kb = 1;
+  auto constexpr num_items      = 1000;
+
+  auto first = thrust::make_transform_iterator(thrust::counting_iterator<uint64_t>(0),
+                                               cuco::xxhash_64<uint64_t>{});
+  auto last  = first + num_items;
+
+  cuco::hyperloglog<uint64_t, cuda::thread_scope_device, cuda::std::identity> estimator{
+    cuco::sketch_size_kb(sketch_size_kb)};
+
+  REQUIRE(estimator.estimate() == 0);
+
+  estimator.add(first, last);
+
+  auto const estimate = estimator.estimate();
+
+  REQUIRE(estimate > 0);
+}


### PR DESCRIPTION
This PR adds a new `add_if_async` API that allows users to conditionally perform add operations without the need for custom kernels. In addition, it resolves a small type-deduction issue when deriving the hash value type with `decltype`, ensuring that references and `const` qualifiers are properly removed.

Required by https://github.com/rapidsai/cudf/pull/20735