### PR TITLE
Delete default constructor and move assignment on hash tables

### DIFF
--- a/include/cuco/dynamic_map.cuh
+++ b/include/cuco/dynamic_map.cuh
@@ -60,7 +60,7 @@ class dynamic_map {
   dynamic_map()                              = delete;
   dynamic_map(dynamic_map const&)            = delete;
   dynamic_map& operator=(dynamic_map const&) = delete;
-  dynamic_map(dynamic_map&&)                 = delete;
+  dynamic_map(dynamic_map&&) noexcept        = default;  ///< Move constructor
   dynamic_map& operator=(dynamic_map&&)      = delete;
   ~dynamic_map()                             = default;
 

--- a/include/cuco/dynamic_map.cuh
+++ b/include/cuco/dynamic_map.cuh
@@ -57,18 +57,12 @@ class dynamic_map {
   using hasher      = typename map_type::hasher;      ///< Hash function type
   using mapped_type = T;                              ///< Payload type
 
+  dynamic_map()                              = delete;
   dynamic_map(dynamic_map const&)            = delete;
   dynamic_map& operator=(dynamic_map const&) = delete;
-
-  dynamic_map(dynamic_map&&) = default;  ///< Move constructor
-
-  /**
-   * @brief Replaces the contents of the container with another container.
-   *
-   * @return Reference of the current map object
-   */
-  dynamic_map& operator=(dynamic_map&&) = default;
-  ~dynamic_map()                        = default;
+  dynamic_map(dynamic_map&&)                 = delete;
+  dynamic_map& operator=(dynamic_map&&)      = delete;
+  ~dynamic_map()                             = default;
 
   /**
    * @brief Constructs a dynamically-sized map.

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -124,7 +124,7 @@ class static_map {
   static_map()                             = delete;
   static_map(static_map const&)            = delete;
   static_map& operator=(static_map const&) = delete;
-  static_map(static_map&&)                 = delete;
+  static_map(static_map&&) noexcept        = default;  ///< Move constructor
   static_map& operator=(static_map&&)      = delete;
   ~static_map()                            = default;
 

--- a/include/cuco/static_map.cuh
+++ b/include/cuco/static_map.cuh
@@ -121,18 +121,12 @@ class static_map {
                                         storage_ref_type,
                                         Operators...>;  ///< Non-owning container ref type
 
+  static_map()                             = delete;
   static_map(static_map const&)            = delete;
   static_map& operator=(static_map const&) = delete;
-
-  static_map(static_map&&) = default;  ///< Move constructor
-
-  /**
-   * @brief Replaces the contents of the container with another container.
-   *
-   * @return Reference of the current map object
-   */
-  static_map& operator=(static_map&&) = default;
-  ~static_map()                       = default;
+  static_map(static_map&&)                 = delete;
+  static_map& operator=(static_map&&)      = delete;
+  ~static_map()                            = default;
 
   /**
    * @brief Constructs a statically-sized map with the specified initial capacity, sentinel values

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -120,7 +120,7 @@ class static_multimap {
   static_multimap()                                  = delete;
   static_multimap(static_multimap const&)            = delete;
   static_multimap& operator=(static_multimap const&) = delete;
-  static_multimap(static_multimap&&)                 = delete;
+  static_multimap(static_multimap&&) noexcept        = default;  ///< Move constructor
   static_multimap& operator=(static_multimap&&)      = delete;
   ~static_multimap()                                 = default;
 

--- a/include/cuco/static_multimap.cuh
+++ b/include/cuco/static_multimap.cuh
@@ -117,18 +117,12 @@ class static_multimap {
                                              storage_ref_type,
                                              Operators...>;  ///< Non-owning container ref type
 
+  static_multimap()                                  = delete;
   static_multimap(static_multimap const&)            = delete;
   static_multimap& operator=(static_multimap const&) = delete;
-
-  static_multimap(static_multimap&&) = default;  ///< Move constructor
-
-  /**
-   * @brief Replaces the contents of the container with another container.
-   *
-   * @return Reference of the current map object
-   */
-  static_multimap& operator=(static_multimap&&) = default;
-  ~static_multimap()                            = default;
+  static_multimap(static_multimap&&)                 = delete;
+  static_multimap& operator=(static_multimap&&)      = delete;
+  ~static_multimap()                                 = default;
 
   /**
    * @brief Constructs a statically-sized map with the specified initial capacity, sentinel values

--- a/include/cuco/static_multiset.cuh
+++ b/include/cuco/static_multiset.cuh
@@ -99,18 +99,12 @@ class static_multiset {
                                              storage_ref_type,
                                              Operators...>;  ///< Non-owning container ref type
 
+  static_multiset()                                  = delete;
   static_multiset(static_multiset const&)            = delete;
   static_multiset& operator=(static_multiset const&) = delete;
-
-  static_multiset(static_multiset&&) = default;  ///< Move constructor
-
-  /**
-   * @brief Replaces the contents of the container with another container.
-   *
-   * @return Reference of the current multiset object
-   */
-  static_multiset& operator=(static_multiset&&) = default;
-  ~static_multiset()                            = default;
+  static_multiset(static_multiset&&)                 = delete;
+  static_multiset& operator=(static_multiset&&)      = delete;
+  ~static_multiset()                                 = default;
 
   /**
    * @brief Constructs a statically-sized multiset with the specified initial capacity, sentinel

--- a/include/cuco/static_multiset.cuh
+++ b/include/cuco/static_multiset.cuh
@@ -102,7 +102,7 @@ class static_multiset {
   static_multiset()                                  = delete;
   static_multiset(static_multiset const&)            = delete;
   static_multiset& operator=(static_multiset const&) = delete;
-  static_multiset(static_multiset&&)                 = delete;
+  static_multiset(static_multiset&&) noexcept        = default;  ///< Move constructor
   static_multiset& operator=(static_multiset&&)      = delete;
   ~static_multiset()                                 = default;
 

--- a/include/cuco/static_set.cuh
+++ b/include/cuco/static_set.cuh
@@ -107,7 +107,7 @@ class static_set {
   static_set()                             = delete;
   static_set(static_set const&)            = delete;
   static_set& operator=(static_set const&) = delete;
-  static_set(static_set&&)                 = delete;
+  static_set(static_set&&) noexcept        = default;  ///< Move constructor
   static_set& operator=(static_set&&)      = delete;
   ~static_set()                            = default;
 

--- a/include/cuco/static_set.cuh
+++ b/include/cuco/static_set.cuh
@@ -104,18 +104,12 @@ class static_set {
                                         storage_ref_type,
                                         Operators...>;  ///< Non-owning container ref type
 
+  static_set()                             = delete;
   static_set(static_set const&)            = delete;
   static_set& operator=(static_set const&) = delete;
-
-  static_set(static_set&&) = default;  ///< Move constructor
-
-  /**
-   * @brief Replaces the contents of the container with another container.
-   *
-   * @return Reference of the current set object
-   */
-  static_set& operator=(static_set&&) = default;
-  ~static_set()                       = default;
+  static_set(static_set&&)                 = delete;
+  static_set& operator=(static_set&&)      = delete;
+  ~static_set()                            = default;
 
   /**
    * @brief Constructs a statically-sized set with the specified initial capacity, sentinel values


### PR DESCRIPTION
The owning hash tables (`static_map`, `static_set`, `static_multimap`, `static_multiset`, `dynamic_map`) defaulted both move operations. This deletes the default constructor and move assignment, and keeps move construction.

Move assignment is the hazard: `impl_ = std::move(rhs.impl_)` frees the still-named destination's storage on its construction stream, so refs handed out from it silently dangle with no host side signal. Move construction just transfers a `unique_ptr`, so refs stay valid and downstream code (e.g. cudf `json_tree.cu`) relies on it.

Fixes #612
