### PR TITLE
Default roaring test data download to standalone builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ target_compile_features(cuco INTERFACE cxx_std_17 cuda_std_17)
 ###################################################################################################
 # - Optionally download RoaringFormatSpec test data -----------------------------------------------
 
-option(CUCO_DOWNLOAD_ROARING_TESTDATA "Download RoaringFormatSpec test data" ON)
+option(CUCO_DOWNLOAD_ROARING_TESTDATA "Download RoaringFormatSpec test data" ${default_build_option_state})
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/roaring_testdata.cmake)
 
 ###################################################################################################


### PR DESCRIPTION
## Summary
- Default `CUCO_DOWNLOAD_ROARING_TESTDATA` to the existing standalone-build option state.
- Avoid downloading RoaringFormatSpec test data when cuCollections is consumed as a subproject with tests/examples/benchmarks disabled.