### PR TITLE
Dedup empty value sentinel

### DIFF
--- a/include/cuco/detail/open_addressing/open_addressing_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_impl.cuh
@@ -1112,8 +1112,6 @@ class open_addressing_impl : private open_addressing_compatible<Key, Value, Prob
   /**
    * @brief Gets the sentinel value used to represent an empty payload slot.
    *
-   * @note Only available when the slot carries a payload (i.e. for maps).
-   *
    * @return The sentinel value used to represent an empty payload slot
    */
   template <bool HasPayload = has_payload, cuda::std::enable_if_t<HasPayload, int> = 0>
@@ -1332,8 +1330,6 @@ class open_addressing_impl : private open_addressing_compatible<Key, Value, Prob
 
   /**
    * @brief Extracts the payload from a given slot.
-   *
-   * @note Only available when the slot carries a payload (i.e. for maps).
    *
    * @param slot The input slot
    *

--- a/include/cuco/detail/open_addressing/open_addressing_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_impl.cuh
@@ -1110,6 +1110,19 @@ class open_addressing_impl : private open_addressing_compatible<Key, Value, Prob
   }
 
   /**
+   * @brief Gets the sentinel value used to represent an empty payload slot.
+   *
+   * @note Only available when the slot carries a payload (i.e. for maps).
+   *
+   * @return The sentinel value used to represent an empty payload slot
+   */
+  template <bool HasPayload = has_payload, cuda::std::enable_if_t<HasPayload, int> = 0>
+  [[nodiscard]] constexpr auto empty_payload_sentinel() const noexcept
+  {
+    return this->extract_payload(this->empty_slot_sentinel_);
+  }
+
+  /**
    * @brief Gets the sentinel value used to represent an erased key slot.
    *
    * @return The sentinel value used to represent an erased key slot
@@ -1308,13 +1321,28 @@ class open_addressing_impl : private open_addressing_compatible<Key, Value, Prob
    *
    * @return The key
    */
-  [[nodiscard]] constexpr key_type const& extract_key(value_type const& slot) const noexcept
+  [[nodiscard]] constexpr key_type extract_key(value_type const& slot) const noexcept
   {
     if constexpr (has_payload) {
       return slot.first;
     } else {
       return slot;
     }
+  }
+
+  /**
+   * @brief Extracts the payload from a given slot.
+   *
+   * @note Only available when the slot carries a payload (i.e. for maps).
+   *
+   * @param slot The input slot
+   *
+   * @return The payload
+   */
+  template <bool HasPayload = has_payload, cuda::std::enable_if_t<HasPayload, int> = 0>
+  [[nodiscard]] constexpr auto extract_payload(value_type const& slot) const noexcept
+  {
+    return slot.second;
   }
 
  protected:

--- a/include/cuco/detail/static_map/static_map.inl
+++ b/include/cuco/detail/static_map/static_map.inl
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,8 +54,7 @@ constexpr static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, 
                                       pred,
                                       probing_scheme,
                                       alloc,
-                                      stream)},
-    empty_value_sentinel_{empty_value_sentinel}
+                                      stream)}
 {
 }
 
@@ -84,8 +83,7 @@ constexpr static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, 
                                       pred,
                                       probing_scheme,
                                       alloc,
-                                      stream)},
-    empty_value_sentinel_{empty_value_sentinel}
+                                      stream)}
 {
 }
 
@@ -114,8 +112,7 @@ constexpr static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, 
                                       pred,
                                       probing_scheme,
                                       alloc,
-                                      stream)},
-    empty_value_sentinel_{empty_value_sentinel}
+                                      stream)}
 {
 }
 
@@ -885,7 +882,7 @@ constexpr static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, 
   static_map<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::
     empty_value_sentinel() const noexcept
 {
-  return this->empty_value_sentinel_;
+  return impl_->empty_payload_sentinel();
 }
 
 template <class Key,

--- a/include/cuco/detail/static_multimap/static_multimap.inl
+++ b/include/cuco/detail/static_multimap/static_multimap.inl
@@ -49,8 +49,7 @@ constexpr static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Alloca
                                       pred,
                                       probing_scheme,
                                       alloc,
-                                      stream)},
-    empty_value_sentinel_{empty_value_sentinel}
+                                      stream)}
 {
 }
 
@@ -79,8 +78,7 @@ constexpr static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Alloca
                                       pred,
                                       probing_scheme,
                                       alloc,
-                                      stream)},
-    empty_value_sentinel_{empty_value_sentinel}
+                                      stream)}
 {
 }
 
@@ -109,8 +107,7 @@ constexpr static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Alloca
                                       pred,
                                       probing_scheme,
                                       alloc,
-                                      stream)},
-    empty_value_sentinel_{empty_value_sentinel}
+                                      stream)}
 {
 }
 
@@ -689,7 +686,7 @@ constexpr static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Alloca
   static_multimap<Key, T, Extent, Scope, KeyEqual, ProbingScheme, Allocator, Storage>::
     empty_value_sentinel() const noexcept
 {
-  return empty_value_sentinel_;
+  return impl_->empty_payload_sentinel();
 }
 
 template <class Key,

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -1237,8 +1237,7 @@ class static_map {
   void dispatch_insert_or_apply(
     InputIt first, InputIt last, InitType init, OpType op, RefType ref, cuda::stream_ref stream);
 
-  std::unique_ptr<impl_type> impl_;   ///< Static map implementation
-  mapped_type empty_value_sentinel_;  ///< Sentinel value that indicates an empty payload
+  std::unique_ptr<impl_type> impl_;  ///< Static map implementation
 };
 
 }  // namespace cuco

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -927,8 +927,7 @@ class static_multimap {
   [[nodiscard]] auto ref(Operators... ops) const noexcept;
 
  private:
-  std::unique_ptr<impl_type> impl_;   ///< Static map implementation
-  mapped_type empty_value_sentinel_;  ///< Sentinel value that indicates an empty payload
+  std::unique_ptr<impl_type> impl_;  ///< Static map implementation
 };
 
 }  // namespace cuco


### PR DESCRIPTION
This PR deduplicates the empty payload sentinel by adding `extract_payload`/`empty_payload_sentinel` to `open_addressing_impl` and dropping the redundant `empty_value_sentinel_` data member from `static_map` and    
 `static_multimap`, leaving `empty_slot_sentinel_` as the single source of truth.