### PR TITLE
Remove Unused Cooperative Group sanitize_hash Overload

### DIFF
--- a/include/cuco/detail/utils.cuh
+++ b/include/cuco/detail/utils.cuh
@@ -121,25 +121,5 @@ __host__ __device__ constexpr SizeType sanitize_hash(HashType hash) noexcept
   }
 }
 
-/**
- * @brief Converts a given hash value and cg_rank, into a valid (positive) size type.
- *
- * @tparam SizeType The target type
- * @tparam CG Cooperative group type
- * @tparam HashType The input type
- *
- * @return Converted hash value
- */
-template <typename SizeType, typename CG, typename HashType>
-__device__ constexpr SizeType sanitize_hash(CG group, HashType hash) noexcept
-{
-  auto const base_hash = sanitize_hash<SizeType>(hash);
-  auto const max_size  = cuda::std::numeric_limits<SizeType>::max();
-  auto const cg_rank   = static_cast<SizeType>(group.thread_rank());
-
-  if (base_hash > (max_size - cg_rank)) { return cg_rank - (max_size - base_hash); }
-  return base_hash + cg_rank;
-}
-
 }  // namespace detail
 }  // namespace cuco


### PR DESCRIPTION
Close #789 

This PR removes the unused 3-parameter `sanitize_hash(CG group, HashType hash)` function from `include/cuco/detail/utils.cuh`. No functional changes.

The 3-parameter version adds `group.thread_rank()` to the hash before the modulo operation in probing schemes. This causes a wrap-around bug where threads in the same cooperative group can end up at opposite ends of storage.

**Example with CGSize=2, upper_bound=100:**
- Thread 0: `(hash + 0) % 50 * 2 = 98` 
- Thread 1: `(hash + 1) % 50 * 2 = 0` ← wraps around
