### PR TITLE
Tuning for retrieve kernel

### DIFF
--- a/include/cuco/detail/open_addressing/kernels.cuh
+++ b/include/cuco/detail/open_addressing/kernels.cuh
@@ -646,7 +646,8 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void count_each(InputIt first,
  * unspecified.
  *
  * @tparam IsOuter Flag indicating whether it's an outer count or not
- * @tparam block_size The size of the thread block
+ * @tparam BlockSize The size of the thread block
+ * @tparam TileStride Number of tile batches assigned to each thread block
  * @tparam InputProbeIt Device accessible input iterator
  * @tparam OutputProbeIt Device accessible input iterator whose `value_type` is
  * convertible to the `InputProbeIt`'s `value_type`
@@ -667,6 +668,7 @@ CUCO_KERNEL __launch_bounds__(BlockSize) void count_each(InputIt first,
  */
 template <bool IsOuter,
           int BlockSize,
+          int TileStride,
           class InputProbeIt,
           class OutputProbeIt,
           class OutputMatchIt,
@@ -681,12 +683,13 @@ CUCO_KERNEL void retrieve(InputProbeIt input_probe,
 {
   namespace cg = cooperative_groups;
 
-  auto const block              = cg::this_thread_block();
-  auto constexpr tiles_in_block = BlockSize / Ref::cg_size;
+  auto const block               = cg::this_thread_block();
+  auto constexpr tiles_in_block  = BlockSize / Ref::cg_size;
+  auto constexpr tiles_per_block = TileStride * tiles_in_block;
 
-  auto const block_begin_offset = block.group_index().x * tiles_in_block;
+  auto const block_begin_offset = block.group_index().x * tiles_per_block;
   auto const block_end_offset =
-    min(n, static_cast<cuco::detail::index_type>(block_begin_offset + tiles_in_block));
+    min(n, static_cast<cuco::detail::index_type>(block_begin_offset + tiles_per_block));
 
   if (block_begin_offset < block_end_offset) {
     if constexpr (IsOuter) {

--- a/include/cuco/detail/open_addressing/open_addressing_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_impl.cuh
@@ -1324,10 +1324,10 @@ class open_addressing_impl : private open_addressing_compatible<Key, Value, Prob
 
     auto constexpr block_size = cuco::detail::default_block_size();
 
-    auto constexpr grid_stride = 1;
+    auto constexpr grid_stride = 4;
     auto const grid_size       = cuco::detail::grid_size(n, cg_size, grid_stride, block_size);
 
-    detail::open_addressing_ns::retrieve<IsOuter, block_size>
+    detail::open_addressing_ns::retrieve<IsOuter, block_size, grid_stride>
       <<<grid_size, block_size, 0, stream.get()>>>(
         first, n, output_probe, output_match, counter.data(), container_ref);
 

--- a/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
+++ b/include/cuco/detail/open_addressing/open_addressing_ref_impl.cuh
@@ -1294,7 +1294,7 @@ class open_addressing_ref_impl
       if (active_flag) {
         // perform probing
         // make sure the flushing_tile is converged at this point to get a coalesced load
-        auto const probe_key = *(input_probe + idx);
+        probe_type const probe_key = *(input_probe + idx);
 
         auto probing_iter = probing_scheme_.template make_iterator<bucket_size>(
           probing_tile, probe_key, storage_ref_.extent());


### PR DESCRIPTION
This PR tunes the `static_multi{set,map}::retrieve` kernel to improve probe throughput.

The retrieve kernel now assigns multiple cooperative-group tile batches to each CTA (`stride = 4`) instead of only
one batch. This gives each CTA more useful work and reduces CTA scheduling / block-level overhead for large retrieve
workloads.

It also makes the probe-key load explicit in the retrieve path, which helps avoid iterator/proxy reloads in
generated code (see https://github.com/NVIDIA/cuCollections/issues/822#issuecomment-4774385027 ).