### PR TITLE
Fix dangling allocator reference in storage deleters

### DIFF
--- a/include/cuco/bucket_storage.cuh
+++ b/include/cuco/bucket_storage.cuh
@@ -252,10 +252,10 @@ class bucket_storage {
   struct aligned_deleter {
     value_type* raw_ptr_;
     std::size_t size_;
-    allocator_type& allocator_;
+    allocator_type allocator_;
     cuda::stream_ref stream_;
 
-    void operator()(value_type*) const { allocator_.deallocate(raw_ptr_, size_, stream_); }
+    void operator()(value_type*) { allocator_.deallocate(raw_ptr_, size_, stream_); }
   };
 
   extent_type extent_;        ///< Storage extent

--- a/include/cuco/detail/storage/storage_base.cuh
+++ b/include/cuco/detail/storage/storage_base.cuh
@@ -39,7 +39,9 @@ struct custom_deleter {
    * @param allocator Allocator used for deallocating device storage
    * @param stream Stream to use for deallocation
    */
-  explicit constexpr custom_deleter(SizeType size, Allocator const& allocator, cuda::stream_ref stream)
+  explicit constexpr custom_deleter(SizeType size,
+                                    Allocator const& allocator,
+                                    cuda::stream_ref stream)
     : size_{size}, allocator_{allocator}, stream_{stream}
   {
   }

--- a/include/cuco/detail/storage/storage_base.cuh
+++ b/include/cuco/detail/storage/storage_base.cuh
@@ -39,7 +39,7 @@ struct custom_deleter {
    * @param allocator Allocator used for deallocating device storage
    * @param stream Stream to use for deallocation
    */
-  explicit constexpr custom_deleter(SizeType size, Allocator& allocator, cuda::stream_ref stream)
+  explicit constexpr custom_deleter(SizeType size, Allocator const& allocator, cuda::stream_ref stream)
     : size_{size}, allocator_{allocator}, stream_{stream}
   {
   }
@@ -52,7 +52,7 @@ struct custom_deleter {
   void operator()(pointer ptr) { allocator_.deallocate(ptr, size_, stream_); }
 
   SizeType size_;            ///< Number of values to delete
-  Allocator& allocator_;     ///< Allocator used deallocating values
+  Allocator allocator_;      ///< Allocator used deallocating values
   cuda::stream_ref stream_;  ///< Stream used for deallocation
 };
 


### PR DESCRIPTION
## Description
This PR resolves intermittent CI failures (specifically row count mismatches in `rapidsmpf` pipelines) caused by a dangling allocator reference in `cuco` storage deleters.

### Root Cause
The `custom_deleter` (in `storage_base.cuh`) and `aligned_deleter` (in `bucket_storage.cuh`) were capturing the `Allocator` by reference (`Allocator&`). When a container (e.g., `static_multimap`) was moved, the new container's deleter held a reference to the `allocator_` of the original, destroyed container. 

Subsequent destruction of the new container invoked `deallocate` on a dangling reference. In asynchronous environments like `rapidsmpf`, this corruption resulted in "falsely freed" memory being reused by concurrent CUDA streams, directly causing the observed row count mismatches and flakiness.

### Changes
- Updated `custom_deleter` and `aligned_deleter` to store the `Allocator` by **value** instead of by reference.
- Updated constructors to take `Allocator const&` to ensure proper copying.
- This ensures the allocator's lifetime is correctly tied to the `unique_ptr` that utilizes it, making all core containers safely movable.

## Checklist
- [x] I have verified the fix logic with a standalone C++ reproduction of the move-destruction pattern.
- [x] PR is ready for review.