### PR TITLE
Add byte-budget construction for Bloom filters

### DIFF
--- a/include/cuco/bloom_filter.cuh
+++ b/include/cuco/bloom_filter.cuh
@@ -8,6 +8,7 @@
 #include <cuco/bloom_filter_policy.cuh>
 #include <cuco/bloom_filter_ref.cuh>
 #include <cuco/detail/storage/storage_base.cuh>
+#include <cuco/detail/utility/strong_type.cuh>
 #include <cuco/extent.cuh>
 #include <cuco/hash_functions.cuh>
 #include <cuco/utility/allocator.hpp>
@@ -23,6 +24,11 @@
 #include <memory>
 
 namespace cuco {
+
+/**
+ * @brief A strong type wrapper for specifying an exact Bloom filter size in bytes.
+ */
+CUCO_DEFINE_STRONG_TYPE(bloom_filter_size_bytes, std::size_t)
 
 /**
  * @brief A GPU-accelerated Bloom filter.
@@ -115,6 +121,48 @@ class bloom_filter {
                                  Policy const& policy           = {},
                                  Allocator const& alloc         = {},
                                  cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
+
+  /**
+   * @brief Constructs a Bloom filter with exactly the requested storage size in bytes.
+   *
+   * @note Validates the size before allocating device storage.
+   *
+   * @throws cuco::logic_error If the size is zero, not a multiple of the block size,
+   * exceeds `max_size()`, or does not match a static extent
+   *
+   * @param size_bytes Exact storage size in bytes
+   * @param scope The scope in which operations will be performed
+   * @param policy Fingerprint generation policy
+   * @param alloc Allocator used for allocating device-accessible storage
+   * @param stream CUDA stream used to initialize the filter
+   */
+  __host__ explicit bloom_filter(bloom_filter_size_bytes size_bytes,
+                                 cuda_thread_scope<Scope> scope = {},
+                                 Policy const& policy           = {},
+                                 Allocator const& alloc         = {},
+                                 cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
+
+  /**
+   * @brief Returns the largest supported block-aligned byte count not exceeding a budget.
+   *
+   * Rounds down to a multiple of `words_per_block * sizeof(word_type)` and caps the result
+   * at `max_size()`. This utility does not enforce a particular static extent.
+   *
+   * @throws cuco::logic_error If the budget cannot accommodate one filter block
+   *
+   * @param size_bytes Storage budget in bytes
+   * @return Positive, block-aligned storage size in bytes
+   */
+  [[nodiscard]] __host__ static constexpr std::size_t aligned_size(std::size_t size_bytes);
+
+  /**
+   * @brief Returns the maximum storage size in bytes supported by the policy and size type.
+   *
+   * @note This limit does not account for available device memory or a particular static extent.
+   *
+   * @return Maximum storage size in bytes
+   */
+  [[nodiscard]] __host__ static constexpr std::size_t max_size() noexcept;
 
   /**
    * @brief Erases all information from the filter.
@@ -444,6 +492,10 @@ class bloom_filter {
   [[nodiscard]] __host__ constexpr ref_type<> ref() const noexcept;
 
  private:
+  template <typename SizeType, std::size_t N>
+  __host__ static constexpr extent_type make_block_extent(bloom_filter_size_bytes size_bytes,
+                                                          cuco::extent<SizeType, N>);
+
   allocator_type allocator_;  ///< Allocator used to allocate device-accessible storage
   std::unique_ptr<typename ref_type<>::filter_block_type,
                   detail::custom_deleter<std::size_t, allocator_type>>

--- a/include/cuco/detail/bloom_filter/bloom_filter.inl
+++ b/include/cuco/detail/bloom_filter/bloom_filter.inl
@@ -5,15 +5,72 @@
 
 #pragma once
 
+#include <cuco/detail/error.hpp>
 #include <cuco/detail/storage/storage_base.cuh>
 #include <cuco/utility/cuda_thread_scope.cuh>
 
 #include <cuda/atomic>
+#include <cuda/std/__algorithm/min.h>
+#include <cuda/std/limits>
 #include <cuda/stream_ref>
 
 #include <cstddef>
 
 namespace cuco {
+
+template <class Key, class Extent, cuda::thread_scope Scope, class Policy, class Allocator>
+__host__ bloom_filter<Key, Extent, Scope, Policy, Allocator>::bloom_filter(
+  bloom_filter_size_bytes size_bytes,
+  cuda_thread_scope<Scope> scope,
+  Policy const& policy,
+  Allocator const& alloc,
+  cuda::stream_ref stream)
+  : bloom_filter{make_block_extent(size_bytes, Extent{0}), scope, policy, alloc, stream}
+{
+}
+
+template <class Key, class Extent, cuda::thread_scope Scope, class Policy, class Allocator>
+[[nodiscard]] __host__ constexpr std::size_t
+bloom_filter<Key, Extent, Scope, Policy, Allocator>::max_size() noexcept
+{
+  constexpr auto block_bytes = words_per_block * sizeof(word_type);
+  constexpr auto max_blocks  = cuda::std::min(
+    static_cast<std::size_t>(Policy::max_filter_blocks),
+    cuda::std::min(static_cast<std::size_t>(cuda::std::numeric_limits<size_type>::max()),
+                   cuda::std::numeric_limits<std::size_t>::max() / block_bytes));
+  return max_blocks * block_bytes;
+}
+
+template <class Key, class Extent, cuda::thread_scope Scope, class Policy, class Allocator>
+[[nodiscard]] __host__ constexpr std::size_t
+bloom_filter<Key, Extent, Scope, Policy, Allocator>::aligned_size(std::size_t size_bytes)
+{
+  constexpr auto block_bytes = words_per_block * sizeof(word_type);
+  CUCO_EXPECTS(size_bytes >= block_bytes,
+               "Storage size must accommodate at least one filter block");
+  auto const capped_bytes = cuda::std::min(size_bytes, max_size());
+  return capped_bytes - capped_bytes % block_bytes;
+}
+
+template <class Key, class Extent, cuda::thread_scope Scope, class Policy, class Allocator>
+template <typename SizeType, std::size_t N>
+__host__ constexpr typename bloom_filter<Key, Extent, Scope, Policy, Allocator>::extent_type
+bloom_filter<Key, Extent, Scope, Policy, Allocator>::make_block_extent(
+  bloom_filter_size_bytes size_bytes, cuco::extent<SizeType, N>)
+{
+  static_assert(N == cuco::dynamic_extent || detail::is_static_extent_representable<SizeType, N>(),
+                "Static extent must be representable by its size type");
+  constexpr auto block_bytes = words_per_block * sizeof(word_type);
+  CUCO_EXPECTS(size_bytes.value > 0, "Storage size must be positive");
+  CUCO_EXPECTS(size_bytes.value % block_bytes == 0,
+               "Storage size must be a multiple of the filter block size");
+  CUCO_EXPECTS(size_bytes.value <= max_size(), "Storage size exceeds the maximum filter size");
+  auto const num_blocks = size_bytes.value / block_bytes;
+  auto const extent     = extent_type{static_cast<size_type>(num_blocks)};
+  CUCO_EXPECTS(static_cast<std::size_t>(static_cast<size_type>(extent)) == num_blocks,
+               "Storage size must match the static block extent");
+  return extent;
+}
 
 template <class Key, class Extent, cuda::thread_scope Scope, class Policy, class Allocator>
 __host__ bloom_filter<Key, Extent, Scope, Policy, Allocator>::bloom_filter(Extent num_blocks,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -144,6 +144,7 @@ ConfigureTest(HYPERLOGLOG_TEST
 ###################################################################################################
 # - bloom_filter ----------------------------------------------------------------------------------
 ConfigureTest(BLOOM_FILTER_TEST
+    bloom_filter/size_test.cu
     bloom_filter/unique_sequence_test.cu
     bloom_filter/variable_cg_test.cu
     bloom_filter/merge_intersect_test.cu

--- a/tests/bloom_filter/size_test.cu
+++ b/tests/bloom_filter/size_test.cu
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cuco/bloom_filter.cuh>
+#include <cuco/utility/error.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+TEMPLATE_TEST_CASE_SIG("bloom_filter byte sizing",
+                       "[bloom_filter][sizing][host]",
+                       (class Policy),
+                       (cuco::bloom_filter_policy<int32_t>),
+                       (cuco::bloom_filter_policy<int32_t, cuco::xxhash_64<int32_t>, 8, 8>))
+{
+  using filter_type =
+    cuco::bloom_filter<int32_t, cuco::extent<std::size_t>, cuda::thread_scope_device, Policy>;
+  constexpr auto block_bytes = Policy::words_per_block * sizeof(typename Policy::word_type);
+  constexpr auto max_bytes   = Policy::max_filter_blocks * block_bytes;
+
+  STATIC_REQUIRE(filter_type::max_size() == max_bytes);
+  STATIC_REQUIRE(filter_type::aligned_size(block_bytes) == block_bytes);
+  REQUIRE(filter_type::aligned_size(2 * block_bytes - 1) == block_bytes);
+  REQUIRE(filter_type::aligned_size(max_bytes) == max_bytes);
+  REQUIRE(filter_type::aligned_size(std::numeric_limits<std::size_t>::max()) == max_bytes);
+  REQUIRE_THROWS_AS(filter_type::aligned_size(block_bytes - 1), cuco::logic_error);
+
+  // These must throw before device allocation, including on hosts without a GPU.
+  for (auto bytes : {std::size_t{0}, block_bytes + 1, max_bytes + block_bytes}) {
+    REQUIRE_THROWS_AS(filter_type{cuco::bloom_filter_size_bytes{bytes}}, cuco::logic_error);
+  }
+}
+
+TEST_CASE("bloom_filter byte sizing extent limits", "[bloom_filter][sizing][host]")
+{
+  using filter_type = cuco::bloom_filter<int32_t, cuco::extent<uint8_t>>;
+  constexpr auto block_bytes =
+    filter_type::words_per_block * sizeof(typename filter_type::word_type);
+  constexpr auto max_bytes = std::numeric_limits<uint8_t>::max() * block_bytes;
+
+  STATIC_REQUIRE(filter_type::max_size() == max_bytes);
+  REQUIRE_THROWS_AS(filter_type{cuco::bloom_filter_size_bytes{max_bytes + block_bytes}},
+                    cuco::logic_error);
+
+  using static_filter = cuco::bloom_filter<int32_t, cuco::extent<std::size_t, 2>>;
+  REQUIRE_THROWS_AS(static_filter{cuco::bloom_filter_size_bytes{block_bytes}}, cuco::logic_error);
+}
+
+TEMPLATE_TEST_CASE_SIG("bloom_filter byte construction",
+                       "[bloom_filter][sizing][gpu]",
+                       (class Extent),
+                       (cuco::extent<std::size_t>),
+                       (cuco::extent<uint8_t, 2>))
+{
+  using filter_type    = cuco::bloom_filter<int32_t, Extent>;
+  constexpr auto bytes = 2 * filter_type::words_per_block * sizeof(typename filter_type::word_type);
+
+  auto by_bytes  = filter_type{cuco::bloom_filter_size_bytes{bytes}};
+  auto by_blocks = filter_type{Extent{2}};
+  REQUIRE(static_cast<std::size_t>(by_bytes.block_extent()) == 2);
+  REQUIRE(by_bytes.block_extent() == by_blocks.block_extent());
+}


### PR DESCRIPTION
Fixes #829.

Adds `cuco::bloom_filter_bytes` construction for dynamic-extent Bloom filters. The value is an upper-bound storage budget: allocation is rounded down to whole filter blocks and capped at `max_size()`, so it never exceeds the requested bytes. Budgets smaller than one block fail before allocation.

The existing block-count constructor remains unchanged. Coverage is folded into the existing Bloom filter policy test rather than a separate test target.

Local validation: repository formatting and copyright hooks, plus `git diff --check`.
